### PR TITLE
[number field]  Prevent scrubbing on horizontal wheel events

### DIFF
--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -1409,6 +1409,68 @@ describe('<NumberField />', () => {
       expect(onValueChange).not.toHaveBeenCalled();
     });
 
+    it('does not scrub on a horizontal wheel event', async () => {
+      const onValueChange = vi.fn();
+      const onValueCommitted = vi.fn();
+      await render(
+        <NumberField
+          defaultValue={5}
+          allowWheelScrub
+          onValueChange={onValueChange}
+          onValueCommitted={onValueCommitted}
+        />,
+      );
+      const input = screen.getByRole('textbox');
+      await act(async () => input.focus());
+
+      fireEvent.wheel(input, { deltaY: 0, deltaX: 100 });
+      expect(input).toHaveValue('5');
+
+      fireEvent.wheel(input, { deltaY: 0, deltaX: -100 });
+      expect(input).toHaveValue('5');
+
+      expect(onValueChange).not.toHaveBeenCalled();
+      expect(onValueCommitted).not.toHaveBeenCalled();
+    });
+
+    it('does not scrub on a horizontal wheel event while shift is held', async () => {
+      const onValueChange = vi.fn();
+      await render(
+        <NumberField
+          defaultValue={0}
+          largeStep={10}
+          allowWheelScrub
+          onValueChange={onValueChange}
+        />,
+      );
+      const input = screen.getByRole('textbox');
+      await act(async () => input.focus());
+
+      fireEvent.wheel(input, { deltaY: 0, deltaX: -100, shiftKey: true });
+      expect(input).toHaveValue('0');
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('does not scrub on a wheel event with no delta', async () => {
+      const onValueChange = vi.fn();
+      await render(<NumberField defaultValue={5} allowWheelScrub onValueChange={onValueChange} />);
+      const input = screen.getByRole('textbox');
+      await act(async () => input.focus());
+
+      fireEvent.wheel(input, { deltaY: 0, deltaX: 0 });
+      expect(input).toHaveValue('5');
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+
+    it('does not block scrolling for a wheel event it ignores', async () => {
+      await render(<NumberField defaultValue={5} allowWheelScrub />);
+      const input = screen.getByRole('textbox');
+      await act(async () => input.focus());
+
+      const horizontalWheel = fireEvent.wheel(input, { deltaY: 0, deltaX: 100 });
+      expect(horizontalWheel).toBe(true);
+    });
+
     it('uses largeStep when shift is held during wheel', async () => {
       const onValueChange = vi.fn();
       await render(

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -1409,7 +1409,7 @@ describe('<NumberField />', () => {
       expect(onValueChange).not.toHaveBeenCalled();
     });
 
-    it('does not scrub on a horizontal wheel event', async () => {
+    it('does not scrub on a horizontal wheel event, and lets it scroll the page', async () => {
       const onValueChange = vi.fn();
       const onValueCommitted = vi.fn();
       await render(
@@ -1423,52 +1423,44 @@ describe('<NumberField />', () => {
       const input = screen.getByRole('textbox');
       await act(async () => input.focus());
 
-      fireEvent.wheel(input, { deltaY: 0, deltaX: 100 });
-      expect(input).toHaveValue('5');
+      // `fireEvent` returns false when the event was canceled with `preventDefault`.
+      expect(fireEvent.wheel(input, { deltaY: 0, deltaX: 100 })).toBe(true);
+      expect(fireEvent.wheel(input, { deltaY: 0, deltaX: -100 })).toBe(true);
+      // A precision touchpad emits sub-pixel noise on the cross axis during a sideways swipe.
+      expect(fireEvent.wheel(input, { deltaY: -0.5, deltaX: 100 })).toBe(true);
+      expect(fireEvent.wheel(input, { deltaY: 0.5, deltaX: -100 })).toBe(true);
+      // An event with no movement at all.
+      expect(fireEvent.wheel(input, { deltaY: 0, deltaX: 0 })).toBe(true);
 
-      fireEvent.wheel(input, { deltaY: 0, deltaX: -100 });
       expect(input).toHaveValue('5');
-
       expect(onValueChange).not.toHaveBeenCalled();
       expect(onValueCommitted).not.toHaveBeenCalled();
     });
 
-    it('does not scrub on a horizontal wheel event while shift is held', async () => {
-      const onValueChange = vi.fn();
-      await render(
-        <NumberField
-          defaultValue={0}
-          largeStep={10}
-          allowWheelScrub
-          onValueChange={onValueChange}
-        />,
-      );
-      const input = screen.getByRole('textbox');
-      await act(async () => input.focus());
-
-      fireEvent.wheel(input, { deltaY: 0, deltaX: -100, shiftKey: true });
-      expect(input).toHaveValue('0');
-      expect(onValueChange).not.toHaveBeenCalled();
-    });
-
-    it('does not scrub on a wheel event with no delta', async () => {
-      const onValueChange = vi.fn();
-      await render(<NumberField defaultValue={5} allowWheelScrub onValueChange={onValueChange} />);
-      const input = screen.getByRole('textbox');
-      await act(async () => input.focus());
-
-      fireEvent.wheel(input, { deltaY: 0, deltaX: 0 });
-      expect(input).toHaveValue('5');
-      expect(onValueChange).not.toHaveBeenCalled();
-    });
-
-    it('does not block scrolling for a wheel event it ignores', async () => {
+    it('scrubs on a vertical wheel event that carries horizontal noise', async () => {
       await render(<NumberField defaultValue={5} allowWheelScrub />);
       const input = screen.getByRole('textbox');
       await act(async () => input.focus());
 
-      const horizontalWheel = fireEvent.wheel(input, { deltaY: 0, deltaX: 100 });
-      expect(horizontalWheel).toBe(true);
+      fireEvent.wheel(input, { deltaY: 1, deltaX: -0.5 });
+      expect(input).toHaveValue('4');
+
+      fireEvent.wheel(input, { deltaY: -1, deltaX: 0.5 });
+      expect(input).toHaveValue('5');
+    });
+
+    it('uses largeStep when shift is held and the browser swaps the wheel axis', async () => {
+      await render(<NumberField defaultValue={0} largeStep={10} allowWheelScrub />);
+      const input = screen.getByRole('textbox');
+      await act(async () => input.focus());
+
+      // Chromium delivers shift + wheel as a horizontal event, so the horizontal delta carries
+      // the intended direction: positive is "down", which steps the value down.
+      fireEvent.wheel(input, { deltaY: 0, deltaX: -100, shiftKey: true });
+      expect(input).toHaveValue('10');
+
+      fireEvent.wheel(input, { deltaY: 0, deltaX: 100, shiftKey: true });
+      expect(input).toHaveValue('0');
     });
 
     it('uses largeStep when shift is held during wheel', async () => {

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -1442,11 +1442,16 @@ describe('<NumberField />', () => {
       const input = screen.getByRole('textbox');
       await act(async () => input.focus());
 
-      fireEvent.wheel(input, { deltaY: 1, deltaX: -0.5 });
+      // `fireEvent` returns false when the event was canceled, which is what stops the page
+      // from scrolling out from under the user while the value scrubs.
+      expect(fireEvent.wheel(input, { deltaY: 1, deltaX: -0.5 })).toBe(false);
       expect(input).toHaveValue('4');
 
-      fireEvent.wheel(input, { deltaY: -1, deltaX: 0.5 });
+      expect(fireEvent.wheel(input, { deltaY: -1, deltaX: 0.5 })).toBe(false);
       expect(input).toHaveValue('5');
+
+      expect(fireEvent.wheel(input, { deltaY: 1 })).toBe(false);
+      expect(input).toHaveValue('4');
     });
 
     it('uses largeStep when shift is held and the browser swaps the wheel axis', async () => {
@@ -1456,10 +1461,18 @@ describe('<NumberField />', () => {
 
       // Chromium delivers shift + wheel as a horizontal event, so the horizontal delta carries
       // the intended direction: positive is "down", which steps the value down.
-      fireEvent.wheel(input, { deltaY: 0, deltaX: -100, shiftKey: true });
+      expect(fireEvent.wheel(input, { deltaY: 0, deltaX: -100, shiftKey: true })).toBe(false);
       expect(input).toHaveValue('10');
 
-      fireEvent.wheel(input, { deltaY: 0, deltaX: 100, shiftKey: true });
+      expect(fireEvent.wheel(input, { deltaY: 0, deltaX: 100, shiftKey: true })).toBe(false);
+      expect(input).toHaveValue('0');
+
+      // Cross-axis noise must not flip the direction of the same physical gesture, so the noise
+      // here opposes the horizontal delta: the dominant axis has to win.
+      expect(fireEvent.wheel(input, { deltaY: 0.5, deltaX: -100, shiftKey: true })).toBe(false);
+      expect(input).toHaveValue('10');
+
+      expect(fireEvent.wheel(input, { deltaY: -0.5, deltaX: 100, shiftKey: true })).toBe(false);
       expect(input).toHaveValue('0');
     });
 

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -356,17 +356,15 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
           return;
         }
 
-        // Shift + wheel is delivered on the horizontal axis by some browsers, so there the
-        // horizontal delta is the intended vertical one.
-        const delta = event.deltaY !== 0 || !event.shiftKey ? event.deltaY : event.deltaX;
+        // Some browsers deliver shift + wheel on the horizontal axis, so there the horizontal
+        // delta is the intended vertical one. Touchpads emit sub-pixel noise on the cross axis,
+        // so compare the axes rather than requiring an exact zero.
+        const isHorizontal = Math.abs(event.deltaX) > Math.abs(event.deltaY);
+        const delta = event.shiftKey && isHorizontal ? event.deltaX : event.deltaY;
 
-        // Ignore horizontal gestures so the page can scroll instead of scrubbing. Touchpads emit
-        // sub-pixel noise on the cross axis, so compare the axes rather than requiring an exact
-        // zero. Shift is exempt: its gesture is horizontal wherever the browser swaps the axis.
-        const isHorizontalGesture =
-          !event.shiftKey && Math.abs(event.deltaX) > Math.abs(event.deltaY);
-
-        if (delta === 0 || isHorizontalGesture) {
+        // Ignore horizontal gestures so the page can scroll instead of scrubbing. Shift is exempt:
+        // its gesture is horizontal wherever the browser swaps the axis.
+        if (delta === 0 || (!event.shiftKey && isHorizontal)) {
           return;
         }
 

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -356,10 +356,17 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
           return;
         }
 
-        // Shift + wheel is delivered on the horizontal axis by some browsers.
+        // Shift + wheel is delivered on the horizontal axis by some browsers, so there the
+        // horizontal delta is the intended vertical one.
         const delta = event.deltaY !== 0 || !event.shiftKey ? event.deltaY : event.deltaX;
-        // Ignore horizontal wheel/trackpad gestures so the page can scroll
-        if (delta === 0) {
+
+        // Ignore horizontal gestures so the page can scroll instead of scrubbing. Touchpads emit
+        // sub-pixel noise on the cross axis, so compare the axes rather than requiring an exact
+        // zero. Shift is exempt: its gesture is horizontal wherever the browser swaps the axis.
+        const isHorizontalGesture =
+          !event.shiftKey && Math.abs(event.deltaX) > Math.abs(event.deltaY);
+
+        if (delta === 0 || isHorizontalGesture) {
           return;
         }
 

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -351,9 +351,15 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
         if (
           // Allow pinch-zooming.
           event.ctrlKey ||
-          activeElement(ownerDocument(inputRef.current)) !== inputRef.current ||
-          event.deltaY === 0
+          activeElement(ownerDocument(inputRef.current)) !== inputRef.current
         ) {
+          return;
+        }
+
+        // Shift + wheel is delivered on the horizontal axis by some browsers.
+        const delta = event.deltaY !== 0 || !event.shiftKey ? event.deltaY : event.deltaX;
+        // Ignore horizontal wheel/trackpad gestures so the page can scroll
+        if (delta === 0) {
           return;
         }
 
@@ -366,7 +372,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
         // Each wheel turn is a discrete, final change, so commit it immediately like keyboard
         // steps (gated on an actual change so boundary no-ops don't commit).
         const changed = incrementValue(amount, {
-          direction: event.deltaY > 0 ? -1 : 1,
+          direction: delta > 0 ? -1 : 1,
           event,
           reason: REASONS.wheel,
         });

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -351,7 +351,8 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
         if (
           // Allow pinch-zooming.
           event.ctrlKey ||
-          activeElement(ownerDocument(inputRef.current)) !== inputRef.current
+          activeElement(ownerDocument(inputRef.current)) !== inputRef.current ||
+          event.deltaY === 0
         ) {
           return;
         }


### PR DESCRIPTION
Wheel scrub treated any event with no vertical delta as an increment, so horizontal trackpad swipes and tilt wheels silently stepped and committed the value while blocking the page scroll. Ignore horizontal-dominant gestures, and use the horizontal delta when shift is held.