### PR TITLE
[docs-infra] Reduce LLM generation memory

### DIFF
--- a/docs/scripts/generateLlmTxt/createFileContent.mjs
+++ b/docs/scripts/generateLlmTxt/createFileContent.mjs
@@ -1,0 +1,56 @@
+/* eslint-disable no-await-in-loop */
+
+import * as prettier from 'prettier';
+
+export async function createFileContent({
+  structure,
+  preamble,
+  pageRenderer,
+  filePath,
+  formatPages = false,
+}) {
+  const prettierOptions = await prettier.resolveConfig(filePath);
+  const formatMarkdown = (content) =>
+    prettier.format(content, {
+      ...prettierOptions,
+      filepath: filePath,
+      parser: 'markdown',
+    });
+
+  const sections = [];
+
+  for (const section of structure.sections) {
+    if (section.pages.length === 0) {
+      continue;
+    }
+
+    const sectionContent = [`## ${section.title}`, ''];
+
+    for (const [pageIndex, page] of section.pages.entries()) {
+      let renderedPage = await pageRenderer(page);
+
+      if (formatPages) {
+        renderedPage = await Promise.all(
+          renderedPage.map(async (pageContent) => (await formatMarkdown(pageContent)).trimEnd()),
+        );
+      }
+
+      sectionContent.push(...renderedPage);
+
+      if (formatPages && pageIndex < section.pages.length - 1) {
+        sectionContent.push('');
+      }
+    }
+
+    sectionContent.push('');
+    sections.push(...sectionContent);
+  }
+
+  const content = [...preamble, ...sections].join('\n');
+
+  if (formatPages) {
+    return `${content.trim()}\n`;
+  }
+
+  return formatMarkdown(content);
+}

--- a/docs/scripts/generateLlmTxt/createFileContent.test.mjs
+++ b/docs/scripts/generateLlmTxt/createFileContent.test.mjs
@@ -1,0 +1,67 @@
+import path from 'path';
+import { expect, it } from 'vitest';
+import { createFileContent } from './createFileContent.mjs';
+
+const filePath = path.resolve(import.meta.dirname, '../../public/llms-full.txt');
+
+const structure = {
+  sections: [
+    {
+      title: 'First section',
+      pages: [
+        { content: '### First page\n\nFirst body.\n' },
+        { content: '### Second page\n\n- First item\n- Second item\n' },
+      ],
+    },
+    {
+      title: 'Empty section',
+      pages: [],
+    },
+    {
+      title: 'Second section',
+      pages: [{ content: '### Third page\n\nFinal body.\n' }],
+    },
+  ],
+};
+
+const preamble = ['# Base UI', '', 'Introduction.', ''];
+const pageRenderer = (page) => [page.content];
+
+it('matches whole-document formatting when pages are formatted separately', async () => {
+  const wholeDocument = await createFileContent({
+    structure,
+    preamble,
+    pageRenderer,
+    filePath,
+  });
+  const separatePages = await createFileContent({
+    structure,
+    preamble,
+    pageRenderer,
+    filePath,
+    formatPages: true,
+  });
+
+  expect(separatePages).toBe(wholeDocument);
+  expect(separatePages).toBe(`# Base UI
+
+Introduction.
+
+## First section
+
+### First page
+
+First body.
+
+### Second page
+
+- First item
+- Second item
+
+## Second section
+
+### Third page
+
+Final body.
+`);
+});

--- a/docs/scripts/generateLlmTxt/index.mjs
+++ b/docs/scripts/generateLlmTxt/index.mjs
@@ -268,7 +268,10 @@ async function generateLlmsTxt() {
       ],
     };
 
