### PR TITLE
[field] Sync controlled value changes with field state

### DIFF
--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { expect, vi } from 'vitest';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';
@@ -18,14 +19,15 @@ describe('<Field.Control />', () => {
   it('avoids rerendering for uncontrolled input changes', async () => {
     const renderCountRef = { current: 0 };
 
-    function RenderCountedControl() {
-      renderCountRef.current += 1;
-      return <Field.Control data-testid="control" />;
-    }
-
     renderNonStrict(
       <Field.Root>
-        <RenderCountedControl />
+        <Field.Control
+          data-testid="control"
+          render={(props) => {
+            renderCountRef.current += 1;
+            return <input {...props} />;
+          }}
+        />
       </Field.Root>,
     );
 
@@ -42,6 +44,41 @@ describe('<Field.Control />', () => {
     expect(afterFirstChange).toBeLessThanOrEqual(initialRenderCount + 1);
   });
 
+  it('renders once per keystroke for controlled input changes', async () => {
+    const renderCountRef = { current: 0 };
+
+    function App() {
+      const [value, setValue] = React.useState('');
+      return (
+        <Field.Root>
+          <Field.Control
+            data-testid="control"
+            value={value}
+            onValueChange={setValue}
+            render={(props) => {
+              renderCountRef.current += 1;
+              return <input {...props} />;
+            }}
+          />
+        </Field.Root>
+      );
+    }
+
+    renderNonStrict(<App />);
+
+    const control = screen.getByTestId('control');
+
+    // The first keystroke also flips dirty and filled, so measure the steady state after it.
+    fireEvent.change(control, { target: { value: 'a' } });
+    const settledRenderCount = renderCountRef.current;
+
+    fireEvent.change(control, { target: { value: 'ab' } });
+    fireEvent.change(control, { target: { value: 'abc' } });
+
+    // The controlled echo must not schedule a second render per keystroke.
+    expect(renderCountRef.current).toBe(settledRenderCount + 2);
+  });
+
   it('validates once when changed by the user', async () => {
     const validate = vi.fn();
 
@@ -55,6 +92,112 @@ describe('<Field.Control />', () => {
 
     expect(validate).toHaveBeenCalledTimes(1);
     expect(validate.mock.lastCall?.[0]).toBe('a');
+  });
+
+  it('validates once when a controlled value is changed by the user', async () => {
+    const validate = vi.fn(() => null);
+
+    function App() {
+      const [value, setValue] = React.useState('');
+      return (
+        <Field.Root validationMode="onChange" validate={validate}>
+          <Field.Control value={value} onValueChange={setValue} />
+        </Field.Root>
+      );
+    }
+
+    await render(<App />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a' } });
+
+    expect(validate).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears dirty state when a numeric controlled value returns to its initial value', async () => {
+    function App() {
+      const [value, setValue] = React.useState(5);
+      return (
+        <Field.Root data-testid="root">
+          <Field.Control value={value} onValueChange={(nextValue) => setValue(Number(nextValue))} />
+        </Field.Root>
+      );
+    }
+
+    await render(<App />);
+
+    const root = screen.getByTestId('root');
+    const control = screen.getByRole('textbox');
+
+    expect(root).not.toHaveAttribute('data-dirty');
+
+    fireEvent.change(control, { target: { value: '56' } });
+
+    expect(root).toHaveAttribute('data-dirty', '');
+
+    fireEvent.change(control, { target: { value: '5' } });
+
+    expect(root).not.toHaveAttribute('data-dirty');
+  });
+
+  it('syncs state and validates when the controlled value changes programmatically', async () => {
+    const validate = vi.fn((_value: unknown) => null);
+
+    function App() {
+      const [value, setValue] = React.useState('');
+      return (
+        <Field.Root data-testid="root" validationMode="onChange" validate={validate}>
+          <Field.Control value={value} onValueChange={setValue} />
+          <button type="button" onClick={() => setValue('external')}>
+            set
+          </button>
+        </Field.Root>
+      );
+    }
+
+    await render(<App />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    const root = screen.getByTestId('root');
+
+    expect(root).toHaveAttribute('data-filled', '');
+    expect(root).toHaveAttribute('data-dirty', '');
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(validate.mock.lastCall?.[0]).toBe('external');
+  });
+
+  it('sets filled state on mount when the control is prefilled', async () => {
+    await render(
+      <Field.Root data-testid="root">
+        <Field.Control defaultValue="foo" />
+      </Field.Root>,
+    );
+
+    expect(screen.getByTestId('root')).toHaveAttribute('data-filled', '');
+  });
+
+  it('does not set filled state on mount for an empty controlled value', async () => {
+    await render(
+      <Field.Root data-testid="root">
+        <Field.Control value="" onValueChange={() => {}} />
+      </Field.Root>,
+    );
+
+    expect(screen.getByTestId('root')).not.toHaveAttribute('data-filled');
+  });
+
+  it('does not validate when the change is canceled', async () => {
+    const validate = vi.fn(() => null);
+
+    await render(
+      <Field.Root validationMode="onChange" validate={validate}>
+        <Field.Control onValueChange={(value, details) => details.cancel()} />
+      </Field.Root>,
+    );
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'a' } });
+
+    expect(validate).not.toHaveBeenCalled();
   });
 
   it('does not clear errors or validate when change is prevented', async () => {

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -13,6 +13,7 @@ import { useLabelableId } from '../../internals/labelable-provider/useLabelableI
 import { fieldValidityMapping } from '../../internals/field-constants/constants';
 import { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
+import { useValueChanged } from '../../internals/useValueChanged';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
 import type { BaseUIChangeEventDetails } from '../../internals/createBaseUIEventDetails';
@@ -72,23 +73,6 @@ export const FieldControl = React.forwardRef(function FieldControl(
 
   const id = useLabelableId({ id: idProp });
 
-  useIsoLayoutEffect(() => {
-    const hasExternalValue = valueProp != null;
-    if (validation.inputRef.current?.value || (hasExternalValue && valueProp !== '')) {
-      setFilled(true);
-    } else if (hasExternalValue && valueProp === '') {
-      setFilled(false);
-    }
-  }, [validation.inputRef, setFilled, valueProp]);
-
-  const inputRef = React.useRef<HTMLElement>(null);
-
-  useIsoLayoutEffect(() => {
-    if (autoFocus && inputRef.current === activeElement(ownerDocument(inputRef.current))) {
-      setFocused(true);
-    }
-  }, [autoFocus, setFocused]);
-
   const [valueUnwrapped] = useControlled({
     controlled: valueProp,
     default: defaultValue,
@@ -98,9 +82,45 @@ export const FieldControl = React.forwardRef(function FieldControl(
 
   const isControlled = valueProp !== undefined;
   const value = isControlled ? valueUnwrapped : undefined;
+  // The DOM value is always a string, so dirty comparisons must serialize the controlled value.
+  const serializedValue = value == null ? undefined : String(value);
+
   const getValueFromInput = useStableCallback(() => validation.inputRef.current?.value);
 
-  useRegisterFieldControl(validation.inputRef, id, value, getValueFromInput, !disabled, nameProp);
+  useRegisterFieldControl(
+    validation.inputRef,
+    id,
+    serializedValue,
+    getValueFromInput,
+    !disabled,
+    nameProp,
+  );
+
+  useIsoLayoutEffect(() => {
+    if (validation.inputRef.current?.value) {
+      setFilled(true);
+    }
+  }, [validation.inputRef, setFilled]);
+
+  useValueChanged(serializedValue, () => {
+    if (serializedValue === undefined) {
+      return;
+    }
+
+    clearErrors(name);
+    setDirty(serializedValue !== (validityData.initialValue ?? ''));
+    setFilled(serializedValue !== '');
+
+    validation.change(serializedValue);
+  });
+
+  const inputRef = React.useRef<HTMLElement>(null);
+
+  useIsoLayoutEffect(() => {
+    if (autoFocus && inputRef.current === activeElement(ownerDocument(inputRef.current))) {
+      setFocused(true);
+    }
+  }, [autoFocus, setFocused]);
 
   const element = useRenderElement('input', componentProps, {
     ref: [forwardedRef, inputRef],
@@ -116,13 +136,21 @@ export const FieldControl = React.forwardRef(function FieldControl(
         ...(isControlled ? { value } : { defaultValue }),
         onChange(event) {
           const inputValue = event.currentTarget.value;
-          onValueChange?.(inputValue, createChangeEventDetails(REASONS.none, event.nativeEvent));
+          const details = createChangeEventDetails(REASONS.none, event.nativeEvent);
+          onValueChange?.(inputValue, details);
+
+          // Controlled values sync from the `value` prop instead, so that a value the consumer
+          // rejects or rewrites never reaches the field state.
+          if (isControlled) {
+            return;
+          }
+
           // `validation.change` reads `markedDirtyRef`, so update dirty before validating.
           setDirty(inputValue !== (validityData.initialValue ?? ''));
           setFilled(inputValue !== '');
 
           // Workaround for https://github.com/react/react/issues/9023
-          if (!event.nativeEvent.defaultPrevented) {
+          if (!event.nativeEvent.defaultPrevented && !details.isCanceled) {
             clearErrors(name);
             validation.change(inputValue);
           }


### PR DESCRIPTION
`Field.Control` was the only Field control that ignored controlled value changes. Switch, Checkbox, Checkbox Group, Radio Group, Select, Slider, Combobox, Number Field, and OTP Field all sync through `useValueChanged` already. `Field.Control` instead drove every field concern from the DOM change event, so a value set from code had no path at all.

Two bugs followed.

**Dirty state never cleared for non-string values.** The dirty check compares the input's string value against a baseline captured from the `value` prop. With `value={5}` the baseline was the number `5`, so `"5" !== 5` held forever and `data-dirty` stayed set even after the user returned the field to its initial value. Array values failed the same way by reference. The control now registers the serialized value, so the baseline and the comparison agree.

**Programmatic changes left the field stale.** Setting the value from code, such as a clear button or a form library reset, updated the input text but not filled, dirty, or validity, so a resolved error stayed visible and a pending async validator for the old value could still publish.

The fix gives each mode one owner instead of running two sync paths at once. `useValueChanged` owns the controlled path, `onChange` owns the uncontrolled path, and `onChange` returns early when controlled. `Field.Control` now has the same shape as its siblings, with the residual difference being the mount-time DOM read that its uncontrolled mode requires.

Two smaller fixes ride along:

- `details.cancel()` in `onValueChange` now stops the internal handling. It was ignored.
- A controlled value the consumer rejects or rewrites no longer reaches the field state, matching Combobox, Number Field and OTP Field.

## Performance

Renders per keystroke for a controlled input, counted in jsdom (mount, then four keystrokes):

| Validation mode | Base | This PR | Number Field |
| --- | --- | --- | --- |
| `onSubmit` | 1 per keystroke | 2 on the first, then 1 | 2 on the first, then 1 |
| `onChange` | 1 per keystroke | 2 per keystroke | 2 per keystroke |

Moving the work into a layout effect costs one extra render per keystroke in `onChange` mode. That is the cost every sibling control already pays, and `Field.Control` now matches Number Field exactly. The base column achieved one render by doing the work synchronously in the change handler, which is the second sync path this PR removes.
