### PR TITLE
[docs] Fix static search result navigation

### DIFF
--- a/docs/src/components/Search/SearchResultsList.tsx
+++ b/docs/src/components/Search/SearchResultsList.tsx
@@ -41,26 +41,40 @@ export function SearchResultsList({
           </Autocomplete.GroupLabel>
         )}
         <Autocomplete.Collection>
-          {(result: SearchResult, i) => (
-            <Autocomplete.Item
-              key={result.id || i}
-              value={result}
-              render={
-                <Link
-                  href={buildResultUrl(result)}
-                  onNavigate={() => onResultNavigate(result)}
-                  tabIndex={-1}
+          {(result: SearchResult, i) => {
+            const href = buildResultUrl(result);
+            const isStaticFile = href.endsWith('.md') || href.endsWith('.txt');
+
+            return (
+              <Autocomplete.Item
+                key={result.id || i}
+                value={result}
+                render={
+                  isStaticFile ? (
+                    // eslint-disable-next-line jsx-a11y/control-has-associated-label
+                    <a
+                      href={href}
+                      onClick={(event) => {
+                        if (isUnmodifiedLeftClick(event)) {
+                          onResultNavigate(result);
+                        }
+                      }}
+                      tabIndex={-1}
+                    />
+                  ) : (
+                    <Link href={href} onNavigate={() => onResultNavigate(result)} tabIndex={-1} />
+                  )
+                }
+                className={classes.item}
+              >
+                <SearchResultItem
+                  result={result}
+                  classes={classes}
+                  separatorVariant={separatorVariant}
                 />
-              }
-              className={classes.item}
-            >
-              <SearchResultItem
-                result={result}
-                classes={classes}
-                separatorVariant={separatorVariant}
-              />
-            </Autocomplete.Item>
-          )}
+              </Autocomplete.Item>
+            );
+          }}
         </Autocomplete.Collection>
       </Autocomplete.Group>
     ),
@@ -68,6 +82,17 @@ export function SearchResultsList({
   );
 
   return <Autocomplete.List className={className}>{renderGroup}</Autocomplete.List>;
+}
+
+function isUnmodifiedLeftClick(event: React.MouseEvent<HTMLAnchorElement>) {
+  return (
+    !event.defaultPrevented &&
+    event.button === 0 &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.shiftKey
+  );
 }
 
 function SearchResultItem({


### PR DESCRIPTION
Fixes #5182

## What changed

- Render `.txt` and `.md` search results as native anchors.
- Preserve search selection handling for ordinary clicks and native modifier-click behavior.
- Keep regular documentation results on `next/link`.

## Why

The production docs use Next.js static export. When `next/link` handles `/llms.txt`, the App Router appends its own `.txt` Flight payload suffix and requests `/llms.txt.txt`. The failed fallback then normalizes the suffix twice and lands on `/llms`.

Using a native anchor for static text resources bypasses the App Router and requests `/llms.txt` directly.