### PR TITLE
[combobox] Remove unsupported data-instant documentation

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/types.md
+++ b/docs/src/app/(docs)/react/components/autocomplete/types.md
@@ -557,7 +557,6 @@ Renders a `<div>` element.
 | data-closed         | -                                                                          | Present when the popup is closed.                                     |
 | data-align          | `'start' \| 'center' \| 'end'`                                             | Indicates how the popup is aligned relative to specified side.        |
 | data-empty          | -                                                                          | Present when the items list is empty.                                 |
-| data-instant        | `'click' \| 'dismiss'`                                                     | Present if animations should be instant.                              |
 | data-side           | `'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
 | data-starting-style | -                                                                          | Present when the popup begins animating in.                           |
 | data-ending-style   | -                                                                          | Present when the popup is animating out.                              |

--- a/docs/src/app/(docs)/react/components/combobox/types.md
+++ b/docs/src/app/(docs)/react/components/combobox/types.md
@@ -574,7 +574,6 @@ Renders a `<div>` element.
 | data-closed         | -                                                                          | Present when the popup is closed.                                     |
 | data-align          | `'start' \| 'center' \| 'end'`                                             | Indicates how the popup is aligned relative to specified side.        |
 | data-empty          | -                                                                          | Present when the items list is empty.                                 |
-| data-instant        | `'click' \| 'dismiss'`                                                     | Present if animations should be instant.                              |
 | data-side           | `'top' \| 'bottom' \| 'left' \| 'right' \| 'inline-end' \| 'inline-start'` | Indicates which side the popup is positioned relative to the trigger. |
 | data-starting-style | -                                                                          | Present when the popup begins animating in.                           |
 | data-ending-style   | -                                                                          | Present when the popup is animating out.                              |

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -223,7 +223,7 @@ An input that suggests options as you type.
     - CSS Variables: --anchor-height, --anchor-width, --available-height, --available-width, --transform-origin
   - Autocomplete - Popup
     - Props: className, finalFocus, initialFocus, render, style
-    - Data Attributes: data-align, data-closed, data-empty, data-ending-style, data-instant, data-open, data-side, data-starting-style
+    - Data Attributes: data-align, data-closed, data-empty, data-ending-style, data-open, data-side, data-starting-style
   - Autocomplete - Arrow
     - Props: className, render, style
     - Data Attributes: data-align, data-closed, data-open, data-side, data-uncentered
@@ -491,7 +491,7 @@ An input combined with a list of predefined items to select.
     - CSS Variables: --anchor-height, --anchor-width, --available-height, --available-width, --transform-origin
   - Combobox - Popup
     - Props: className, finalFocus, initialFocus, render, style
-    - Data Attributes: data-align, data-closed, data-empty, data-ending-style, data-instant, data-open, data-side, data-starting-style
+    - Data Attributes: data-align, data-closed, data-empty, data-ending-style, data-open, data-side, data-starting-style
   - Combobox - Arrow
     - Props: className, render, style
     - Data Attributes: data-align, data-closed, data-open, data-side, data-uncentered

--- a/packages/react/src/combobox/popup/ComboboxPopupDataAttributes.ts
+++ b/packages/react/src/combobox/popup/ComboboxPopupDataAttributes.ts
@@ -28,11 +28,6 @@ export enum ComboboxPopupDataAttributes {
    */
   align = CommonPopupDataAttributes.align,
   /**
-   * Present if animations should be instant.
-   * @type {'click' | 'dismiss'}
-   */
-  instant = 'data-instant',
-  /**
    * Present when the items list is empty.
    */
   empty = 'data-empty',


### PR DESCRIPTION
## Summary

- Remove the unsupported `data-instant` entry from `ComboboxPopupDataAttributes`.
- Regenerate the Combobox and Autocomplete API documentation.

The shared Combobox popup does not implement an instant animation state, so documenting this attribute was misleading and the attribute is never rendered at runtime.

Closes #5350

## Checks

- `pnpm docs:api`
- `pnpm prettier`
- `pnpm typescript`
- `pnpm eslint`
- `pnpm stylelint`
- `pnpm test:jsdom Combobox --no-watch`
- `pnpm test:chromium Combobox --no-watch`
