### PR TITLE
[test] Stabilize Combobox and Menu test timing

### DIFF
--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -5295,7 +5295,7 @@ describe('<Combobox.Root />', () => {
       await waitFor(() => expect(popup).not.toHaveAttribute('data-ending-style'));
 
       expect(input).toHaveValue('apple');
-      expect(screen.getAllByRole('option')).toHaveLength(3);
+      await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(3));
     });
 
     it('keeps the typed filter when items change afterwards (input outside popup)', async ({
@@ -5413,9 +5413,7 @@ describe('<Combobox.Root />', () => {
       await flushMicrotasks();
 
       expect(input).toHaveValue('apple');
-
-      await waitFor(() => expect(screen.queryByRole('listbox')).not.toBe(null));
-      expect(screen.queryAllByRole('option')).toHaveLength(1);
+      await waitFor(() => expect(screen.queryAllByRole('option')).toHaveLength(1));
     });
 
     it('does not re-emit a clear when closing again without typing (multiple, input outside popup)', async ({
@@ -5598,8 +5596,8 @@ describe('<Combobox.Root />', () => {
 
       await user.click(screen.getByTestId('reopen'));
 
-      expect(input).toHaveValue('');
-      expect(screen.getByRole('option', { name: 'banana' })).not.toBe(null);
+      await waitFor(() => expect(input).toHaveValue(''));
+      expect(await screen.findByRole('option', { name: 'banana' })).not.toBe(null);
 
       onInputValueChange.mockClear();
       await user.keyboard('{Escape}');
@@ -5703,10 +5701,9 @@ describe('<Combobox.Root />', () => {
       // A consumer mirroring the selection into the popup input must not leave the reopened
       // list filtered by it: an interrupted close opens blank, same as a completed one.
       await user.click(screen.getByTestId('trigger'));
-      await flushMicrotasks();
 
       const inputAfter = await screen.findByTestId('input');
-      expect(inputAfter).toHaveValue('');
+      await waitFor(() => expect(inputAfter).toHaveValue(''));
       await waitFor(() => expect(screen.queryAllByRole('option')).toHaveLength(3));
     });
 
@@ -6800,7 +6797,7 @@ describe('<Combobox.Root />', () => {
 
         await user.click(screen.getByTestId('trigger'));
 
-        expect(input).toHaveValue('');
+        await waitFor(() => expect(input).toHaveValue(''));
         expect(await screen.findByRole('option', { name: 'banana' })).not.toBe(null);
       },
     );

--- a/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.test.tsx
+++ b/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.test.tsx
@@ -2,7 +2,7 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
-import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 
 describe('<Menu.CheckboxItemIndicator />', () => {
   beforeEach(() => {
@@ -42,7 +42,16 @@ describe('<Menu.CheckboxItemIndicator />', () => {
 
   it.skipIf(isJSDOM)(
     'should remove the indicator when there is no exit animation defined',
-    async () => {
+    async ({ onTestFinished }) => {
+      const frameCallbacks: FrameRequestCallback[] = [];
+      const requestAnimationFrameSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback) => {
+          frameCallbacks.push(callback);
+          return frameCallbacks.length;
+        });
+      onTestFinished(() => requestAnimationFrameSpy.mockRestore());
+
       function Test() {
         const [checked, setChecked] = React.useState(true);
         return (
@@ -63,13 +72,20 @@ describe('<Menu.CheckboxItemIndicator />', () => {
         );
       }
 
-      const { user } = await render(<Test />);
+      await render(<Test />);
 
       expect(screen.queryByTestId('indicator')).not.toBe(null);
 
-      const closeButton = screen.getByText('Close');
+      await waitFor(() => expect(frameCallbacks.length).toBeGreaterThan(0));
+      while (frameCallbacks.length > 0) {
+        act(() => {
+          const callbacks = frameCallbacks.splice(0);
+          callbacks.forEach((callback) => callback(performance.now()));
+        });
+      }
+      requestAnimationFrameSpy.mockRestore();
 
-      await user.click(closeButton);
+      fireEvent.click(screen.getByText('Close'));
 
       await waitFor(() => {
         expect(screen.queryByTestId('indicator')).toBe(null);

--- a/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.test.tsx
+++ b/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.test.tsx
@@ -2,7 +2,7 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
-import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 
 describe('<Menu.RadioItemIndicator />', () => {
   const { render } = createRenderer();
@@ -40,7 +40,16 @@ describe('<Menu.RadioItemIndicator />', () => {
 
   it.skipIf(isJSDOM)(
     'should remove the indicator when there is no exit animation defined',
-    async () => {
+    async ({ onTestFinished }) => {
+      const frameCallbacks: FrameRequestCallback[] = [];
+      const requestAnimationFrameSpy = vi
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback) => {
+          frameCallbacks.push(callback);
+          return frameCallbacks.length;
+        });
+      onTestFinished(() => requestAnimationFrameSpy.mockRestore());
+
       function Test() {
         const [value, setValue] = React.useState('a');
         return (
@@ -68,13 +77,20 @@ describe('<Menu.RadioItemIndicator />', () => {
         );
       }
 
-      const { user } = await render(<Test />);
+      await render(<Test />);
 
       expect(screen.queryByTestId('indicator')).not.toBe(null);
 
-      const closeButton = screen.getByText('Close');
+      await waitFor(() => expect(frameCallbacks.length).toBeGreaterThan(0));
+      while (frameCallbacks.length > 0) {
+        act(() => {
+          const callbacks = frameCallbacks.splice(0);
+          callbacks.forEach((callback) => callback(performance.now()));
+        });
+      }
+      requestAnimationFrameSpy.mockRestore();
 
-      await user.click(closeButton);
+      fireEvent.click(screen.getByText('Close'));
 
       await waitFor(() => {
         expect(screen.queryByTestId('indicator')).toBe(null);


### PR DESCRIPTION
PR #5362 added close-animation coverage that could assert before the reopened Combobox input cleanup committed under full browser-suite load. Two Menu indicator tests could also finish while an open-state animation frame was still pending, producing React act warnings.\n\n## Changes\n\n- Wait for the observable Combobox input and option state in the affected reopen paths instead of relying on one microtask or a nearby DOM signal.\n- Capture and flush the Menu open-state animation-frame queue inside act before testing synchronous no-animation indicator removal.\n\nThe final close-animation set passed 20 consecutive runs, both complete Menu indicator files passed 10 consecutive runs, and the full Chromium project passed three consecutive runs with 8,648 tests per run.