### PR TITLE
[code-infra] Ignore unrelated fixed issue PRs

### DIFF
--- a/.github/workflows/fixed-issue.yml
+++ b/.github/workflows/fixed-issue.yml
@@ -33,15 +33,13 @@ jobs:
               query($owner:String!, $repo:String!, $issueNumber:Int!) {
                 repository(owner: $owner, name: $repo) {
                   issue(number: $issueNumber) {
+                    # includeClosedPrs is required: merged PRs are excluded by default.
                     closedByPullRequestsReferences(last: 100, includeClosedPrs: true) {
                       nodes {
                         number
                         headRefOid
                         merged
                         mergedAt
-                        repository {
-                          nameWithOwner
-                        }
                       }
                     }
                   }
@@ -65,7 +63,7 @@ jobs:
                 const closingPRs = result.repository.issue.closedByPullRequestsReferences.nodes;
 
                 for (const pr of closingPRs) {
-                  if (pr.merged && pr.repository.nameWithOwner === `${variables.owner}/${variables.repo}`) {
+                  if (pr.merged) {
                     relatedPRs.push({
                       number: pr.number,
                       commit: pr.headRefOid,
@@ -93,7 +91,7 @@ jobs:
               core.setOutput('has_pr', 'true');
 
             } catch (error) {
-              console.error('Error fetching related PRs:', error);
+              core.warning(`Error fetching related PRs: ${error.message}`);
             }
 
       - name: Add comment to issue

--- a/.github/workflows/fixed-issue.yml
+++ b/.github/workflows/fixed-issue.yml
@@ -22,6 +22,11 @@ jobs:
 
             console.log(`Processing issue #${issue_number}`);
 
+            if (context.payload.issue.state_reason === 'not_planned') {
+              console.log(`Skipping issue #${issue_number} because it was closed as not planned`);
+              return;
+            }
+
             // Use GraphQL to find PRs that close this issue
             const query = `
               query($owner:String!, $repo:String!, $issueNumber:Int!) {
@@ -37,6 +42,9 @@ jobs:
                               headRefOid
                               merged
                               mergedAt
+                              repository {
+                                nameWithOwner
+                              }
                             }
                           }
                         }
@@ -47,6 +55,9 @@ jobs:
                               headRefOid
                               merged
                               mergedAt
+                              repository {
+                                nameWithOwner
+                              }
                             }
                           }
                         }
@@ -81,7 +92,11 @@ jobs:
                     pr = item.source;
                   }
 
-                  if (pr && pr.merged) {
+                  if (
+                    pr &&
+                    pr.merged &&
+                    pr.repository.nameWithOwner === `${variables.owner}/${variables.repo}`
+                  ) {
                     relatedPRs.push({
                       number: pr.number,
                       commit: pr.headRefOid,

--- a/.github/workflows/fixed-issue.yml
+++ b/.github/workflows/fixed-issue.yml
@@ -40,6 +40,9 @@ jobs:
                         headRefOid
                         merged
                         mergedAt
+                        repository {
+                          nameWithOwner
+                        }
                       }
                     }
                   }
@@ -57,13 +60,15 @@ jobs:
               const result = await github.graphql(query, variables);
               console.log('GraphQL query completed successfully');
 
-              // Extract all merged PRs that close this issue
+              // Extract all merged PRs that close this issue. Closing PRs can live in
+              // another repository, so the owner/name check is required: issue #1217 is
+              // closed by floating-ui/floating-ui#3259.
               const relatedPRs = [];
               if (result.repository.issue) {
                 const closingPRs = result.repository.issue.closedByPullRequestsReferences.nodes;
 
                 for (const pr of closingPRs) {
-                  if (pr.merged) {
+                  if (pr.merged && pr.repository.nameWithOwner === `${variables.owner}/${variables.repo}`) {
                     relatedPRs.push({
                       number: pr.number,
                       commit: pr.headRefOid,

--- a/.github/workflows/fixed-issue.yml
+++ b/.github/workflows/fixed-issue.yml
@@ -22,8 +22,9 @@ jobs:
 
             console.log(`Processing issue #${issue_number}`);
 
-            if (context.payload.issue.state_reason === 'not_planned') {
-              console.log(`Skipping issue #${issue_number} because it was closed as not planned`);
+            const stateReason = context.payload.issue.state_reason;
+            if (['not_planned', 'duplicate'].includes(stateReason)) {
+              console.log(`Skipping issue #${issue_number} because it was closed as ${stateReason}`);
               return;
             }
 
@@ -32,34 +33,14 @@ jobs:
               query($owner:String!, $repo:String!, $issueNumber:Int!) {
                 repository(owner: $owner, name: $repo) {
                   issue(number: $issueNumber) {
-                    timelineItems(last: 100, itemTypes: [CONNECTED_EVENT, CROSS_REFERENCED_EVENT]) {
+                    closedByPullRequestsReferences(last: 100, includeClosedPrs: true) {
                       nodes {
-                        __typename
-                        ... on ConnectedEvent {
-                          subject {
-                            ... on PullRequest {
-                              number
-                              headRefOid
-                              merged
-                              mergedAt
-                              repository {
-                                nameWithOwner
-                              }
-                            }
-                          }
-                        }
-                        ... on CrossReferencedEvent {
-                          source {
-                            ... on PullRequest {
-                              number
-                              headRefOid
-                              merged
-                              mergedAt
-                              repository {
-                                nameWithOwner
-                              }
-                            }
-                          }
+                        number
+                        headRefOid
+                        merged
+                        mergedAt
+                        repository {
+                          nameWithOwner
                         }
                       }
                     }
@@ -78,25 +59,13 @@ jobs:
               const result = await github.graphql(query, variables);
               console.log('GraphQL query completed successfully');
 
-              // Extract all merged PRs that are linked to this issue
+              // Extract all merged PRs that close this issue
               const relatedPRs = [];
               if (result.repository.issue) {
-                const timelineItems = result.repository.issue.timelineItems.nodes;
+                const closingPRs = result.repository.issue.closedByPullRequestsReferences.nodes;
 
-                for (const item of timelineItems) {
-                  let pr = null;
-
-                  if (item.__typename === 'ConnectedEvent' && item.subject) {
-                    pr = item.subject;
-                  } else if (item.__typename === 'CrossReferencedEvent' && item.source) {
-                    pr = item.source;
-                  }
-
-                  if (
-                    pr &&
-                    pr.merged &&
-                    pr.repository.nameWithOwner === `${variables.owner}/${variables.repo}`
-                  ) {
+                for (const pr of closingPRs) {
+                  if (pr.merged && pr.repository.nameWithOwner === `${variables.owner}/${variables.repo}`) {
                     relatedPRs.push({
                       number: pr.number,
                       commit: pr.headRefOid,


### PR DESCRIPTION
The fixed-issue workflow treated any merged PR in an issue timeline as a Base UI fix, including cross-references from other repositories. This caused #5443 to receive canary instructions built from an unrelated external PR.

## Changes

- Use `closedByPullRequestsReferences` so only PRs linked to close the issue count, instead of every PR that mentions it.
- Restrict candidates to PRs in this repository, because closing links can cross repositories.
- Skip issues closed as not planned or duplicate before querying or commenting.
- Report GraphQL failures as a run annotation instead of a silent log line.

## Why both filters are needed

Neither filter subsumes the other.

`closedByPullRequestsReferences` drops incidental mentions, which is what produced the comment on #5443. It does not restrict results to this repository. A separate sweep of all 1,170 closed Base UI issues found five whose merged closing PR lives elsewhere: issues 1217, 1552, 1997, and 2013 are closed by `floating-ui/floating-ui` PRs, and 2097 by a `WordPress/gutenberg` PR.

Issue 2097 shows why the repository check has to stay. It has two merged closing PRs, `mui/base-ui#4704` and `WordPress/gutenberg#78448`. The WordPress PR merged later, and candidates are sorted newest first, so dropping the check would advertise a Base UI canary built from a WordPress commit.

## Effect on a 100-issue sample

Both algorithms were replayed over GitHub's `issues(last: 100, states: CLOSED)` sample. In this repository, that connection returned the 100 most recently created issues that are now closed, not the 100 highest `closedAt` timestamps.

- 48 select the same PR.
- 41 select no PR either way.
- 11 select a different result. Ten improve; one correct historical comment is no longer produced.

The ten improvements are:

- Two wrong comments are prevented:
  - Issue 4864 received `npm i https://pkg.pr.new/@base-ui/react@78399`, referring to `WordPress/gutenberg#78399` ("Add Combobox primitives").
  - Issue 5443 received `@base-ui/react@28acb0c`, the head commit of `craftwell-ai/quill-ds#89`.
- Issue 4915 was closed as not planned but received a canary for PR 5151. The new guard skips it.
- Issues 4729, 4966, and 5108 now select the linked Base UI closing PR instead of depending on whichever referenced PR merged most recently.
- Issues 4956, 5014, 5073, and 5170 resolve to an unrelated or non-closing PR under the old query today, and to nothing under the new one.

> [!NOTE]
> The tradeoff is issue 5042. It was reported against a released version, PR 4930 had already shipped the fix, and a maintainer later closed the issue with a comment linking that PR. Because there is no formal closing link, the new query no longer produces that otherwise-correct canary comment.
>
> To keep the comment in this situation, add a closing keyword such as `Closes #123` to the PR, or link the PR to the issue from the Development section of the sidebar.