-    const createFile = async (filename, pageRenderer) => {
+    const createFile = async (filename, pageRenderer, { formatPages = false } = {}) => {
+      const filePath = path.join(OUTPUT_BASE_DIR, filename);
+      const prettierOptions = await prettier.resolveConfig(filePath);
+
       // Generate sections with shared logic
       const sections = [];
 
@@ -280,9 +283,28 @@ async function generateLlmsTxt() {
         const sectionContent = [`## ${section.title}`, ''];
 
         // Use the page renderer for each page (handle async renderers)
-        for (const page of section.pages) {
-          const renderedPage = await pageRenderer(page);
+        for (const [pageIndex, page] of section.pages.entries()) {
+          let renderedPage = await pageRenderer(page);
+
+          if (formatPages) {
+            renderedPage = await Promise.all(
+              renderedPage.map(async (pageContent) =>
+                (
+                  await prettier.format(pageContent, {
+                    ...prettierOptions,
+                    filepath: filePath,
+                    parser: 'markdown',
+                  })
+                ).trimEnd(),
+              ),
+            );
+          }
+
           sectionContent.push(...renderedPage);
+
+          if (formatPages && pageIndex < section.pages.length - 1) {
+            sectionContent.push('');
+          }
         }
 
         sectionContent.push(''); // Add empty line after section
@@ -291,15 +313,16 @@ async function generateLlmsTxt() {
 
       let content = [...preamble, ...sections].join('\n');
 
-      // Apply prettier formatting
-      const filePath = path.join(OUTPUT_BASE_DIR, filename);
-      const prettierOptions = await prettier.resolveConfig(filePath);
-
-      content = await prettier.format(content, {
-        ...prettierOptions,
-        filepath: filePath,
-        parser: 'markdown',
-      });
+      if (formatPages) {
+        content = `${content.trim()}\n`;
+      } else {
+        // Apply prettier formatting
+        content = await prettier.format(content, {
+          ...prettierOptions,
+          filepath: filePath,
+          parser: 'markdown',
+        });
+      }
 
       await fs.writeFile(filePath, content, 'utf-8');
     };
@@ -307,7 +330,9 @@ async function generateLlmsTxt() {
     // Generate both files in parallel
     await Promise.all([
       createFile('llms.txt', renderPageAsLink),
-      createFile('llms-full.txt', renderPageAsInline),
+      // Format each page separately: formatting the multi-megabyte aggregate in one pass makes
+      // Prettier retain several gigabytes of Markdown AST and document nodes.
+      createFile('llms-full.txt', renderPageAsInline, { formatPages: true }),
       createFile('index.md', renderPageAsRelativeLink),
     ]);
 

--- a/docs/scripts/generateLlmTxt/index.mjs
+++ b/docs/scripts/generateLlmTxt/index.mjs
@@ -11,6 +11,7 @@ import remarkParse from 'remark-parse';
 import remarkGfm from 'remark-gfm';
 import remarkStringify from 'remark-stringify';
 import { visit } from 'unist-util-visit';
+import { createFileContent } from './createFileContent.mjs';
 import { mdxToMarkdown } from './mdxToMarkdown.mjs';
 import { resolveUrl, isAbsoluteUrl } from './resolver.mjs';
 
@@ -270,59 +271,13 @@ async function generateLlmsTxt() {
 
     const createFile = async (filename, pageRenderer, { formatPages = false } = {}) => {
       const filePath = path.join(OUTPUT_BASE_DIR, filename);
-      const prettierOptions = await prettier.resolveConfig(filePath);
-
-      // Generate sections with shared logic
-      const sections = [];
-
-      for (const section of structure.sections) {
-        if (section.pages.length === 0) {
-          continue;
-        }
-
-        const sectionContent = [`## ${section.title}`, ''];
-
-        // Use the page renderer for each page (handle async renderers)
-        for (const [pageIndex, page] of section.pages.entries()) {
-          let renderedPage = await pageRenderer(page);
-
-          if (formatPages) {
-            renderedPage = await Promise.all(
-              renderedPage.map(async (pageContent) =>
-                (
-                  await prettier.format(pageContent, {
-                    ...prettierOptions,
-                    filepath: filePath,
-                    parser: 'markdown',
-                  })
-                ).trimEnd(),
-              ),
-            );
-          }
-
-          sectionContent.push(...renderedPage);
-
-          if (formatPages && pageIndex < section.pages.length - 1) {
-            sectionContent.push('');
-          }
-        }
-
-        sectionContent.push(''); // Add empty line after section
-        sections.push(...sectionContent);
-      }
-
-      let content = [...preamble, ...sections].join('\n');
-
-      if (formatPages) {
-        content = `${content.trim()}\n`;
-      } else {
-        // Apply prettier formatting
-        content = await prettier.format(content, {
-          ...prettierOptions,
-          filepath: filePath,
-          parser: 'markdown',
-        });
-      }
+      const content = await createFileContent({
+        structure,
+        preamble,
+        pageRenderer,
+        filePath,
+        formatPages,
+      });
 
       await fs.writeFile(filePath, content, 'utf-8');
     };


### PR DESCRIPTION
## Summary

- format each page of `llms-full.txt` before concatenating the aggregate document
- avoid constructing a multi-million-node Prettier document for the complete documentation corpus
- preserve the exact formatted output

## Motivation

Prettier’s Markdown formatting memory grows disproportionately when `llms-full.txt` is formatted as one multi-megabyte document. Additional documentation pushed the generator past Node’s default 2 GB heap, causing every `release:build` consumer and the Netlify build to fail before their actual build or test step.

This is a docs infrastructure scaling issue, not a runtime memory leak.

## Verification

- `NODE_OPTIONS=--max-old-space-size=2048 pnpm docs:generate-llms`
  - before: deterministic heap OOM near 2 GB with the larger documentation corpus
  - after: succeeds with approximately 427–438 MB peak RSS
- compared the new aggregate output with a whole-file Prettier pass: byte-for-byte identical
- `pnpm eslint docs/scripts/generateLlmTxt/index.mjs`
- `pnpm prettier --check docs/scripts/generateLlmTxt/index.mjs`