### PR TITLE
[toast] Support partial data updates

### DIFF
--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -823,6 +823,8 @@ type ToastManagerPromiseOptions<Value, Data extends {}> = {
 
 ```typescript
 type ToastManagerUpdateOptions<Data extends {}> = {
+  /** Custom data for the toast. */
+  data?: Partial<Data>;
   /** The title of the toast. */
   title?: React.ReactNode;
   /**
@@ -856,8 +858,6 @@ type ToastManagerUpdateOptions<Data extends {}> = {
   >;
   /** The props forwarded to the toast positioner element when rendering anchored toasts. */
   positionerProps?: ToastManagerPositionerProps;
-  /** Custom data for the toast. */
-  data?: Data;
 };
 ```
 

--- a/packages/react/src/toast/createToastManager.spec.tsx
+++ b/packages/react/src/toast/createToastManager.spec.tsx
@@ -41,6 +41,12 @@ typedManager.update('typed', {
   },
 });
 
+typedManager.update('typed', {
+  data: {
+    count: 2,
+  },
+});
+
 typedManager.promise(Promise.resolve(2), {
   loading: 'loading',
   success: (value) => ({

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -95,6 +95,19 @@ describe('ToastStore', () => {
     expect(selectors.toast(store.state, 'a')?.transitionStatus).toBe(undefined);
   });
 
+  it('shallow merges custom data when updating a toast', () => {
+    const store = createStore([{ id: 'a', data: { name: 'Draft', count: 1 } }]);
+
+    store.updateToast('a', { data: { count: 2 } });
+    expect(selectors.toast(store.state, 'a')?.data).toEqual({ name: 'Draft', count: 2 });
+
+    store.updateToast('a', { title: 'Saved' });
+    expect(selectors.toast(store.state, 'a')?.data).toEqual({ name: 'Draft', count: 2 });
+
+    store.updateToast('a', { data: undefined });
+    expect(selectors.toast(store.state, 'a')?.data).toBe(undefined);
+  });
+
   it('does not invoke onRemove for a toast that is no longer in the store', () => {
     const onRemove = vi.fn();
     const store = createStore([{ id: 'a', onRemove }]);

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -13,8 +13,10 @@ import { activeElement, contains, getTarget } from '../floating-ui-react/utils';
 import { isFocusVisible } from './utils/focusVisible';
 
 type ToastInternalUpdateOptions<Data extends object> = Partial<
-  Omit<ToastObject<Data>, 'id' | 'updateKey'>
->;
+  Omit<ToastObject<Data>, 'id' | 'updateKey' | 'data'>
+> & {
+  data?: Partial<Data> | undefined;
+};
 
 /**
  * A toast once it lives in the store. `addToast` is the only way in and it always
@@ -228,6 +230,9 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     const nextToast: StoredToast<Data> = {
       ...prevToast,
       ...updates,
+      ...(updates.data && {
+        data: { ...prevToast.data, ...updates.data },
+      }),
       ...(markUpdated && {
         updateKey: prevToast.updateKey + 1,
       }),

--- a/packages/react/src/toast/useToastManager.spec.tsx
+++ b/packages/react/src/toast/useToastManager.spec.tsx
@@ -45,6 +45,12 @@ typedManager.update('typed', {
   },
 });
 
+typedManager.update('typed', {
+  data: {
+    count: 2,
+  },
+});
+
 typedManager.promise(Promise.resolve(2), {
   loading: 'loading',
   success: (value) => ({

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -129,8 +129,16 @@ export interface ToastManagerAddOptions<Data extends object> extends Omit<
 }
 
 export interface ToastManagerUpdateOptions<Data extends object> extends Partial<
-  Omit<ToastObject<Data>, 'id' | 'ref' | 'height' | 'transitionStatus' | 'limited' | 'updateKey'>
-> {}
+  Omit<
+    ToastObject<Data>,
+    'id' | 'ref' | 'height' | 'transitionStatus' | 'limited' | 'updateKey' | 'data'
+  >
+> {
+  /**
+   * Custom data for the toast.
+   */
+  data?: Partial<Data> | undefined;
+}
 
 export interface ToastManagerPromiseOptions<Value, Data extends object> {
   loading: string | ToastManagerUpdateOptions<Data>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR proposes shallow-merging custom toast data when updating a toast.

Currently, the `data` passed to `update` replaces the existing data, so fields that should remain unchanged must be passed again:

```ts
toastManager.update(id, {
  data: {
    uploadId: '123',
    progress: 50,
  },
});
```

With this change, the same update can be written as:

```ts
toastManager.update(id, {
  data: {
    progress: 50,
  },
});
```

The existing `uploadId` is preserved, and `data` is typed as `Partial<Data>`, consistent with the other update options.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
