### PR TITLE
[docs-infra] Pad inline code rendered directly in a code block

### DIFF
--- a/docs/src/components/CodeBlock/CodeBlock.css
+++ b/docs/src/components/CodeBlock/CodeBlock.css
@@ -24,6 +24,12 @@
     }
   }
 
+  /* Inline code placed directly in a block has no `.frame` or `pre` to carry the inset above. */
+  .CodeBlockRoot > code {
+    display: block;
+    padding: 0.5rem 0.75rem;
+  }
+
   .CodeBlockPanel {
     font-size: var(--font-size-14);
     line-height: 1;


### PR DESCRIPTION
Inline code placed as a direct child of `CodeBlockRoot` has neither a `.frame` wrapper nor a `pre` to carry the inset that `.CodeBlockRoot code .frame` and `.CodeBlockPre` provide, so it renders flush against the border with no padding at all — horizontal or vertical.

![before and after](https://raw.githubusercontent.com/brijeshb42/base-ui/pr-assets/codeblock-inline-padding.png)

The child selector matches only the unwrapped case. Every current caller — MDX `pre` blocks, `InstallationBlock`, `AdditionalTypes`, and the reference tables' detailed types — nests its code inside `CodeBlock.Pre` with `.frame` spans, so none of them are affected.

