### PR TITLE
[all components] Fix label association when a control unregisters

### DIFF
--- a/docs/src/app/(docs)/react/components/slider/types.md
+++ b/docs/src/app/(docs)/react/components/slider/types.md
@@ -595,7 +595,7 @@ type SliderRootChangeEventCustomProperties = {
 ### ThumbMetadata
 
 ```typescript
-type ThumbMetadata = { inputId: string | null | undefined };
+type ThumbMetadata = { inputId: string | undefined };
 ```
 
 ## External Types

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -154,35 +154,5 @@ describe('<Field.Control />', () => {
       expect(screen.getByRole('textbox')).toHaveAttribute('id', 'b');
       expect(screen.getByTestId('label')).toHaveAttribute('for', 'b');
     });
-
-    it('keeps the label associated when an explicit id control is replaced by one without an id', async () => {
-      function App() {
-        const [explicit, setExplicit] = React.useState(true);
-        return (
-          <React.Fragment>
-            <Field.Root>
-              <Field.Label data-testid="label">Label</Field.Label>
-              {explicit ? <Field.Control key="a" id="custom" /> : <Field.Control key="b" />}
-            </Field.Root>
-            <button onClick={() => setExplicit(false)}>swap</button>
-          </React.Fragment>
-        );
-      }
-
-      const { user } = await renderNonStrict(<App />);
-
-      expect(screen.getByTestId('label')).toHaveAttribute('for', 'custom');
-
-      fireEvent.click(screen.getByRole('button'));
-
-      const control = screen.getByRole('textbox');
-      expect(control.id).not.toBe('');
-      expect(control.id).not.toBe('custom');
-      expect(screen.getByTestId('label')).toHaveAttribute('for', control.id);
-
-      await user.click(screen.getByTestId('label'));
-
-      expect(control).toHaveFocus();
-    });
   });
 });

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -130,7 +130,7 @@ describe('<Field.Control />', () => {
   });
 
   describe('id', () => {
-    it('updates the label association when the control is swapped', () => {
+    it('updates the label association when the control is swapped', async () => {
       function App() {
         const [controlKey, setControlKey] = React.useState('a');
         return (
@@ -144,7 +144,7 @@ describe('<Field.Control />', () => {
         );
       }
 
-      renderNonStrict(<App />);
+      await renderNonStrict(<App />);
 
       expect(screen.getByRole('textbox')).toHaveAttribute('id', 'a');
       expect(screen.getByTestId('label')).toHaveAttribute('for', 'a');

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -1,4 +1,5 @@
 import { expect, vi } from 'vitest';
+import * as React from 'react';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
@@ -126,5 +127,62 @@ describe('<Field.Control />', () => {
     expect(screen.getByTestId('root')).toHaveAttribute('data-focused', '');
     expect(control).toHaveAttribute('data-focused', '');
     expect(screen.getByText('Name')).toHaveAttribute('data-focused', '');
+  });
+
+  describe('id', () => {
+    it('updates the label association when the control is swapped', () => {
+      function App() {
+        const [controlKey, setControlKey] = React.useState('a');
+        return (
+          <React.Fragment>
+            <Field.Root>
+              <Field.Label data-testid="label">Label</Field.Label>
+              <Field.Control key={controlKey} id={controlKey} />
+            </Field.Root>
+            <button onClick={() => setControlKey('b')}>swap</button>
+          </React.Fragment>
+        );
+      }
+
+      renderNonStrict(<App />);
+
+      expect(screen.getByRole('textbox')).toHaveAttribute('id', 'a');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'a');
+
+      fireEvent.click(screen.getByRole('button'));
+
+      expect(screen.getByRole('textbox')).toHaveAttribute('id', 'b');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'b');
+    });
+
+    it('keeps the label associated when an explicit id control is replaced by one without an id', async () => {
+      function App() {
+        const [explicit, setExplicit] = React.useState(true);
+        return (
+          <React.Fragment>
+            <Field.Root>
+              <Field.Label data-testid="label">Label</Field.Label>
+              {explicit ? <Field.Control key="a" id="custom" /> : <Field.Control key="b" />}
+            </Field.Root>
+            <button onClick={() => setExplicit(false)}>swap</button>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await renderNonStrict(<App />);
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'custom');
+
+      fireEvent.click(screen.getByRole('button'));
+
+      const control = screen.getByRole('textbox');
+      expect(control.id).not.toBe('');
+      expect(control.id).not.toBe('custom');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', control.id);
+
+      await user.click(screen.getByTestId('label'));
+
+      expect(control).toHaveFocus();
+    });
   });
 });

--- a/packages/react/src/field/label/FieldLabel.test.tsx
+++ b/packages/react/src/field/label/FieldLabel.test.tsx
@@ -6,6 +6,7 @@ import { createRenderer, describeConformance } from '#test-utils';
 
 describe('<Field.Label />', () => {
   const { render } = createRenderer();
+  const { render: renderNonStrict } = createRenderer({ strict: false });
 
   describeConformance(<Field.Label />, () => ({
     refInstanceof: window.HTMLLabelElement,
@@ -43,6 +44,39 @@ describe('<Field.Label />', () => {
 
     await user.click(label);
     expect(control).toHaveFocus();
+  });
+
+  describe('control selection', () => {
+    function Fields(props: { first?: boolean; second?: boolean }) {
+      const { first = true, second = true } = props;
+      return (
+        <Field.Root>
+          {first && <Field.Control id="a" />}
+          {second && <Field.Control id="b" />}
+          <Field.Label data-testid="label">Label</Field.Label>
+        </Field.Root>
+      );
+    }
+
+    it('keeps the selected control id when another control unmounts', async () => {
+      const { rerender } = await renderNonStrict(<Fields />);
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'a');
+
+      await rerender(<Fields second={false} />);
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'a');
+    });
+
+    it('falls over to the remaining control when the selected one unmounts', async () => {
+      const { rerender } = await renderNonStrict(<Fields />);
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'a');
+
+      await rerender(<Fields first={false} />);
+
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'b');
+    });
   });
 
   it('reflects the disabled state from Field.Item', async () => {

--- a/packages/react/src/field/root/FieldRoot.react17.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.react17.test.tsx
@@ -2,7 +2,7 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { Field } from '@base-ui/react/field';
-import { screen } from '@mui/internal-test-utils';
+import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';
 
 vi.mock('@base-ui/utils/safeReact', async (importOriginal) => {
@@ -19,6 +19,42 @@ vi.mock('@base-ui/utils/safeReact', async (importOriginal) => {
 
 describe('<Field.Root /> with the React 17 id fallback', () => {
   const { render } = createRenderer();
+  const { render: renderNonStrict } = createRenderer({ strict: false });
+
+  it('falls back to a generated id when an explicit control id is removed', async () => {
+    function TestCase() {
+      const [explicit, setExplicit] = React.useState(true);
+
+      return (
+        <React.Fragment>
+          <Field.Root>
+            <Field.Label data-testid="label">Label</Field.Label>
+            <Field.Control id={explicit ? 'custom' : undefined} />
+          </Field.Root>
+          <button type="button" onClick={() => setExplicit(false)}>
+            clear
+          </button>
+        </React.Fragment>
+      );
+    }
+
+    await renderNonStrict(<TestCase />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'custom');
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox').id).not.toBe('custom');
+    });
+
+    const control = screen.getByRole('textbox');
+
+    expect(control.id).not.toBe('');
+    expect(screen.getByTestId('label')).toHaveAttribute('for', control.id);
+  });
 
   it('allows mount-time imperative validation before the fallback id is assigned', async () => {
     function TestCase() {

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -19,7 +19,6 @@ import {
   waitFor,
 } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
-import { LabelableProvider } from '../../internals/labelable-provider';
 
 describe('<Field.Root />', () => {
   const { render, renderToString } = createRenderer();
@@ -84,23 +83,6 @@ describe('<Field.Root />', () => {
     await waitFor(() => {
       expect(label).toHaveAttribute('for', 'control-b');
     });
-  });
-
-  it('preserves null initial control ids', async () => {
-    await render(
-      <Field.Root>
-        <LabelableProvider controlId={null}>
-          <Field.Label>Label</Field.Label>
-          <Field.Control data-testid="control" />
-        </LabelableProvider>
-      </Field.Root>,
-    );
-
-    const label = screen.getByText('Label');
-    const control = screen.getByTestId('control');
-
-    expect(label).not.toHaveAttribute('for');
-    expect(control.getAttribute('id')).not.toBe(null);
   });
 
   it('updates label associations when the control id changes', async () => {
@@ -281,7 +263,7 @@ describe('<Field.Root />', () => {
   );
 
   it.skipIf(reactMajor < 19)(
-    'does not loop when a control is unmounted and remounted',
+    'preserves label association without looping when a control is unmounted and remounted',
     async () => {
       const errorSpy = vi
         .spyOn(console, 'error')
@@ -303,12 +285,10 @@ describe('<Field.Root />', () => {
           return (
             <React.Fragment>
               <Field.Root>
-                <Field.Label nativeLabel={false} render={<div />}>
-                  Label
-                </Field.Label>
+                <Field.Label data-testid="label">Label</Field.Label>
                 <Activity mode={showSelect ? 'visible' : 'hidden'}>
                   <Select.Root id="select">
-                    <Select.Trigger>
+                    <Select.Trigger data-testid="trigger">
                       <Select.Value placeholder="Select a model" />
                     </Select.Trigger>
                     <Select.Portal>
@@ -334,10 +314,17 @@ describe('<Field.Root />', () => {
         await renderStrict(<TestCase />);
 
         const checkbox = screen.getByRole('checkbox');
+        const label = screen.getByTestId('label');
+
+        expect(label).toHaveAttribute('for', screen.getByTestId('trigger').id);
 
         fireEvent.click(checkbox);
+
+        expect(label).toHaveAttribute('for', screen.getByTestId('trigger').id);
+
         fireEvent.click(checkbox);
 
+        expect(label).toHaveAttribute('for', screen.getByTestId('trigger').id);
         expect(errorSpy.mock.calls.length).toBe(0);
       } finally {
         errorSpy.mockRestore();

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -332,6 +332,48 @@ describe('<Field.Root />', () => {
     },
   );
 
+  it.skipIf(reactMajor < 19)(
+    'keeps an explicit control id while the subtree is hidden',
+    async () => {
+      type ActivityProps = {
+        mode: 'visible' | 'hidden';
+        children: React.ReactNode;
+      };
+
+      const Activity = (React as typeof React & { Activity: React.ComponentType<ActivityProps> })
+        .Activity;
+
+      function TestCase() {
+        const [visible, setVisible] = React.useState(true);
+
+        return (
+          <React.Fragment>
+            <Field.Root>
+              <Field.Label data-testid="label">Email</Field.Label>
+              <Activity mode={visible ? 'visible' : 'hidden'}>
+                <Field.Control id="email" data-testid="control" />
+              </Activity>
+            </Field.Root>
+            <button type="button" onClick={() => setVisible(false)}>
+              hide
+            </button>
+          </React.Fragment>
+        );
+      }
+
+      await render(<TestCase />);
+
+      expect(screen.getByTestId('control')).toHaveAttribute('id', 'email');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'email');
+
+      fireEvent.click(screen.getByRole('button', { name: 'hide' }));
+
+      // Hiding destroys the control's effects but keeps its DOM, so the association must hold.
+      expect(screen.getByTestId('control')).toHaveAttribute('id', 'email');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'email');
+    },
+  );
+
   describe('prop: disabled', () => {
     it('should add data-disabled style hook to all components', async () => {
       await render(

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -20,6 +20,14 @@ import {
 } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
+type ActivityProps = {
+  mode: 'visible' | 'hidden';
+  children: React.ReactNode;
+};
+
+const Activity = (React as typeof React & { Activity: React.ComponentType<ActivityProps> })
+  .Activity;
+
 describe('<Field.Root />', () => {
   const { render, renderToString } = createRenderer();
   const { render: renderStrict } = createRenderer({ strict: true });
@@ -271,14 +279,6 @@ describe('<Field.Root />', () => {
         .mockImplementation(() => {});
 
       try {
-        type ActivityProps = {
-          mode: 'visible' | 'hidden';
-          children: React.ReactNode;
-        };
-
-        const Activity = (React as typeof React & { Activity: React.ComponentType<ActivityProps> })
-          .Activity;
-
         function TestCase() {
           const [showSelect, setShowSelect] = React.useState(true);
 
@@ -333,16 +333,55 @@ describe('<Field.Root />', () => {
   );
 
   it.skipIf(reactMajor < 19)(
+    'preserves a non-native label association when a control is unmounted and remounted',
+    async () => {
+      function TestCase() {
+        const [showSelect, setShowSelect] = React.useState(true);
+
+        return (
+          <React.Fragment>
+            <Field.Root>
+              <Field.Label nativeLabel={false} render={<div />} data-testid="label">
+                Label
+              </Field.Label>
+              <Activity mode={showSelect ? 'visible' : 'hidden'}>
+                <Select.Root>
+                  <Select.Trigger data-testid="trigger">
+                    <Select.Value placeholder="Select a model" />
+                  </Select.Trigger>
+                </Select.Root>
+              </Activity>
+            </Field.Root>
+            <Checkbox.Root
+              checked={!showSelect}
+              onCheckedChange={(checked) => {
+                setShowSelect(!checked);
+              }}
+            />
+          </React.Fragment>
+        );
+      }
+
+      await renderStrict(<TestCase />);
+
+      const checkbox = screen.getByRole('checkbox');
+      const labelId = screen.getByTestId('label').id;
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('aria-labelledby', labelId);
+
+      fireEvent.click(checkbox);
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('aria-labelledby', labelId);
+
+      fireEvent.click(checkbox);
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('aria-labelledby', labelId);
+    },
+  );
+
+  it.skipIf(reactMajor < 19)(
     'keeps an explicit control id while the subtree is hidden',
     async () => {
-      type ActivityProps = {
-        mode: 'visible' | 'hidden';
-        children: React.ReactNode;
-      };
-
-      const Activity = (React as typeof React & { Activity: React.ComponentType<ActivityProps> })
-        .Activity;
-
       function TestCase() {
         const [visible, setVisible] = React.useState(true);
 
@@ -371,6 +410,46 @@ describe('<Field.Root />', () => {
       // Hiding destroys the control's effects but keeps its DOM, so the association must hold.
       expect(screen.getByTestId('control')).toHaveAttribute('id', 'email');
       expect(screen.getByTestId('label')).toHaveAttribute('for', 'email');
+    },
+  );
+
+  it.skipIf(reactMajor < 19)(
+    'keeps the label pointing at a rendered control when a hidden subtree holds several',
+    async () => {
+      function TestCase() {
+        const [visible, setVisible] = React.useState(true);
+
+        return (
+          <React.Fragment>
+            <Field.Root>
+              <Field.Label data-testid="label">Apples</Field.Label>
+              <Activity mode={visible ? 'visible' : 'hidden'}>
+                <CheckboxGroup allValues={['fuji', 'gala']} defaultValue={[]}>
+                  <Checkbox.Root parent />
+                  <Checkbox.Root value="fuji" />
+                  <Checkbox.Root value="gala" />
+                </CheckboxGroup>
+              </Activity>
+            </Field.Root>
+            <button type="button" onClick={() => setVisible(false)}>
+              hide
+            </button>
+          </React.Fragment>
+        );
+      }
+
+      await render(<TestCase />);
+
+      const labelledControl = () =>
+        document.getElementById(screen.getByTestId('label').getAttribute('for') ?? '');
+
+      expect(labelledControl()).not.toBe(null);
+
+      fireEvent.click(screen.getByRole('button', { name: 'hide' }));
+
+      // Each control unregisters separately, so the selection must not settle on the id the
+      // provider generated for itself while the group is still rendered.
+      expect(labelledControl()).not.toBe(null);
     },
   );
 

--- a/packages/react/src/internals/labelable-provider/LabelableContext.ts
+++ b/packages/react/src/internals/labelable-provider/LabelableContext.ts
@@ -6,10 +6,9 @@ import { HTMLProps } from '../types';
 export interface LabelableContext {
   /**
    * The `id` of the labelable element.
-   * When `null` the association is implicit.
    */
-  controlId: string | null | undefined;
-  registerControlId: (source: symbol, id: string | null | undefined) => void;
+  controlId: string | undefined;
+  registerControlId: (source: symbol, id: string | undefined) => void;
   /**
    * The `id` of the label.
    */

--- a/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
+++ b/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
@@ -10,53 +10,50 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
   props,
 ) {
   const defaultId = useBaseUiId();
-  const initialControlId = props.controlId === undefined ? defaultId : props.controlId;
-
-  const [controlId, setControlIdState] = React.useState<string | null | undefined>(
-    initialControlId,
-  );
-  const [labelId, setLabelId] = React.useState<string | undefined>(props.labelId);
+  const [controlIdState, setControlIdState] = React.useState<string | undefined>(defaultId);
+  const [labelId, setLabelId] = React.useState<string | undefined>();
   const [messageIds, setMessageIds] = React.useState<string[]>([]);
 
-  const registrationsRef = useRefWithInit(() => new Map<symbol, string | null>());
+  // `undefined` only survives until the React 17 fallback id is assigned.
+  const controlId = controlIdState ?? defaultId;
+
+  const registrationsRef = useRefWithInit(() => new Map<symbol, string>());
 
   const { messageIds: parentMessageIds } = useLabelableContext();
 
-  const registerControlId = useStableCallback(
-    (source: symbol, nextId: string | null | undefined) => {
-      const registrations = registrationsRef.current;
+  const registerControlId = useStableCallback((source: symbol, nextId: string | undefined) => {
+    const registrations = registrationsRef.current;
 
-      if (nextId === undefined) {
-        registrations.delete(source);
-        return;
+    if (nextId === undefined) {
+      registrations.delete(source);
+    } else {
+      registrations.set(source, nextId);
+    }
+
+    // Keep the previously selected id while it is still registered so rapid
+    // unmount/remount cycles (e.g. React Activity) don't churn the selection.
+    setControlIdState((prev) => {
+      // Controls rendered without an explicit `id` never register, so fall back to this
+      // provider's own id to keep them associated with the label.
+      if (registrations.size === 0) {
+        return defaultId;
       }
 
-      registrations.set(source, nextId);
+      let nextControlId: string | undefined;
 
-      // Only flush when registering, not when unregistering.
-      // This prevents loops during rapid unmount/remount cycles (e.g. React Activity).
-      // The next registration will pick up the correct state.
-      setControlIdState((prev) => {
-        if (registrations.size === 0) {
-          return undefined;
+      for (const id of registrations.values()) {
+        if (id === prev) {
+          return prev;
         }
 
-        let nextControlId: string | null | undefined;
-
-        for (const id of registrations.values()) {
-          if (prev !== undefined && id === prev) {
-            return prev;
-          }
-
-          if (nextControlId === undefined) {
-            nextControlId = id;
-          }
+        if (nextControlId === undefined) {
+          nextControlId = id;
         }
+      }
 
-        return nextControlId;
-      });
-    },
-  );
+      return nextControlId;
+    });
+  });
 
   const getDescriptionProps = React.useCallback(
     (externalProps: HTMLProps) => {
@@ -102,8 +99,6 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
 export interface LabelableProviderState {}
 
 export interface LabelableProviderProps {
-  controlId?: string | null | undefined;
-  labelId?: string | undefined;
   children?: React.ReactNode;
 }
 

--- a/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
+++ b/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
@@ -40,6 +40,10 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
     // Keep the previously selected id while it is still registered so an unrelated
     // registration doesn't steal the selection.
     setControlIdState((prev) => {
+      if (registrations.size === 0) {
+        return prev;
+      }
+
       let nextControlId: string | undefined;
 
       for (const id of registrations.values()) {

--- a/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
+++ b/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
@@ -26,12 +26,19 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
 
     if (nextId === undefined) {
       registrations.delete(source);
+
+      // A hidden subtree (React Activity, a re-suspending Suspense) destroys effects but keeps
+      // its DOM, so an empty map is indistinguishable from a real unmount. Keep the selection
+      // so a control that is still rendered stays paired with the label.
+      if (registrations.size === 0) {
+        return;
+      }
     } else {
       registrations.set(source, nextId);
     }
 
-    // Keep the previously selected id while it is still registered so rapid
-    // unmount/remount cycles (e.g. React Activity) don't churn the selection.
+    // Keep the previously selected id while it is still registered so an unrelated
+    // registration doesn't steal the selection.
     setControlIdState((prev) => {
       let nextControlId: string | undefined;
 

--- a/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
+++ b/packages/react/src/internals/labelable-provider/LabelableProvider.tsx
@@ -33,12 +33,6 @@ export const LabelableProvider: React.FC<LabelableProvider.Props> = function Lab
     // Keep the previously selected id while it is still registered so rapid
     // unmount/remount cycles (e.g. React Activity) don't churn the selection.
     setControlIdState((prev) => {
-      // Controls rendered without an explicit `id` never register, so fall back to this
-      // provider's own id to keep them associated with the label.
-      if (registrations.size === 0) {
-        return defaultId;
-      }
-
       let nextControlId: string | undefined;
 
       for (const id of registrations.values()) {

--- a/packages/react/src/internals/labelable-provider/useLabel.ts
+++ b/packages/react/src/internals/labelable-provider/useLabel.ts
@@ -64,7 +64,7 @@ export function useLabel(params: UseLabelParameters = {}): UseLabelReturnValue {
   return native
     ? {
         id,
-        htmlFor: resolvedControlId ?? undefined,
+        htmlFor: resolvedControlId,
         onMouseDown: handleInteraction,
       }
     : {
@@ -81,7 +81,7 @@ export interface UseLabelParameters {
   /**
    * Control id used when no labelable context control id exists.
    */
-  fallbackControlId?: string | null | undefined;
+  fallbackControlId?: string | undefined;
   /**
    * Whether the rendered element is a native `<label>`.
    * @default false
@@ -95,9 +95,7 @@ export interface UseLabelParameters {
    * Custom focus handler for non-native labels.
    * If omitted, focus behavior targets the resolved control id.
    */
-  focusControl?:
-    | ((event: React.MouseEvent, controlId: string | null | undefined) => void)
-    | undefined;
+  focusControl?: ((event: React.MouseEvent, controlId: string | undefined) => void) | undefined;
 }
 
 export type UseLabelReturnValue = React.HTMLAttributes<any> & React.LabelHTMLAttributes<any>;

--- a/packages/react/src/internals/labelable-provider/useLabelableId.ts
+++ b/packages/react/src/internals/labelable-provider/useLabelableId.ts
@@ -3,19 +3,16 @@ import * as React from 'react';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
-import { isElement } from '@floating-ui/utils/dom';
 import { NOOP } from '../noop';
 import { useBaseUiId } from '../useBaseUiId';
 import { useLabelableContext } from './LabelableContext';
 
 export function useLabelableId(params: UseLabelableIdParameters = {}) {
-  const { id, implicit = false, controlRef } = params;
+  const { id } = params;
 
   const { controlId, registerControlId } = useLabelableContext();
 
-  const defaultId = useBaseUiId(id);
-
-  const controlIdForEffect = implicit ? controlId : undefined;
+  const defaultId = useBaseUiId();
 
   const controlSourceRef = useRefWithInit(() => Symbol());
   const hasRegisteredRef = React.useRef(false);
@@ -35,26 +32,17 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
       return undefined;
     }
 
-    let nextId: string | null | undefined;
+    let nextId: string | undefined;
 
-    if (implicit) {
-      const elem = controlRef?.current;
-
-      if (isElement(elem) && elem.closest('label') != null) {
-        nextId = id ?? null;
-      } else {
-        nextId = controlIdForEffect ?? defaultId;
-      }
-    } else if (id != null) {
+    if (id != null) {
       hadExplicitIdRef.current = true;
       nextId = id;
     } else if (hadExplicitIdRef.current) {
       nextId = defaultId;
-    } else {
-      unregisterControlId();
-      return undefined;
     }
 
+    // Either the control never had an explicit `id`, or the React 17 fallback id
+    // has not been assigned yet. Neither is worth registering.
     if (nextId === undefined) {
       unregisterControlId();
       return undefined;
@@ -64,35 +52,20 @@ export function useLabelableId(params: UseLabelableIdParameters = {}) {
     registerControlId(controlSourceRef.current, nextId);
 
     return undefined;
-  }, [
-    id,
-    controlRef,
-    controlIdForEffect,
-    registerControlId,
-    implicit,
-    defaultId,
-    controlSourceRef,
-    unregisterControlId,
-  ]);
+  }, [id, registerControlId, defaultId, controlSourceRef, unregisterControlId]);
 
   React.useEffect(() => {
     return unregisterControlId;
   }, [unregisterControlId]);
 
-  return controlId ?? defaultId;
+  // Don't let an explicit `id` preempt the provider's selected id: during SSR the label
+  // renders `htmlFor` from the provider's pre-registration state, and preempting it here
+  // would desynchronize the pair until hydration.
+  return controlId ?? id ?? defaultId;
 }
 
 export interface UseLabelableIdParameters {
   id?: string | undefined;
-  /**
-   * Whether implicit labelling is supported.
-   * @default false
-   */
-  implicit?: boolean | undefined;
-  /**
-   * A ref to an element that can be implicitly labelled.
-   */
-  controlRef?: React.RefObject<HTMLElement | null> | undefined;
 }
 
 export type UseLabelableIdReturnValue = string;

--- a/packages/react/src/radio/root/RadioRoot.tsx
+++ b/packages/react/src/radio/root/RadioRoot.tsx
@@ -113,11 +113,7 @@ export const RadioRoot = React.forwardRef(function RadioRoot<Value>(
   }, [checked, disabled, registerInputRef]);
 
   const id = useBaseUiId();
-  const inputId = useLabelableId({
-    id: idProp,
-    implicit: false,
-    controlRef: radioRef,
-  });
+  const inputId = useLabelableId({ id: idProp });
   const hiddenInputId = nativeButton ? undefined : inputId;
   const ariaLabelledBy = useAriaLabelledBy(
     ariaLabelledByProp,

--- a/packages/react/src/slider/label/SliderLabel.tsx
+++ b/packages/react/src/slider/label/SliderLabel.tsx
@@ -26,7 +26,7 @@ export const SliderLabel = React.forwardRef(function SliderLabel(
 
   const { state, setLabelId, controlRef, rootLabelId } = useSliderRootContext();
 
-  function focusControl(event: React.MouseEvent, controlId: string | null | undefined) {
+  function focusControl(event: React.MouseEvent, controlId: string | undefined) {
     if (controlId) {
       const controlElement = ownerDocument(event.currentTarget).getElementById(controlId);
       if (isHTMLElement(controlElement)) {

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -80,11 +80,7 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
 
   const id = useBaseUiId();
 
-  const controlId = useLabelableId({
-    id: idProp,
-    implicit: false,
-    controlRef: switchRef,
-  });
+  const controlId = useLabelableId({ id: idProp });
   const hiddenInputId = nativeButton ? undefined : controlId;
 
   const [checked, setCheckedState] = useControlled({


### PR DESCRIPTION
Split out of #5448, which was too large. This is the core fix only.

`LabelableProvider` recomputes the selected control id when a control registers, but never when it unregisters. Registration runs in a layout effect, unregistration is a passive cleanup. On a swap, the replacement registers during the commit phase before the outgoing control's cleanup runs, so the selector sees the old id still in the map and keeps it. The delete that follows never re-runs the selector, and the id stays latched.

StrictMode's simulated remount hides this, so the regression tests render with `strict: false`.

| Scenario | Before | After |
| --- | --- | --- |
| `<Field.Control key="a" id="a" />` → `key="b" id="b"` | control renders `id="a"`, label `for="a"` | `id="b"`, `for="b"` |
| Two controls `id="a"` and `id="b"`, first unmounts | survivor renders `id="a"` | `id="b"` |

In both cases the control ignores the `id` prop it was given, and an id belonging to a removed control leaks onto a different element.

## Changes

- The provider recomputes the selection on unregister as well as register, keeping the current id only while it is still registered.
- `useLabelableId` drops the dead `implicit` / `controlRef` branch. Nothing passed `implicit: true`; `Radio.Root` and `Switch.Root` passed `implicit: false` explicitly.
- The control id type narrows from `string | null | undefined` to `string | undefined`, which narrows `Slider`'s `ThumbMetadata.inputId`. `useLabel` and `Slider.Label` drop `null` from their control-id types too.
- `LabelableProvider` loses its unused `controlId` and `labelId` props.

## Hidden subtrees

Unregistering does not recompute when it empties the registration map. React destroys a hidden subtree's effects but keeps its DOM, so an empty map cannot be told apart from a real unmount. Flushing there would strip a consumer's explicit `id` off a control that is still rendered: `<Field.Control id="email" />` inside a hidden `<Activity>` would swap to a generated id, and `document.getElementById('email')` would stop matching until the subtree was shown again.

Keeping the selection costs one case. Replacing an explicit-id control with one that has no `id` leaves the label on the old id, because the replacement never registers and the map goes empty. Fixing that needs id-less controls to register as well, which is the trigger-ownership work deferred out of this PR.

The other parts of #5448 (non-native label focus, the `preferId` trigger work, and the Checkbox ownership rework) follow in separate PRs.
