### PR TITLE
[docs][experiments] Persist settings between page refreshes

### DIFF
--- a/docs/src/app/(private)/experiments/[...slug]/page.tsx
+++ b/docs/src/app/(private)/experiments/[...slug]/page.tsx
@@ -26,9 +26,13 @@ export default async function Page(props: Props) {
     const experimentModule = await import(`../${slug.join('/')}.tsx`);
     const Experiment = experimentModule.default;
     const settingsMetadata = experimentModule.settingsMetadata;
+    const applySettingsAfterHydration = experimentModule.applySettingsAfterHydration;
 
     return (
-      <ExperimentSettingsProvider metadata={settingsMetadata}>
+      <ExperimentSettingsProvider
+        metadata={settingsMetadata}
+        applySettingsAfterHydration={applySettingsAfterHydration}
+      >
         <ExperimentRoot
           sidebar={
             <Sidebar

--- a/docs/src/app/(private)/experiments/[...slug]/page.tsx
+++ b/docs/src/app/(private)/experiments/[...slug]/page.tsx
@@ -26,13 +26,9 @@ export default async function Page(props: Props) {
     const experimentModule = await import(`../${slug.join('/')}.tsx`);
     const Experiment = experimentModule.default;
     const settingsMetadata = experimentModule.settingsMetadata;
-    const applySettingsAfterHydration = experimentModule.applySettingsAfterHydration;
 
     return (
-      <ExperimentSettingsProvider
-        metadata={settingsMetadata}
-        applySettingsAfterHydration={applySettingsAfterHydration}
-      >
+      <ExperimentSettingsProvider metadata={settingsMetadata}>
         <ExperimentRoot
           sidebar={
             <Sidebar

--- a/docs/src/app/(private)/experiments/_components/ExperimentRoot.tsx
+++ b/docs/src/app/(private)/experiments/_components/ExperimentRoot.tsx
@@ -21,10 +21,11 @@ const STORAGE_KEY = 'base-ui-experiments-sidebar';
 export function ExperimentRoot(props: ExperimentRootProps) {
   const { children, sidebar } = props;
 
-  // The sidebar is rendered on the client only, so the stored visibility is applied on the very
-  // first render it takes part in instead of hiding a sidebar that was already painted. It stays
-  // `null` until read from session storage in a layout effect, which is what the server renders
-  // too. The experiment itself is outside of this and keeps its server-rendered markup.
+  // The sidebar is rendered on the client only. It stays `null` — neither shown nor taking up
+  // space, which is also what the server renders — until the stored visibility is read in a
+  // layout effect, defaulting to visible when nothing is stored. This way a sidebar that is
+  // meant to be hidden is never painted first. The experiment itself is outside of this and
+  // keeps its server-rendered markup.
   const [sidebarVisible, setSidebarVisible] = React.useState<boolean | null>(null);
 
   useIsoLayoutEffect(() => {
@@ -43,11 +44,7 @@ export function ExperimentRoot(props: ExperimentRootProps) {
 
   return (
     <ExperimentRootContext value={rootContext}>
-      {/*
-       * The space for the sidebar is kept until it is known to be hidden, so that the experiment
-       * doesn't shift sideways in the common case of a sidebar that turns out to be visible.
-       */}
-      <div className={clsx(classes.root, sidebarVisible !== false && classes.withSidebar)}>
+      <div className={clsx(classes.root, sidebarVisible && classes.withSidebar)}>
         {sidebarVisible === true && sidebar}
         {sidebarVisible === false && <ShowSidebar />}
         <main className={classes.main}>{children}</main>

--- a/docs/src/app/(private)/experiments/_components/ExperimentRoot.tsx
+++ b/docs/src/app/(private)/experiments/_components/ExperimentRoot.tsx
@@ -1,38 +1,80 @@
 'use client';
 import * as React from 'react';
 import clsx from 'clsx';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { ShowSidebar } from './ShowSidebar';
 import classes from './ExperimentRoot.module.css';
 
 export interface ExperimentRootContext {
-  sidebarVisible: boolean;
-  setSidebarVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  setSidebarVisible: (visible: boolean) => void;
 }
 
 export const ExperimentRootContext = React.createContext<ExperimentRootContext | undefined>(
   undefined,
 );
 
+// Shared by all experiments rather than stored per experiment, so that hiding the sidebar keeps
+// it hidden while moving between them.
+const STORAGE_KEY = 'base-ui-experiments-sidebar';
+
 export function ExperimentRoot(props: ExperimentRootProps) {
   const { children, sidebar } = props;
-  const [sidebarVisible, setSidebarVisible] = React.useState(true);
+
+  // The sidebar is rendered on the client only, so the stored visibility is applied on the very
+  // first render it takes part in instead of hiding a sidebar that was already painted. It stays
+  // `null` until read from session storage in a layout effect, which is what the server renders
+  // too. The experiment itself is outside of this and keeps its server-rendered markup.
+  const [sidebarVisible, setSidebarVisible] = React.useState<boolean | null>(null);
+
+  useIsoLayoutEffect(() => {
+    setSidebarVisible(readStoredSidebarVisible());
+  }, []);
+
+  const changeSidebarVisible = useStableCallback((visible: boolean) => {
+    setSidebarVisible(visible);
+    storeSidebarVisible(visible);
+  });
 
   const rootContext = React.useMemo(
-    () => ({
-      sidebarVisible,
-      setSidebarVisible,
-    }),
-    [sidebarVisible],
+    () => ({ setSidebarVisible: changeSidebarVisible }),
+    [changeSidebarVisible],
   );
 
   return (
     <ExperimentRootContext value={rootContext}>
-      <div className={clsx(classes.root, sidebarVisible && classes.withSidebar)}>
-        {sidebarVisible ? sidebar : <ShowSidebar />}
+      {/*
+       * The space for the sidebar is kept until it is known to be hidden, so that the experiment
+       * doesn't shift sideways in the common case of a sidebar that turns out to be visible.
+       */}
+      <div className={clsx(classes.root, sidebarVisible !== false && classes.withSidebar)}>
+        {sidebarVisible === true && sidebar}
+        {sidebarVisible === false && <ShowSidebar />}
         <main className={classes.main}>{children}</main>
       </div>
     </ExperimentRootContext>
   );
+}
+
+function readStoredSidebarVisible() {
+  try {
+    return sessionStorage.getItem(STORAGE_KEY) !== 'hidden';
+  } catch (error) {
+    console.warn('Could not read the sidebar visibility from session storage.', error);
+    return true;
+  }
+}
+
+function storeSidebarVisible(visible: boolean) {
+  try {
+    if (visible) {
+      sessionStorage.removeItem(STORAGE_KEY);
+    } else {
+      sessionStorage.setItem(STORAGE_KEY, 'hidden');
+    }
+  } catch (error) {
+    console.warn('Could not save the sidebar visibility to session storage.', error);
+  }
 }
 
 export interface ExperimentRootProps {

--- a/docs/src/app/(private)/experiments/_components/SettingsPanel.tsx
+++ b/docs/src/app/(private)/experiments/_components/SettingsPanel.tsx
@@ -21,22 +21,22 @@ export const ExperimentSettingsContext = React.createContext<
 >(undefined);
 
 export function ExperimentSettingsProvider<Settings extends {}>(
-  props: React.PropsWithChildren<{ metadata: SettingsMetadata<Settings> }>,
+  props: ExperimentSettingsProviderProps<Settings>,
 ) {
-  const { metadata, children } = props;
+  const { metadata, applySettingsAfterHydration = false, children } = props;
 
   // Persisted settings live in session storage, so they can only be read on the client and the
   // first render has to match the server output. By default nothing is rendered until the
   // stored values are read in a layout effect (which runs before the browser paints), so that
   // experiments mount with the persisted settings instead of rendering the defaults and
   // flipping afterwards. This matters for props that are only read on mount, and costs the
-  // experiment its server-rendered markup — which `applyAfterHydration` opts out of.
+  // experiment its server-rendered markup — which `applySettingsAfterHydration` opts out of.
   const [settings, setSettings] = React.useState<Settings | null>(() => {
     if (metadata == null) {
       return {} as Settings;
     }
 
-    return metadata.applyAfterHydration ? getDefaultSettings(metadata) : null;
+    return applySettingsAfterHydration ? getDefaultSettings(metadata) : null;
   });
 
   // Mirrors the committed settings so that consecutive updates within a single batch build on
@@ -94,6 +94,22 @@ export function ExperimentSettingsProvider<Settings extends {}>(
   );
 }
 
+export interface ExperimentSettingsProviderProps<Settings> extends React.PropsWithChildren<{}> {
+  metadata: SettingsMetadata<Settings>;
+  /**
+   * Whether to server-render the experiment with the default settings and apply the stored ones
+   * after hydration, at the cost of the experiment briefly rendering with the defaults.
+   * Set it on experiments that demonstrate server rendering; otherwise leave it off so that the
+   * experiment mounts with the stored settings already applied.
+   *
+   * Experiments opt in by exporting `applySettingsAfterHydration` next to `settingsMetadata`.
+   * It cannot live in the metadata itself, as experiments are free to type their settings with
+   * a string index signature, which any extra key would clash with.
+   * @default false
+   */
+  applySettingsAfterHydration?: boolean;
+}
+
 const STORAGE_KEY_PREFIX = 'base-ui-experiment-settings:';
 
 function getStorageKey() {
@@ -136,7 +152,7 @@ function isValidValue(fieldMetadata: FieldMetadata, value: unknown) {
 function getDefaultSettings<Settings extends {}>(metadata: SettingsMetadata<Settings>): Settings {
   const settings = {} as Settings;
 
-  getFieldKeys(metadata).forEach((key) => {
+  Object.keys(metadata).forEach((key) => {
     settings[key as keyof Settings] = getDefaultValue(
       metadata[key as keyof Settings],
     ) as Settings[keyof Settings];
@@ -166,7 +182,7 @@ function readStoredOverrides<Settings extends {}>(
 
   const overrides: Partial<Settings> = {};
 
-  getFieldKeys(metadata).forEach((key) => {
+  Object.keys(metadata).forEach((key) => {
     const storedValue = storedValues[key];
 
     if (isValidValue(metadata[key as keyof Settings], storedValue)) {
@@ -187,7 +203,7 @@ function saveSettings<Settings extends {}>(
 ) {
   const overrides: Record<string, unknown> = {};
 
-  getFieldKeys(metadata).forEach((key) => {
+  Object.keys(metadata).forEach((key) => {
     const fieldMetadata = metadata[key as keyof Settings];
     const value = settings[key as keyof Settings];
 
@@ -237,7 +253,7 @@ export function SettingsPanel<Settings extends {}>(props: SettingsPanelProps<Set
   const controls = (
     <div {...otherProps} className={clsx(classes.settings, className)}>
       <h2>Settings</h2>
-      {getFieldKeys(metadata).map((key) => {
+      {Object.keys(metadata).map((key) => {
         const value = (settings as Record<string, unknown>)[key];
         const fieldMetadata: FieldMetadata = metadata[key as keyof Settings];
         switch (fieldMetadata.type) {
@@ -292,34 +308,7 @@ export interface FieldMetadata {
   default?: unknown;
 }
 
-/**
- * Experiment-wide options, set alongside the field definitions in `settingsMetadata`.
- * Their keys are reserved, so a setting cannot be named after one of them.
- */
-export interface SettingsOptions {
-  /**
-   * Whether to server-render the experiment with the default settings and apply the stored ones
-   * after hydration, at the cost of the experiment briefly rendering with the defaults.
-   * Set it on experiments that demonstrate server rendering; otherwise leave it off so that the
-   * experiment mounts with the stored settings already applied.
-   * @default false
-   */
-  applyAfterHydration?: boolean;
-}
-
-export type SettingsMetadata<Settings> = Record<keyof Settings, FieldMetadata> & SettingsOptions;
-
-const OPTION_KEYS: ReadonlySet<string> = new Set([
-  'applyAfterHydration',
-] satisfies (keyof SettingsOptions)[]);
-
-/**
- * Lists the setting names in the metadata, skipping the experiment-wide options that share
- * the object with them.
- */
-function getFieldKeys<Settings extends {}>(metadata: SettingsMetadata<Settings>): string[] {
-  return Object.keys(metadata).filter((key) => !OPTION_KEYS.has(key));
-}
+export type SettingsMetadata<Settings> = Record<keyof Settings, FieldMetadata>;
 
 export interface SettingsPanelProps<Settings> extends React.HTMLAttributes<HTMLDivElement> {
   metadata: SettingsMetadata<Settings>;

--- a/docs/src/app/(private)/experiments/_components/SettingsPanel.tsx
+++ b/docs/src/app/(private)/experiments/_components/SettingsPanel.tsx
@@ -21,22 +21,22 @@ export const ExperimentSettingsContext = React.createContext<
 >(undefined);
 
 export function ExperimentSettingsProvider<Settings extends {}>(
-  props: ExperimentSettingsProviderProps<Settings>,
+  props: React.PropsWithChildren<{ metadata: SettingsMetadata<Settings> }>,
 ) {
-  const { metadata, applySettingsAfterHydration = false, children } = props;
+  const { metadata, children } = props;
 
   // Persisted settings live in session storage, so they can only be read on the client and the
   // first render has to match the server output. By default nothing is rendered until the
   // stored values are read in a layout effect (which runs before the browser paints), so that
   // experiments mount with the persisted settings instead of rendering the defaults and
   // flipping afterwards. This matters for props that are only read on mount, and costs the
-  // experiment its server-rendered markup — which `applySettingsAfterHydration` opts out of.
+  // experiment its server-rendered markup — which `applyAfterHydration` opts out of.
   const [settings, setSettings] = React.useState<Settings | null>(() => {
     if (metadata == null) {
       return {} as Settings;
     }
 
-    return applySettingsAfterHydration ? getDefaultSettings(metadata) : null;
+    return metadata.applyAfterHydration ? getDefaultSettings(metadata) : null;
   });
 
   // Mirrors the committed settings so that consecutive updates within a single batch build on
@@ -89,18 +89,6 @@ export function ExperimentSettingsProvider<Settings extends {}>(
   );
 }
 
-export interface ExperimentSettingsProviderProps<Settings> extends React.PropsWithChildren<{}> {
-  metadata: SettingsMetadata<Settings>;
-  /**
-   * Whether to server-render the experiment with the default settings and apply the stored ones
-   * after hydration, at the cost of the experiment briefly rendering with the defaults.
-   * Set it on experiments that demonstrate server rendering; otherwise leave it off so that the
-   * experiment mounts with the stored settings already applied.
-   * @default false
-   */
-  applySettingsAfterHydration?: boolean;
-}
-
 const STORAGE_KEY_PREFIX = 'base-ui-experiment-settings:';
 
 function getStorageKey() {
@@ -143,7 +131,7 @@ function isValidValue(fieldMetadata: FieldMetadata, value: unknown) {
 function getDefaultSettings<Settings extends {}>(metadata: SettingsMetadata<Settings>): Settings {
   const settings = {} as Settings;
 
-  Object.keys(metadata).forEach((key) => {
+  getFieldKeys(metadata).forEach((key) => {
     settings[key as keyof Settings] = getDefaultValue(
       metadata[key as keyof Settings],
     ) as Settings[keyof Settings];
@@ -173,7 +161,7 @@ function readStoredOverrides<Settings extends {}>(
 
   const overrides: Partial<Settings> = {};
 
-  Object.keys(metadata).forEach((key) => {
+  getFieldKeys(metadata).forEach((key) => {
     const storedValue = storedValues[key];
 
     if (isValidValue(metadata[key as keyof Settings], storedValue)) {
@@ -194,7 +182,7 @@ function saveSettings<Settings extends {}>(
 ) {
   const overrides: Record<string, unknown> = {};
 
-  Object.keys(metadata).forEach((key) => {
+  getFieldKeys(metadata).forEach((key) => {
     const fieldMetadata = metadata[key as keyof Settings];
     const value = settings[key as keyof Settings];
 
@@ -244,7 +232,7 @@ export function SettingsPanel<Settings extends {}>(props: SettingsPanelProps<Set
   const controls = (
     <div {...otherProps} className={clsx(classes.settings, className)}>
       <h2>Settings</h2>
-      {Object.keys(metadata).map((key) => {
+      {getFieldKeys(metadata).map((key) => {
         const value = (settings as Record<string, unknown>)[key];
         const fieldMetadata: FieldMetadata = metadata[key as keyof Settings];
         switch (fieldMetadata.type) {
@@ -299,7 +287,34 @@ export interface FieldMetadata {
   default?: unknown;
 }
 
-export type SettingsMetadata<Settings> = Record<keyof Settings, FieldMetadata>;
+/**
+ * Experiment-wide options, set alongside the field definitions in `settingsMetadata`.
+ * Their keys are reserved, so a setting cannot be named after one of them.
+ */
+export interface SettingsOptions {
+  /**
+   * Whether to server-render the experiment with the default settings and apply the stored ones
+   * after hydration, at the cost of the experiment briefly rendering with the defaults.
+   * Set it on experiments that demonstrate server rendering; otherwise leave it off so that the
+   * experiment mounts with the stored settings already applied.
+   * @default false
+   */
+  applyAfterHydration?: boolean;
+}
+
+export type SettingsMetadata<Settings> = Record<keyof Settings, FieldMetadata> & SettingsOptions;
+
+const OPTION_KEYS: ReadonlySet<string> = new Set([
+  'applyAfterHydration',
+] satisfies (keyof SettingsOptions)[]);
+
+/**
+ * Lists the setting names in the metadata, skipping the experiment-wide options that share
+ * the object with them.
+ */
+function getFieldKeys<Settings extends {}>(metadata: SettingsMetadata<Settings>): string[] {
+  return Object.keys(metadata).filter((key) => !OPTION_KEYS.has(key));
+}
 
 export interface SettingsPanelProps<Settings> extends React.HTMLAttributes<HTMLDivElement> {
   metadata: SettingsMetadata<Settings>;

--- a/docs/src/app/(private)/experiments/_components/SettingsPanel.tsx
+++ b/docs/src/app/(private)/experiments/_components/SettingsPanel.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 import clsx from 'clsx';
 import { Popover } from '@base-ui/react/popover';
 import { Field } from '@base-ui/react/field';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { Switch } from './Switch';
 import { Input } from './Input';
 import { Select } from './Select';
@@ -20,51 +22,146 @@ export const ExperimentSettingsContext = React.createContext<
 export function ExperimentSettingsProvider<Settings extends {}>(
   props: React.PropsWithChildren<{ metadata: SettingsMetadata<Settings> }>,
 ) {
-  const [settingsState, setSettings] = React.useState<Settings>({} as Settings);
   const { metadata, children } = props;
-  const isInitializedRef = React.useRef(false);
 
-  const settings = settingsState;
+  // Persisted settings live in session storage, so they can only be read on the client and the
+  // first render has to match the server output. Instead of rendering the experiment with the
+  // defaults and updating it afterwards, nothing is rendered until the stored values are read
+  // in a layout effect (which runs before the browser paints). This way experiments always
+  // mount with the persisted settings, which matters for props that are only read on mount.
+  const [settings, setSettings] = React.useState<Settings | null>(() =>
+    metadata == null ? ({} as Settings) : null,
+  );
 
-  if (!isInitializedRef.current && metadata != null) {
-    Object.keys(metadata).forEach((key) => {
-      const fieldMetadata = metadata[key as keyof Settings];
-      if (fieldMetadata.default !== undefined) {
-        settings[key as keyof Settings] = fieldMetadata.default as any;
-      } else {
-        switch (fieldMetadata.type) {
-          case 'boolean':
-            (settings[key as keyof Settings] as any) = false;
-            break;
-          case 'number':
-            (settings[key as keyof Settings] as any) = 0;
-            break;
-          case 'string':
-            (settings[key as keyof Settings] as any) = '';
-            break;
-          default:
-            break;
-        }
-      }
-    });
+  useIsoLayoutEffect(() => {
+    if (metadata != null) {
+      setSettings(loadSettings(metadata));
+    }
+  }, [metadata]);
 
-    isInitializedRef.current = true;
-    setSettings(settings);
-  }
+  const updateSettings = useStableCallback((action: React.SetStateAction<Settings>) => {
+    const nextSettings =
+      typeof action === 'function'
+        ? (action as (prevState: Settings) => Settings)(settings as Settings)
+        : action;
+
+    setSettings(nextSettings);
+
+    if (metadata != null) {
+      saveSettings(metadata, nextSettings);
+    }
+  });
 
   const context = React.useMemo(
-    () => ({
-      settings,
-      setSettings,
-    }),
-    [settings],
+    () => (settings == null ? null : { settings, setSettings: updateSettings }),
+    [settings, updateSettings],
   );
+
+  if (context == null) {
+    return null;
+  }
 
   return (
     <ExperimentSettingsContext value={context as ExperimentsSettingsContext}>
       {children}
     </ExperimentSettingsContext>
   );
+}
+
+const STORAGE_KEY_PREFIX = 'base-ui-experiment-settings:';
+
+function getStorageKey() {
+  return `${STORAGE_KEY_PREFIX}${window.location.pathname.replace(/\/$/, '')}`;
+}
+
+function getDefaultValue(fieldMetadata: FieldMetadata) {
+  if (fieldMetadata.default !== undefined) {
+    return fieldMetadata.default;
+  }
+
+  switch (fieldMetadata.type) {
+    case 'boolean':
+      return false;
+    case 'number':
+      return 0;
+    case 'string':
+      return '';
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Checks whether a value read from session storage still matches the field's metadata.
+ * Metadata changes as experiments are edited, so stored values can become stale.
+ */
+function isValidValue(fieldMetadata: FieldMetadata, value: unknown) {
+  if (typeof value !== fieldMetadata.type) {
+    return false;
+  }
+
+  if (fieldMetadata.options) {
+    return fieldMetadata.options.includes(value as string);
+  }
+
+  return true;
+}
+
+function loadSettings<Settings extends {}>(metadata: SettingsMetadata<Settings>): Settings {
+  let storedValues: Record<string, unknown> = {};
+
+  try {
+    const serialized = sessionStorage.getItem(getStorageKey());
+    const parsed = serialized == null ? null : JSON.parse(serialized);
+    if (typeof parsed === 'object' && parsed !== null) {
+      storedValues = parsed;
+    }
+  } catch (error) {
+    console.warn('Could not read the experiment settings from session storage.', error);
+  }
+
+  const settings = {} as Settings;
+
+  Object.keys(metadata).forEach((key) => {
+    const fieldMetadata = metadata[key as keyof Settings];
+    const storedValue = storedValues[key];
+
+    settings[key as keyof Settings] = (
+      isValidValue(fieldMetadata, storedValue) ? storedValue : getDefaultValue(fieldMetadata)
+    ) as Settings[keyof Settings];
+  });
+
+  return settings;
+}
+
+/**
+ * Stores only the values that differ from the defaults, so that experiments pick up changes
+ * to the defaults in their metadata instead of being stuck with a previously stored copy.
+ */
+function saveSettings<Settings extends {}>(
+  metadata: SettingsMetadata<Settings>,
+  settings: Settings,
+) {
+  const overrides: Record<string, unknown> = {};
+
+  Object.keys(metadata).forEach((key) => {
+    const fieldMetadata = metadata[key as keyof Settings];
+    const value = settings[key as keyof Settings];
+
+    if (isValidValue(fieldMetadata, value) && value !== getDefaultValue(fieldMetadata)) {
+      overrides[key] = value;
+    }
+  });
+
+  try {
+    if (Object.keys(overrides).length === 0) {
+      sessionStorage.removeItem(getStorageKey());
+    } else {
+      sessionStorage.setItem(getStorageKey(), JSON.stringify(overrides));
+    }
+  } catch (error) {
+    console.warn('Could not save the experiment settings to session storage.', error);
+  }
 }
 
 export function useExperimentSettings<Settings extends {}>() {

--- a/docs/src/app/(private)/experiments/_components/SettingsPanel.tsx
+++ b/docs/src/app/(private)/experiments/_components/SettingsPanel.tsx
@@ -50,6 +50,11 @@ export function ExperimentSettingsProvider<Settings extends {}>(
 
     const storedSettings = { ...getDefaultSettings(metadata), ...readStoredOverrides(metadata) };
 
+    // Rewrite the entry so it only holds overrides that are still valid and still differ from
+    // the defaults. Without this, an override that a metadata change turned into the default
+    // would linger and shadow that default if it ever changed back.
+    saveSettings(metadata, storedSettings);
+
     // Already up to date when the defaults were server-rendered and nothing was stored.
     if (fastObjectShallowCompare(settingsRef.current, storedSettings)) {
       return;

--- a/docs/src/app/(private)/experiments/_components/SettingsPanel.tsx
+++ b/docs/src/app/(private)/experiments/_components/SettingsPanel.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import clsx from 'clsx';
 import { Popover } from '@base-ui/react/popover';
 import { Field } from '@base-ui/react/field';
+import { fastObjectShallowCompare } from '@base-ui/utils/fastObjectShallowCompare';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { Switch } from './Switch';
@@ -20,31 +21,51 @@ export const ExperimentSettingsContext = React.createContext<
 >(undefined);
 
 export function ExperimentSettingsProvider<Settings extends {}>(
-  props: React.PropsWithChildren<{ metadata: SettingsMetadata<Settings> }>,
+  props: ExperimentSettingsProviderProps<Settings>,
 ) {
-  const { metadata, children } = props;
+  const { metadata, applySettingsAfterHydration = false, children } = props;
 
   // Persisted settings live in session storage, so they can only be read on the client and the
-  // first render has to match the server output. Instead of rendering the experiment with the
-  // defaults and updating it afterwards, nothing is rendered until the stored values are read
-  // in a layout effect (which runs before the browser paints). This way experiments always
-  // mount with the persisted settings, which matters for props that are only read on mount.
-  const [settings, setSettings] = React.useState<Settings | null>(() =>
-    metadata == null ? ({} as Settings) : null,
-  );
+  // first render has to match the server output. By default nothing is rendered until the
+  // stored values are read in a layout effect (which runs before the browser paints), so that
+  // experiments mount with the persisted settings instead of rendering the defaults and
+  // flipping afterwards. This matters for props that are only read on mount, and costs the
+  // experiment its server-rendered markup — which `applySettingsAfterHydration` opts out of.
+  const [settings, setSettings] = React.useState<Settings | null>(() => {
+    if (metadata == null) {
+      return {} as Settings;
+    }
+
+    return applySettingsAfterHydration ? getDefaultSettings(metadata) : null;
+  });
+
+  // Mirrors the committed settings so that consecutive updates within a single batch build on
+  // each other instead of the last rendered value.
+  const settingsRef = React.useRef(settings);
 
   useIsoLayoutEffect(() => {
-    if (metadata != null) {
-      setSettings(loadSettings(metadata));
+    if (metadata == null) {
+      return;
     }
+
+    const storedSettings = { ...getDefaultSettings(metadata), ...readStoredOverrides(metadata) };
+
+    // Already up to date when the defaults were server-rendered and nothing was stored.
+    if (fastObjectShallowCompare(settingsRef.current, storedSettings)) {
+      return;
+    }
+
+    settingsRef.current = storedSettings;
+    setSettings(storedSettings);
   }, [metadata]);
 
   const updateSettings = useStableCallback((action: React.SetStateAction<Settings>) => {
     const nextSettings =
       typeof action === 'function'
-        ? (action as (prevState: Settings) => Settings)(settings as Settings)
+        ? (action as (prevState: Settings) => Settings)(settingsRef.current as Settings)
         : action;
 
+    settingsRef.current = nextSettings;
     setSettings(nextSettings);
 
     if (metadata != null) {
@@ -66,6 +87,18 @@ export function ExperimentSettingsProvider<Settings extends {}>(
       {children}
     </ExperimentSettingsContext>
   );
+}
+
+export interface ExperimentSettingsProviderProps<Settings> extends React.PropsWithChildren<{}> {
+  metadata: SettingsMetadata<Settings>;
+  /**
+   * Whether to server-render the experiment with the default settings and apply the stored ones
+   * after hydration, at the cost of the experiment briefly rendering with the defaults.
+   * Set it on experiments that demonstrate server rendering; otherwise leave it off so that the
+   * experiment mounts with the stored settings already applied.
+   * @default false
+   */
+  applySettingsAfterHydration?: boolean;
 }
 
 const STORAGE_KEY_PREFIX = 'base-ui-experiment-settings:';
@@ -107,7 +140,25 @@ function isValidValue(fieldMetadata: FieldMetadata, value: unknown) {
   return true;
 }
 
-function loadSettings<Settings extends {}>(metadata: SettingsMetadata<Settings>): Settings {
+function getDefaultSettings<Settings extends {}>(metadata: SettingsMetadata<Settings>): Settings {
+  const settings = {} as Settings;
+
+  Object.keys(metadata).forEach((key) => {
+    settings[key as keyof Settings] = getDefaultValue(
+      metadata[key as keyof Settings],
+    ) as Settings[keyof Settings];
+  });
+
+  return settings;
+}
+
+/**
+ * Reads the stored values that are still described by the metadata. Values of fields that were
+ * since removed or redefined are dropped, so the defaults apply to them again.
+ */
+function readStoredOverrides<Settings extends {}>(
+  metadata: SettingsMetadata<Settings>,
+): Partial<Settings> {
   let storedValues: Record<string, unknown> = {};
 
   try {
@@ -120,18 +171,17 @@ function loadSettings<Settings extends {}>(metadata: SettingsMetadata<Settings>)
     console.warn('Could not read the experiment settings from session storage.', error);
   }
 
-  const settings = {} as Settings;
+  const overrides: Partial<Settings> = {};
 
   Object.keys(metadata).forEach((key) => {
-    const fieldMetadata = metadata[key as keyof Settings];
     const storedValue = storedValues[key];
 
-    settings[key as keyof Settings] = (
-      isValidValue(fieldMetadata, storedValue) ? storedValue : getDefaultValue(fieldMetadata)
-    ) as Settings[keyof Settings];
+    if (isValidValue(metadata[key as keyof Settings], storedValue)) {
+      overrides[key as keyof Settings] = storedValue as Settings[keyof Settings];
+    }
   });
 
-  return settings;
+  return overrides;
 }
 
 /**

--- a/docs/src/app/(private)/experiments/_components/ShowSidebar.module.css
+++ b/docs/src/app/(private)/experiments/_components/ShowSidebar.module.css
@@ -11,6 +11,10 @@
   gap: 2px;
   justify-content: center;
   align-items: center;
+  cursor: pointer;
+  transition:
+    box-shadow 150ms,
+    outline-color 150ms;
 
   &::before,
   &::after {
@@ -20,29 +24,42 @@
     height: 2px;
     background-color: var(--color-gray-500);
     border-radius: 1px;
+    transition: background-color 150ms;
+  }
+
+  /* The icon carries most of the hover feedback, with the tinted surface backing it up. */
+  &:hover::before,
+  &:hover::after {
+    background-color: var(--color-gray-900);
   }
 
   @media (prefers-color-scheme: light) {
     outline: 1px solid var(--color-gray-200);
+
+    /* The inset layer tints the surface while keeping it opaque, since the button sits on top
+       of the experiment once the sidebar is out of the way. */
     box-shadow:
+      inset 0 0 0 32px transparent,
       0 10px 15px -3px var(--color-gray-200),
       0 4px 6px -4px var(--color-gray-200);
 
     &:hover {
+      outline-color: var(--color-gray-400);
       box-shadow:
-        0 15px 20px -3px var(--color-gray-200),
-        0 6px 9px -4px var(--color-gray-200);
+        inset 0 0 0 32px var(--color-gray-200),
+        0 10px 20px -3px var(--color-gray-300),
+        0 4px 8px -4px var(--color-gray-300);
     }
-
-    transition: box-shadow 200ms;
   }
 
   @media (prefers-color-scheme: dark) {
     outline: 1px solid var(--color-gray-300);
     outline-offset: -1px;
+    box-shadow: inset 0 0 0 32px transparent;
 
     &:hover {
-      outline: 2px solid var(--color-gray-200);
+      outline-color: var(--color-gray-600);
+      box-shadow: inset 0 0 0 32px var(--color-gray-300);
     }
   }
 }

--- a/docs/src/app/(private)/experiments/_components/ShowSidebar.module.css
+++ b/docs/src/app/(private)/experiments/_components/ShowSidebar.module.css
@@ -11,7 +11,6 @@
   gap: 2px;
   justify-content: center;
   align-items: center;
-  cursor: pointer;
   transition:
     box-shadow 150ms,
     outline-color 150ms;


### PR DESCRIPTION
Experiment settings now survive a page refresh instead of resetting to their defaults.

- Settings are stored in **session storage**, keyed by the experiment path. Session storage rather than local storage so PR preview deployments don't accumulate hundreds of entries in the browser.
- Only values that **differ from the metadata defaults** are stored, so changing a `default:` in an experiment's metadata still takes effect rather than being shadowed by a previously stored copy. The entry is removed entirely once nothing is overridden.
- Stored values are validated against the field metadata (type, and `options` for selects) and discarded when they no longer match, so editing an experiment's settings metadata can't leave it in a broken state.

Settings are applied **on mount**, not after: `ExperimentSettingsProvider` renders nothing until the stored values are read in a layout effect (which runs before paint), so an experiment never renders with the defaults and flips to the saved values afterwards. This matters for props that are only read on mount. The initial client render matches the server output, so there's no hydration mismatch.

Experiments without `settingsMetadata` are unaffected — they initialize synchronously and are still server-rendered, which `tabs/tabs-streaming-ssr` relies on.

## Testing

Verified manually on `/experiments/popover/popovers`:

- Changed `openOnHover`, `delay`, `side`, and `keepMounted` → all four restored after a reload, no console errors or hydration warnings.
- Resetting values back to their defaults shrank the stored entry to just the remaining override.
- Seeding the entry with an invalid select option, a wrong-typed number, and an unknown key fell back to the defaults cleanly.
- Confirmed via the server HTML that `tabs/tabs-streaming-ssr` still server-renders its content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)