### PR TITLE
[field] Validate once on Enter inside a Form

### DIFF
--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -271,6 +271,34 @@ describe('<Field.Control />', () => {
     expect(handleSubmit).not.toHaveBeenCalled();
   });
 
+  it.skipIf(isJSDOM)(
+    'validates when a disabled submit button blocks implicit submission',
+    async () => {
+      const { userEvent } = await import('vitest/browser');
+      const user = userEvent.setup();
+      const validate = vi.fn(() => null);
+      const handleSubmit = vi.fn();
+
+      await render(
+        <Form onSubmit={handleSubmit}>
+          <Field.Root validate={validate}>
+            <Field.Control defaultValue="a" />
+          </Field.Root>
+          <button type="submit" disabled>
+            submit
+          </button>
+        </Form>,
+      );
+
+      const control = screen.getByRole<HTMLInputElement>('textbox');
+
+      await act(() => user.type(control, '[Enter]'));
+
+      expect(validate).toHaveBeenCalledTimes(1);
+      expect(handleSubmit).not.toHaveBeenCalled();
+    },
+  );
+
   it.skipIf(isJSDOM)('validates the latest value when Enter does not submit the form', async () => {
     const { userEvent } = await import('vitest/browser');
     const user = userEvent.setup();

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect, vi } from 'vitest';
-import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
+import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
 import { describeConformance, isJSDOM } from '#test-utils';
@@ -223,6 +223,93 @@ describe('<Field.Control />', () => {
     expect(handleValueChange).toHaveBeenCalledTimes(1);
     expect(validate).not.toHaveBeenCalled();
     expect(screen.getByText('Server error')).toBeInTheDocument();
+  });
+
+  it.skipIf(isJSDOM)('validates once when Enter implicitly submits a form', async () => {
+    const { userEvent } = await import('vitest/browser');
+    const user = userEvent.setup();
+    const validate = vi.fn(() => null);
+    const handleSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
+
+    await render(
+      <Form onSubmit={handleSubmit}>
+        <Field.Root validate={validate}>
+          <Field.Control defaultValue="a" />
+        </Field.Root>
+        <button type="submit">submit</button>
+      </Form>,
+    );
+
+    const control = screen.getByRole<HTMLInputElement>('textbox');
+
+    await act(() => user.type(control, '[Enter]'));
+
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it.skipIf(isJSDOM)('validates when Enter does not implicitly submit the form', async () => {
+    const { userEvent } = await import('vitest/browser');
+    const user = userEvent.setup();
+    const validate = vi.fn(() => null);
+    const handleSubmit = vi.fn();
+
+    await render(
+      <Form onSubmit={handleSubmit}>
+        <Field.Root validate={validate}>
+          <Field.Control defaultValue="a" />
+        </Field.Root>
+        <input />
+      </Form>,
+    );
+
+    const control = screen.getByDisplayValue<HTMLInputElement>('a');
+
+    await act(() => user.type(control, '[Enter]'));
+
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it.skipIf(isJSDOM)('validates the latest value when Enter does not submit the form', async () => {
+    const { userEvent } = await import('vitest/browser');
+    const user = userEvent.setup();
+    const validate = vi.fn((_value: unknown) => null);
+
+    function App() {
+      const [value, setValue] = React.useState('a');
+      return (
+        <Form onKeyDown={() => setValue('')}>
+          <Field.Root validate={validate}>
+            <Field.Control value={value} onValueChange={setValue} />
+          </Field.Root>
+          <input />
+        </Form>
+      );
+    }
+
+    await render(<App />);
+
+    await act(() => user.type(screen.getByDisplayValue('a'), '[Enter]'));
+
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(validate.mock.lastCall?.[0]).toBe('');
+  });
+
+  it('validates when Enter is pressed outside a form', async () => {
+    const validate = vi.fn(() => null);
+
+    await render(
+      <Field.Root validate={validate}>
+        <Field.Control defaultValue="a" />
+      </Field.Root>,
+    );
+
+    const control = screen.getByRole('textbox');
+    act(() => control.focus());
+    fireEvent.keyDown(control, { key: 'Enter' });
+
+    expect(validate).toHaveBeenCalledTimes(1);
   });
 
   it('shows a required error when a prefilled value is cleared', async () => {

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { expect, vi } from 'vitest';
-import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
+import { act, createRenderer, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
 import { describeConformance, isJSDOM } from '#test-utils';
@@ -299,9 +299,7 @@ describe('<Field.Control />', () => {
     },
   );
 
-  it.skipIf(isJSDOM)('validates the latest value when Enter does not submit the form', async () => {
-    const { userEvent } = await import('vitest/browser');
-    const user = userEvent.setup();
+  it('validates the latest value when Enter does not submit the form', async () => {
     const validate = vi.fn((_value: unknown) => null);
 
     function App() {
@@ -318,9 +316,14 @@ describe('<Field.Control />', () => {
 
     await render(<App />);
 
-    await act(() => user.type(screen.getByDisplayValue('a'), '[Enter]'));
+    const control = screen.getByDisplayValue<HTMLInputElement>('a');
+    act(() => control.focus());
+    fireEvent.keyDown(control, { key: 'Enter' });
 
-    expect(validate).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(validate).toHaveBeenCalledTimes(1);
+    });
+
     expect(validate.mock.lastCall?.[0]).toBe('');
   });
 

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -4,6 +4,7 @@ import { useControlled } from '@base-ui/utils/useControlled';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
+import { useTimeout } from '@base-ui/utils/useTimeout';
 import { type FieldRootState } from '../root/FieldRoot';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
 import { useRegisterFieldControl } from '../../internals/field-register-control/useRegisterFieldControl';
@@ -59,7 +60,7 @@ export const FieldControl = React.forwardRef(function FieldControl(
     validationMode,
     validation,
   } = useFieldRootContext();
-  const { clearErrors } = useFormContext();
+  const { clearErrors, elementRef: formElementRef, submitCountRef } = useFormContext();
 
   const disabled = fieldDisabled || disabledProp;
   const name = fieldName ?? nameProp;
@@ -115,6 +116,7 @@ export const FieldControl = React.forwardRef(function FieldControl(
   });
 
   const inputRef = React.useRef<HTMLElement>(null);
+  const enterValidationTimeout = useTimeout();
 
   useIsoLayoutEffect(() => {
     if (autoFocus && inputRef.current === activeElement(ownerDocument(inputRef.current))) {
@@ -169,7 +171,21 @@ export const FieldControl = React.forwardRef(function FieldControl(
         onKeyDown(event) {
           if (event.currentTarget.tagName === 'INPUT' && event.key === 'Enter') {
             setTouched(true);
-            validation.commit(event.currentTarget.value);
+            const value = event.currentTarget.value;
+            const form = event.currentTarget.form;
+            if (form && form === formElementRef.current && !event.defaultPrevented) {
+              const input = event.currentTarget;
+              const submitCount = submitCountRef.current;
+
+              // Implicit submission runs after keydown. Fall back unless Form handles it first.
+              enterValidationTimeout.start(0, () => {
+                if (submitCountRef.current === submitCount) {
+                  validation.commit(input.value);
+                }
+              });
+            } else {
+              validation.commit(value);
+            }
           }
         },
       },

--- a/packages/react/src/field/root/FieldRoot.tsx
+++ b/packages/react/src/field/root/FieldRoot.tsx
@@ -23,7 +23,7 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
   componentProps: FieldRoot.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { errors, validationMode: formValidationMode, submitAttemptedRef } = useFormContext();
+  const { errors, validationMode: formValidationMode, submitCountRef } = useFormContext();
 
   const {
     render,
@@ -87,7 +87,7 @@ const FieldRootInner = React.forwardRef(function FieldRootInner(
   const shouldValidateOnChange = useStableCallback(
     () =>
       validationMode === 'onChange' ||
-      (validationMode === 'onSubmit' && submitAttemptedRef.current),
+      (validationMode === 'onSubmit' && submitCountRef.current > 0),
   );
 
   const formError =

--- a/packages/react/src/field/validity/FieldValidity.test.tsx
+++ b/packages/react/src/field/validity/FieldValidity.test.tsx
@@ -28,8 +28,7 @@ describe('<Field.Validity />', () => {
         if (validationMode === 'onBlur') {
           fireEvent.blur(input);
         } else {
-          act(() => input.focus());
-          fireEvent.keyDown(input, { key: 'Enter' });
+          fireEvent.click(screen.getByText('submit'));
         }
       };
 
@@ -46,10 +45,12 @@ describe('<Field.Validity />', () => {
       fireEvent.change(input, { target: { value: '' } });
 
       expect(handleValidity.mock.lastCall?.[0].value).toBe('');
-      expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(false);
+      expect(handleValidity.mock.lastCall?.[0].validity.customError).toBe(
+        validationMode === 'onSubmit',
+      );
       expect(handleValidity.mock.lastCall?.[0].validity.valueMissing).toBe(true);
       expect(screen.getByText('Required')).toBeVisible();
-      expect(validate).toHaveBeenCalledTimes(1);
+      expect(validate).toHaveBeenCalledTimes(validationMode === 'onBlur' ? 1 : 2);
 
       if (validationMode === 'onBlur') {
         fireEvent.blur(input);

--- a/packages/react/src/form/Form.tsx
+++ b/packages/react/src/form/Form.tsx
@@ -38,7 +38,7 @@ export const Form = React.forwardRef(function Form<
   });
   const elementRef = React.useRef<HTMLFormElement>(null);
   const submittedRef = React.useRef(false);
-  const submitAttemptedRef = React.useRef(false);
+  const submitCountRef = React.useRef(0);
 
   const focusFirstInvalid = useStableCallback(() => {
     // A field can be invalid without a focusable control (for example a checkbox group whose
@@ -109,7 +109,7 @@ export const Form = React.forwardRef(function Form<
       {
         noValidate: true,
         onSubmit(event) {
-          submitAttemptedRef.current = true;
+          submitCountRef.current += 1;
 
           // Async validation isn't supported to stop the submit event.
           formRef.current.fields.forEach((field) => {
@@ -163,7 +163,7 @@ export const Form = React.forwardRef(function Form<
       validationMode,
       errors: errors ?? EMPTY_OBJECT,
       clearErrors,
-      submitAttemptedRef,
+      submitCountRef,
     }),
     [formRef, validationMode, errors, clearErrors],
   );

--- a/packages/react/src/internals/form-context/FormContext.ts
+++ b/packages/react/src/internals/form-context/FormContext.ts
@@ -27,7 +27,7 @@ export interface FormContext {
     >;
   }>;
   validationMode: Form.ValidationMode;
-  submitAttemptedRef: React.RefObject<boolean>;
+  submitCountRef: React.RefObject<number>;
 }
 
 export const FormContext = React.createContext<FormContext>({
@@ -40,8 +40,8 @@ export const FormContext = React.createContext<FormContext>({
   errors: {},
   clearErrors: NOOP,
   validationMode: 'onSubmit',
-  submitAttemptedRef: {
-    current: false,
+  submitCountRef: {
+    current: 0,
   },
 });
 


### PR DESCRIPTION
When a `Field.Control` input sits inside a `Form` and is natively associated with it, pressing Enter ran the focused field's validator twice. The keydown handler committed validation, and the browser's implicit submission then ran `Form`'s submit handler, which validates every field again. An async or server-side validator on that field fired two requests per keypress, and `onValidityChange` fired twice.

The keydown commit is now deferred by a timeout and skipped when the form submitted in the meantime. `submitAttemptedRef` becomes `submitCountRef` (a counter) so each keypress can tell whether a submit happened after it. The deferral only applies when the input is natively associated with the surrounding Base UI form and the keydown was not `preventDefault()`-ed; standalone inputs and foreign-form associations still commit synchronously.

A plain "skip the commit inside a Form" gate is not enough. Implicit submission does not happen when the default submit button is disabled, or when a keydown listener prevents it, and Enter must still validate the field in those cases. The timeout fallback covers them.

## Notes

- Enter validation inside a `Form` is now asynchronous. Tests that assert synchronously after an Enter keydown need to await a tick.
- The `FieldValidity.test.tsx` assertion change (validator count 1 → 2 in `onSubmit` mode) is correct rather than a regression. A real submit bumps the submit count, and `onSubmit` mode re-validates on change after a submit attempt. The old count of 1 relied on the keydown loophole never registering the attempt.
- jsdom does not perform implicit submission, which is why the bug went unnoticed and why the new tests run in Chromium only.
- Bundle size: `@base-ui/react/input` grows by ~198 B gzipped, mostly the `Timeout` class entering a bundle that previously had none. Alongside any other Base UI import that already ships `Timeout` (field, select, tooltip, toast, …), the marginal cost is ~50 B.
