### PR TITLE
[navigation-menu] Fix pointer-events lock when sweeping quickly across a trigger

### DIFF
--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
@@ -533,4 +533,51 @@ describe('<NavigationMenu.Trigger />', () => {
       });
     },
   );
+
+  it.skipIf(isJSDOM)(
+    'releases the pointer-events lock when the pointer sweeps across a trigger without the menu opening',
+    async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+
+      await render(
+        <NavigationMenu.Root>
+          <NavigationMenu.List data-testid="list">
+            <NavigationMenu.Item value="a">
+              <NavigationMenu.Trigger>A</NavigationMenu.Trigger>
+              <NavigationMenu.Content>
+                <NavigationMenu.Link href="#a">A link</NavigationMenu.Link>
+              </NavigationMenu.Content>
+            </NavigationMenu.Item>
+            <NavigationMenu.Item value="b">
+              <NavigationMenu.Trigger>B</NavigationMenu.Trigger>
+              <NavigationMenu.Content>
+                <NavigationMenu.Link href="#b">B link</NavigationMenu.Link>
+              </NavigationMenu.Content>
+            </NavigationMenu.Item>
+          </NavigationMenu.List>
+          <NavigationMenu.Portal keepMounted>
+            <NavigationMenu.Positioner>
+              <NavigationMenu.Popup>
+                <NavigationMenu.Viewport />
+              </NavigationMenu.Popup>
+            </NavigationMenu.Positioner>
+          </NavigationMenu.Portal>
+        </NavigationMenu.Root>,
+      );
+
+      const list = screen.getByTestId('list');
+      const triggerA = screen.getByRole('button', { name: 'A' });
+
+      // Sweep across the trigger and leave before the rest delay elapses, so the menu
+      // never opens. `mouseenter` applies the safe-polygon pointer-events lock on the
+      // list eagerly (the Portal is `keepMounted`, so the floating element exists while
+      // closed); without an open -> close cycle nothing releases it.
+      await user.pointer([{ target: triggerA }, { target: document.body }]);
+
+      await waitFor(() => {
+        expect(list.style.pointerEvents).toBe('');
+      });
+      expect(screen.queryByRole('link', { name: 'A link' })).to.equal(null);
+    },
+  );
 });

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
@@ -577,7 +577,7 @@ describe('<NavigationMenu.Trigger />', () => {
       await waitFor(() => {
         expect(list.style.pointerEvents).toBe('');
       });
-      expect(screen.queryByRole('link', { name: 'A link' })).to.equal(null);
+      expect(screen.queryByRole('link', { name: 'A link' })).toBe(null);
     },
   );
 });

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -684,6 +684,11 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
     onMouseMove() {
       allowFocusRef.current = false;
     },
+    onMouseLeave() {
+      if (value == null) {
+        clearSafePolygonPointerEventsMutation(hoverInteractionState);
+      }
+    },
     onKeyDown(event) {
       allowFocusRef.current = true;
 


### PR DESCRIPTION
Fixes https://github.com/mui/base-ui/issues/5453.

When the pointer sweeps across a trigger too quickly for its content to open, the safe-polygon `pointer-events: none` lock is never released. Currently all the existing release paths only run after a menu has opened so in this case the list is left frozen.

This PR calls `clearSafePolygonPointerEventsMutation` on the trigger's `mouseleave` when no item is open.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
