### PR TITLE
[utils] Add Shadow DOM-safe closest

### DIFF
--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -107,7 +107,7 @@ Core regression + correctness pass. Cover all sub-angles:
   forwarding/merging, context registration cleanup, nested component coordination,
   portals, focus management, keyboard navigation, ARIA attributes, disabled/read-only
   states, form integration, SSR/hydration safety, Strict Mode behavior, shadow
-  DOM-safe DOM access (`contains`, `getTarget`, `activeElement`, `ownerDocument`,
+  DOM-safe DOM access (`closest`, `contains`, `getTarget`, `activeElement`, `ownerDocument`,
   `ownerWindow`).
 - **Removed-behavior auditor.** For every line diff DELETES or replaces, name
   invariant/behavior it enforced, then search new code for where invariant

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ This repository contains the source code and documentation for Base UI: a headl
 - Always use the `useTimeout` utility from `@base-ui/utils/useTimeout` instead of `window.setTimeout`, and `useAnimationFrame` from `@base-ui/utils/useAnimationFrame` instead of `requestAnimationFrame`. Search for other example usage in the codebase if unsure how to use them.
 - Use the `useStableCallback` utility from `@base-ui/utils/useStableCallback` instead of `React.useCallback` if the function is called within an effect or event handler. The utility cannot be used to memoize functions that are called directly in the body of a component (during render), so continue with `React.useCallback` in those scenarios.
 - Always use the `useIsoLayoutEffect` utility from `@base-ui/utils/useIsoLayoutEffect` instead of `React.useLayoutEffect`.
-- Always use the shadow DOM-safe utilities for DOM traversal and event targeting: `contains`, `getTarget`, and `activeElement`. Always use the owner utilities `ownerDocument` and `ownerWindow` instead of global `document`/`window` lookups when the code is tied to a DOM node, including realm-sensitive checks such as `instanceof`.
+- Always use the shadow DOM-safe utilities for DOM traversal and event targeting: `closest`, `contains`, `getTarget`, and `activeElement`. Always use the owner utilities `ownerDocument` and `ownerWindow` instead of global `document`/`window` lookups when the code is tied to a DOM node, including realm-sensitive checks such as `instanceof`.
 - Avoid duplicating logic where necessary. If two components can share logic (such as event handlers), define the logic/handlers in the parent and share it through a context to the child; use the existing context if it exists.
 
 ## Styling

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -20,7 +20,7 @@ import {
   useClick,
 } from '../../floating-ui-react';
 import { gridNavigation } from '../../floating-ui-react/hooks/gridNavigation';
-import { contains, getTarget } from '../../floating-ui-react/utils';
+import { closest, contains, getTarget } from '../../floating-ui-react/utils';
 import {
   createChangeEventDetails,
   createGenericEventDetails,
@@ -861,7 +861,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
       const eventDetails = createChangeEventDetails(REASONS.itemPress, overrideEvent);
 
       // Let the link handle the click.
-      const href = targetEl?.closest('a')?.getAttribute('href');
+      const href = closest(targetEl, 'a')?.getAttribute('href');
       if (href) {
         if (href.startsWith('#')) {
           setOpen(false, eventDetails);
@@ -975,7 +975,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
   // `role=dialog` part must be the animated element.
   const resolvedPopupRef: React.RefObject<HTMLElement | null> = React.useMemo(() => {
     if (inline && positionerElement) {
-      return { current: positionerElement.closest('[role="dialog"]') };
+      return { current: closest(positionerElement, '[role="dialog"]') };
     }
     return popupRef;
   }, [inline, positionerElement]);

--- a/packages/react/src/drawer/viewport/DrawerViewport.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.tsx
@@ -32,7 +32,7 @@ import * as DrawerBackdropCssVars from '../backdrop/DrawerBackdropCssVars';
 import { DRAWER_CONTENT_ATTRIBUTE } from '../content/drawerContentAttribute';
 import { REASONS } from '../../internals/reasons';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
-import { activeElement, contains, getTarget } from '../../floating-ui-react/utils';
+import { activeElement, closest, contains, getTarget } from '../../floating-ui-react/utils';
 import { DrawerViewportContext } from './DrawerViewportContext';
 import { TransitionStatusDataAttributes } from '../../internals/stateAttributesMapping';
 import { findScrollableTouchTarget, type ScrollAxis } from '../../utils/scrollable';
@@ -1060,11 +1060,11 @@ function setBackdropSwipingAttribute(backdropElement: HTMLElement | null, swipin
 }
 
 function isSwipeIgnoredTarget(target: Element | null): boolean {
-  return Boolean(target?.closest(BASE_UI_SWIPE_IGNORE_SELECTOR));
+  return Boolean(closest(target, BASE_UI_SWIPE_IGNORE_SELECTOR));
 }
 
 function isDrawerContentTarget(target: Element | null): boolean {
-  return Boolean(target?.closest(DRAWER_CONTENT_SELECTOR));
+  return Boolean(closest(target, DRAWER_CONTENT_SELECTOR));
 }
 
 function getBaseSwipeSize(element: HTMLElement, direction: SwipeDirection): number {

--- a/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
+++ b/packages/react/src/drawer/virtual-keyboard-provider/DrawerVirtualKeyboardProvider.tsx
@@ -10,6 +10,7 @@ import { useTimeout } from '@base-ui/utils/useTimeout';
 import { useDialogRootContext } from '../../dialog/root/DialogRootContext';
 import {
   activeElement,
+  closest,
   contains,
   getTarget,
   isInteractiveElement,
@@ -693,7 +694,7 @@ function resolveKeyboardInputTarget(target: EventTarget | null): HTMLElement | n
     return target.isContentEditable ? getContentEditableHost(target) : target;
   }
 
-  const label = target.closest('label') as HTMLLabelElement | null;
+  const label = closest(target, 'label');
   const control = label?.control ?? null;
 
   return isHTMLElement(control) && isKeyboardInputElement(control) ? control : null;
@@ -747,7 +748,7 @@ function resolveKeyboardTouchTargetFromPoint(
   // `closest('label')` covers labels of non-keyboard controls (e.g. checkboxes).
   // Returning the blocked sentinel (rather than `null`) stops the caller from falling
   // back to the touchstart target, which would re-steal the very tap rejected here.
-  if (isInteractiveElement(exactTarget) || exactTarget?.closest('label') != null) {
+  if (isInteractiveElement(exactTarget) || closest(exactTarget, 'label') != null) {
     return KEYBOARD_TAP_BLOCKED;
   }
 

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -15,6 +15,7 @@ import { ownerDocument, ownerWindow } from '@base-ui/utils/owner';
 import { FocusGuard } from '../../utils/FocusGuard';
 import {
   activeElement,
+  closest,
   contains,
   getTarget,
   isTypeableCombobox,
@@ -371,7 +372,7 @@ export function FloatingFocusManager(props: FloatingFocusManagerProps): React.JS
       lastInteractionTypeRef.current =
         (event.pointerType as React.PointerEvent['pointerType']) || 'keyboard';
 
-      if (target?.closest(`[${CLICK_TRIGGER_IDENTIFIER}]`)) {
+      if (closest(target, `[${CLICK_TRIGGER_IDENTIFIER}]`)) {
         isPointerDownRef.current = true;
         // Reset on the next tick so a single click on a click-trigger doesn't
         // permanently suppress focus-out closing for the lifetime of the instance.

--- a/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
+++ b/packages/react/src/floating-ui-react/hooks/useHoverFloatingInteraction.ts
@@ -11,7 +11,7 @@ import { createChangeEventDetails } from '../../internals/createBaseUIEventDetai
 import { REASONS } from '../../internals/reasons';
 import { useFloatingParentNodeId, useFloatingTree } from '../components/FloatingTree';
 import type { FloatingContext, FloatingRootContext } from '../types';
-import { contains, getTarget } from '../utils/element';
+import { closest, contains, getTarget } from '../utils/element';
 import { getNodeChildren } from '../utils/nodes';
 import {
   applySafePolygonPointerEventsMutation,
@@ -128,7 +128,7 @@ export function useHoverFloatingInteraction(
         instance.handleCloseOptions?.getScope?.() ??
         cachedScopeElement ??
         parentScopeElement ??
-        (ref.closest('[data-rootownerid]') as HTMLElement | SVGSVGElement | null) ??
+        (closest(ref, '[data-rootownerid]') as HTMLElement | SVGSVGElement | null) ??
         doc.body;
 
       applySafePolygonPointerEventsMutation(instance, {
@@ -186,7 +186,7 @@ export function useHoverFloatingInteraction(
         return;
       }
 
-      instance.interactedInside = target?.closest('[aria-haspopup]') != null;
+      instance.interactedInside = closest(target, '[aria-haspopup]') != null;
     }
 
     function onFloatingMouseEnter() {

--- a/packages/react/src/floating-ui-react/utils/composite.ts
+++ b/packages/react/src/floating-ui-react/utils/composite.ts
@@ -4,6 +4,7 @@ import { getComputedStyle } from '@floating-ui/utils/dom';
 import type { Dimensions } from '../types';
 import { stopEvent } from './event';
 import { ARROW_DOWN, ARROW_LEFT, ARROW_RIGHT, ARROW_UP } from './constants';
+import { closest } from './element';
 
 export type DisabledIndices = ReadonlyArray<number> | ((index: number) => boolean);
 
@@ -117,7 +118,7 @@ export function getGridNavigatedIndex(
 
         visibleItemCount += 1;
 
-        const rowEl = el.closest('[role="row"]');
+        const rowEl = closest(el, '[role="row"]');
         if (rowEl) {
           hasRoleRow = true;
         }

--- a/packages/react/src/floating-ui-react/utils/element.ts
+++ b/packages/react/src/floating-ui-react/utils/element.ts
@@ -1,11 +1,11 @@
 import { isElement, isHTMLElement } from '@floating-ui/utils/dom';
 import { platform } from '@base-ui/utils/platform';
-import { activeElement, contains, getTarget } from '@base-ui/utils/shadowDom';
+import { activeElement, closest, contains, getTarget } from '@base-ui/utils/shadowDom';
 import { FOCUSABLE_ATTRIBUTE, TYPEABLE_SELECTOR } from './constants';
 import { type PopupTriggerMap } from '../../utils/popups';
 import * as TooltipTriggerDataAttributes from '../../tooltip/trigger/TooltipTriggerDataAttributes';
 
-export { activeElement, contains, getTarget };
+export { activeElement, closest, contains, getTarget };
 
 export function isTargetInsideEnabledTrigger(
   target: EventTarget | null,
@@ -54,7 +54,8 @@ export function isTypeableElement(element: unknown): boolean {
 
 export function isInteractiveElement(element: Element | null) {
   return (
-    element?.closest(
+    closest(
+      element,
       `button,a[href],[role="button"],select,[tabindex]:not([tabindex="-1"]),${TYPEABLE_SELECTOR}`,
     ) != null
   );

--- a/packages/react/src/internals/labelable-provider/useLabel.test.tsx
+++ b/packages/react/src/internals/labelable-provider/useLabel.test.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+import { act, screen } from '@mui/internal-test-utils';
+import { createRenderer } from '#test-utils';
+import { useLabel } from './useLabel';
+
+describe('useLabel', () => {
+  const { render } = createRenderer();
+
+  it('does not focus the control when a composed click originates inside a nested button', async () => {
+    function Test() {
+      const labelProps = useLabel({ fallbackControlId: 'control' });
+      const hostRef = React.useCallback((host: HTMLSpanElement | null) => {
+        if (host && !host.shadowRoot) {
+          const target = document.createElement('span');
+          target.dataset.testid = 'shadow-target';
+          host.attachShadow({ mode: 'open' }).appendChild(target);
+        }
+      }, []);
+
+      return (
+        <React.Fragment>
+          <div {...labelProps}>
+            Label
+            <button type="button">
+              Action
+              <span ref={hostRef} />
+            </button>
+          </div>
+          <input id="control" />
+        </React.Fragment>
+      );
+    }
+
+    await render(<Test />);
+
+    const button = screen.getByRole('button');
+    const target = button.querySelector('span')?.shadowRoot?.querySelector('span');
+    const control = screen.getByRole('textbox');
+
+    expect(target).not.toBeNull();
+
+    await act(async () => {
+      target?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+    });
+
+    expect(control).not.toHaveFocus();
+  });
+});

--- a/packages/react/src/internals/labelable-provider/useLabel.ts
+++ b/packages/react/src/internals/labelable-provider/useLabel.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { isHTMLElement } from '@floating-ui/utils/dom';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { getTarget } from '../../floating-ui-react/utils';
+import { closest, getTarget } from '../../floating-ui-react/utils';
 import { useRegisteredLabelId } from '../../utils/useRegisteredLabelId';
 import { useLabelableContext } from './LabelableContext';
 
@@ -45,7 +45,7 @@ export function useLabel(params: UseLabelParameters = {}): UseLabelReturnValue {
 
   function handleInteraction(event: React.MouseEvent) {
     const target = getTarget(event.nativeEvent) as HTMLElement | null;
-    if (target?.closest('button,input,select,textarea')) {
+    if (closest(target, 'button,input,select,textarea')) {
       return;
     }
 

--- a/packages/react/src/navigation-menu/list/NavigationMenuList.tsx
+++ b/packages/react/src/navigation-menu/list/NavigationMenuList.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { useDismiss, useHoverFloatingInteraction } from '../../floating-ui-react';
-import { getTarget } from '../../floating-ui-react/utils';
+import { closest, getTarget } from '../../floating-ui-react/utils';
 import type { BaseUIComponentProps, HTMLProps } from '../../internals/types';
 import { CompositeRoot } from '../../internals/composite/root/CompositeRoot';
 import {
@@ -56,7 +56,8 @@ export const NavigationMenuList = React.forwardRef(function NavigationMenuList(
     outsidePressEvent: 'intentional',
     outsidePress(event) {
       const target = getTarget(event) as HTMLElement | null;
-      const closestNavigationMenuTrigger = target?.closest(
+      const closestNavigationMenuTrigger = closest(
+        target,
         `[${NAVIGATION_MENU_TRIGGER_IDENTIFIER}]`,
       );
       return closestNavigationMenuTrigger === null;

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -22,6 +22,7 @@ import {
   useHoverInteractionSharedState,
 } from '../../floating-ui-react/hooks/useHoverInteractionSharedState';
 import {
+  closest,
   contains,
   getTabbableAfterElement,
   getNextTabbable,
@@ -512,7 +513,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
       return null;
     }
 
-    return triggerElementRef.current?.closest('ul') ?? null;
+    return closest(triggerElementRef.current, 'ul');
   }
 
   const hoverProps = useHoverReferenceInteraction(context, {

--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -6,7 +6,7 @@ import { ownerDocument } from '@base-ui/utils/owner';
 import { inertValue } from '@base-ui/utils/inertValue';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { activeElement, contains, getTarget } from '../../floating-ui-react/utils';
+import { activeElement, closest, contains, getTarget } from '../../floating-ui-react/utils';
 import type { BaseUIComponentProps, HTMLProps } from '../../internals/types';
 import type { ToastObject as ToastObjectType } from '../useToastManager';
 import { ToastRootContext } from './ToastRootContext';
@@ -248,7 +248,8 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
 
     const target = getTarget(event.nativeEvent) as HTMLElement | null;
 
-    const isInteractiveElement = target?.closest(
+    const isInteractiveElement = closest(
+      target,
       `button,a,input,textarea,[role="button"],${TOAST_SWIPE_IGNORE_SELECTOR}`,
     );
 

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.tsx
@@ -18,7 +18,7 @@ import {
   useFocus,
   useHoverReferenceInteraction,
 } from '../../floating-ui-react';
-import { contains } from '../../floating-ui-react/utils/element';
+import { closest, contains } from '../../floating-ui-react/utils/element';
 import { isMouseLikePointerType } from '../../floating-ui-react/utils/event';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
@@ -44,21 +44,6 @@ function getTargetElement(event: Event): Element | null {
   const target = event.target;
   if (isElement(target)) {
     return target;
-  }
-
-  return null;
-}
-
-function closestEnabledTooltipTrigger(element: Element | null): Element | null {
-  let current = element;
-  while (current) {
-    const trigger = current.closest(`[${TOOLTIP_TRIGGER_IDENTIFIER}]`);
-    if (trigger) {
-      return trigger;
-    }
-
-    const root = current.getRootNode();
-    current = 'host' in root && isElement(root.host) ? root.host : null;
   }
 
   return null;
@@ -153,7 +138,7 @@ export const TooltipTrigger = fastComponentRef(function TooltipTrigger(
       return false;
     }
 
-    const nearestTrigger = closestEnabledTooltipTrigger(target);
+    const nearestTrigger = closest(target, `[${TOOLTIP_TRIGGER_IDENTIFIER}]`);
     return (
       nearestTrigger !== null && nearestTrigger !== triggerEl && contains(triggerEl, nearestTrigger)
     );

--- a/packages/react/src/utils/useSwipeDismiss.ts
+++ b/packages/react/src/utils/useSwipeDismiss.ts
@@ -1,9 +1,9 @@
 'use client';
 import * as React from 'react';
+import { clamp } from '@base-ui/utils/clamp';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { ownerDocument } from '@base-ui/utils/owner';
-import { clamp } from '@base-ui/utils/clamp';
-import { contains, getTarget } from '../floating-ui-react/utils';
+import { closest, contains, getTarget } from '../floating-ui-react/utils';
 import { findScrollableTouchTarget, hasScrollableAncestor, type ScrollAxis } from './scrollable';
 import { getElementAtPoint } from './getElementAtPoint';
 import { getElementTransform } from './getElementTransform';
@@ -374,7 +374,7 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
     }
     swipeFromScrollableRef.current = Boolean(scrollableTarget && ignoreScrollableTarget);
 
-    const isInteractiveElement = target ? target.closest(ignoreSelector) : false;
+    const isInteractiveElement = closest(target, ignoreSelector);
     if (isInteractiveElement && (!touchLike || ignoreSelectorWhenTouch)) {
       return false;
     }

--- a/packages/utils/src/shadowDom.test.ts
+++ b/packages/utils/src/shadowDom.test.ts
@@ -1,32 +1,103 @@
-import { expect, describe, it } from 'vitest';
-import { getTarget } from './shadowDom';
+import { expect, describe, it, afterEach, vi } from 'vitest';
+import { closest, getTarget } from './shadowDom';
 
-describe('getTarget', () => {
-  it('returns the composed-path target while the event is being dispatched', () => {
-    const parent = document.createElement('div');
-    const child = document.createElement('span');
-    parent.appendChild(child);
-    document.body.appendChild(parent);
+afterEach(() => {
+  document.body.innerHTML = '';
+});
 
-    let target: EventTarget | null = null;
-    parent.addEventListener('click', (event) => {
-      target = getTarget(event);
+describe('shadow DOM utilities', () => {
+  describe('closest', () => {
+    it('finds an ancestor across nested shadow roots from a non-Element node', () => {
+      const button = document.createElement('button');
+      const outerHost = document.createElement('span');
+      const innerHost = document.createElement('span');
+      const target = document.createTextNode('target');
+
+      document.body.appendChild(button);
+      button.appendChild(outerHost);
+      outerHost.attachShadow({ mode: 'open' }).appendChild(innerHost);
+      innerHost.attachShadow({ mode: 'open' }).appendChild(target);
+
+      expect(closest(target, 'button')).toBe(button);
     });
-    child.dispatchEvent(new Event('click', { bubbles: true }));
 
-    expect(target).toBe(child);
-    parent.remove();
+    it('follows the composed tree through slots', () => {
+      const host = document.createElement('span');
+      const target = document.createElement('span');
+      const shadowAncestor = document.createElement('div');
+      const slot = document.createElement('slot');
+
+      shadowAncestor.dataset.testid = 'shadow-ancestor';
+      shadowAncestor.appendChild(slot);
+      host.attachShadow({ mode: 'open' }).appendChild(shadowAncestor);
+      host.appendChild(target);
+      document.body.appendChild(host);
+
+      expect(closest(target, '[data-testid="shadow-ancestor"]')).toBe(shadowAncestor);
+    });
+
+    it('returns null for a detached node instead of falling back to the document element', () => {
+      document.documentElement.classList.add('match');
+      const element = document.createElement('div');
+
+      expect(closest(element, '.match')).toBeNull();
+      document.documentElement.classList.remove('match');
+    });
+
+    it('preserves native selector validation', () => {
+      const element = document.createElement('div');
+
+      expect(() => closest(element, '[')).toThrow();
+    });
+
+    it('finds an interactive ancestor outside a composed event target shadow root', () => {
+      const button = document.createElement('button');
+      let matchedElement: Element | null = null;
+      const listener = vi.fn((event: PointerEvent) => {
+        matchedElement = closest(getTarget(event) as Node, 'button');
+      });
+      const host = document.createElement('span');
+      const target = document.createElement('span');
+
+      document.body.appendChild(button);
+      button.appendChild(host);
+      host.attachShadow({ mode: 'open' }).appendChild(target);
+      button.addEventListener('pointerdown', listener);
+
+      target.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, composed: true }));
+
+      expect(listener).toHaveBeenCalledOnce();
+      expect(matchedElement).toBe(button);
+    });
   });
 
-  it('falls back to `target` once dispatch has completed', () => {
-    const element = document.createElement('div');
-    document.body.appendChild(element);
+  describe('getTarget', () => {
+    it('returns the composed-path target while the event is being dispatched', () => {
+      const parent = document.createElement('div');
+      const child = document.createElement('span');
+      parent.appendChild(child);
+      document.body.appendChild(parent);
 
-    const event = new Event('click');
-    element.dispatchEvent(event);
+      let target: EventTarget | null = null;
+      parent.addEventListener('click', (event) => {
+        target = getTarget(event);
+      });
+      child.dispatchEvent(new Event('click', { bubbles: true }));
 
-    expect(event.composedPath()).toHaveLength(0);
-    expect(getTarget(event)).toBe(element);
-    element.remove();
+      expect(target).toBe(child);
+      parent.remove();
+    });
+
+    it('falls back to `target` once dispatch has completed', () => {
+      const element = document.createElement('div');
+      document.body.appendChild(element);
+
+      const event = new Event('click');
+      element.dispatchEvent(event);
+
+      expect(event.composedPath()).toHaveLength(0);
+      expect(getTarget(event)).toBe(element);
+      element.remove();
+    });
   });
 });

--- a/packages/utils/src/shadowDom.ts
+++ b/packages/utils/src/shadowDom.ts
@@ -1,4 +1,4 @@
-import { isShadowRoot } from '@floating-ui/utils/dom';
+import { isElement, isShadowRoot } from '@floating-ui/utils/dom';
 
 export function activeElement(doc: Document) {
   let element = doc.activeElement;
@@ -34,6 +34,39 @@ export function contains(parent?: Element | null, child?: Element | null) {
   }
 
   return false;
+}
+
+/**
+ * Finds the closest matching element in the composed tree, crossing slots and shadow roots.
+ * `:scope` is not supported.
+ */
+export function closest<K extends keyof HTMLElementTagNameMap>(
+  node: Node | null | undefined,
+  selector: K,
+): HTMLElementTagNameMap[K] | null;
+export function closest<K extends keyof SVGElementTagNameMap>(
+  node: Node | null | undefined,
+  selector: K,
+): SVGElementTagNameMap[K] | null;
+export function closest<E extends Element = Element>(
+  node: Node | null | undefined,
+  selector: string,
+): E | null;
+export function closest(node: Node | null | undefined, selector: string): Element | null {
+  let current = node;
+
+  while (current) {
+    if (isElement(current) && current.matches(selector)) {
+      return current;
+    }
+
+    current =
+      (current as Element).assignedSlot ??
+      current.parentNode ??
+      (isShadowRoot(current) ? current.host : null);
+  }
+
+  return null;
 }
 
 export function getTarget(event: Event) {


### PR DESCRIPTION
When an event originates inside a shadow root, `getTarget` exposes the deepest composed target, but native `Element.closest()` cannot reach interactive ancestors outside that root. In labelable components, this could make a click inside a nested button focus the label's associated control instead.

## Changes

- Add a composed-tree `closest` helper that uses `matches()` with the existing shadow-safe parent traversal. It supports slots, nested shadow roots, and non-Element starting nodes while preserving selector behavior.
- Migrate event-target classification and composed ownership queries across the affected label, popup, Drawer, navigation, Toast, Combobox, and swipe code paths.
- Keep native `closest()` where same-root semantics are intentional, including native implicit-label detection and pre-hydration markup queries.
- Add focused utility and label interaction regression coverage for jsdom and Chromium.
