### PR TITLE
[select] Fix the root id being ignored inside a Field

### DIFF
--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -307,7 +307,7 @@ describe('<Field.Root />', () => {
                   Label
                 </Field.Label>
                 <Activity mode={showSelect ? 'visible' : 'hidden'}>
-                  <Select.Root>
+                  <Select.Root id="select">
                     <Select.Trigger>
                       <Select.Value placeholder="Select a model" />
                     </Select.Trigger>

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -2949,6 +2949,22 @@ describe('<Select.Root />', () => {
   });
 
   describe('with Field.Root parent', () => {
+    it('applies the root id to the trigger', async () => {
+      await render(
+        <Field.Root>
+          <Field.Label data-testid="label">Label</Field.Label>
+          <Select.Root id="test-id">
+            <Select.Trigger data-testid="trigger">
+              <Select.Value />
+            </Select.Trigger>
+          </Select.Root>
+        </Field.Root>,
+      );
+
+      expect(screen.getByTestId('trigger')).toHaveAttribute('id', 'test-id');
+      expect(screen.getByTestId('label')).toHaveAttribute('for', 'test-id');
+    });
+
     it('should receive disabled prop from Field.Root', async () => {
       await render(
         <Field.Root disabled>

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -89,7 +89,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   const id = idProp ?? rootId;
   const ariaLabelledBy = resolveAriaLabelledBy(fieldLabelId, selectLabelId);
 
-  useLabelableId({ id });
+  useLabelableId({ id: idProp });
 
   const positionerRef = useValueAsRef(positionerElement);
 


### PR DESCRIPTION
An `id` on `Select.Root` is dropped when the Select sits inside a `Field.Root`. The trigger renders a generated id instead, so `#my-id` matches nothing and `Field.Label` points at the generated id. Outside a Field it works.

`Select.Trigger` registered `idProp ?? rootId` with the labelable provider, and `rootId` is the provider's own selected id read back through the Select store. The provider keeps its current selection while that id is still registered, so the generated id kept re-electing itself and the root's `id` could never take over. The trigger now registers only its own explicit `id`, which leaves the root as the sole registrant when the trigger has none.

Carved out of #5448, which fixed this through a `preferId` argument on `registerControlId`. That argument is not needed for this case.

#5448's notes also describe an exception in the unregister flush for `Select.Trigger`, because it registered an id adopted from the provider one commit behind. That registration no longer exists, so the exception may no longer be needed.

Still unfixed, and out of scope here: an explicit `id` on `Select.Trigger` does not move the label when it changes at runtime, and the equivalent Combobox cases are untouched.
