### PR TITLE
[collapsible][accordion] Expand hiddenUntilFound panels synchronously on beforematch

### DIFF
--- a/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
@@ -1596,6 +1596,60 @@ describe('<Collapsible.Panel />', () => {
       expect(panel.style.transitionDuration).toBe('123ms');
     });
 
+    it('expands the panel while beforematch is being dispatched', async () => {
+      await render(
+        <React.Fragment>
+          <style>{`
+            .transition-test-panel {
+              overflow: hidden;
+              height: var(--collapsible-panel-height);
+              transition-property: height;
+              transition-duration: 999ms;
+              transition-timing-function: linear;
+            }
+
+            .transition-test-panel[data-starting-style],
+            .transition-test-panel[data-ending-style] {
+              height: 0;
+            }
+          `}</style>
+
+          <Collapsible.Root>
+            <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+            <Collapsible.Panel
+              className="transition-test-panel"
+              data-testid="panel"
+              hiddenUntilFound
+            >
+              {PANEL_CONTENT}
+            </Collapsible.Panel>
+          </Collapsible.Root>
+        </React.Fragment>,
+      );
+
+      const panel = screen.getByTestId('panel');
+
+      expect(panel).toHaveAttribute('data-starting-style');
+
+      let startingStyleWhenRevealed: boolean | undefined;
+      let heightWhenRevealed: string | undefined;
+
+      // Registered after the component's own listener, so this observes the panel
+      // from where the browser does: the same task, once `beforematch` handling is
+      // done. The browser drops `hidden` and measures the match there, and a panel
+      // still holding its collapsed starting styles measures as zero-sized.
+      panel.addEventListener('beforematch', () => {
+        startingStyleWhenRevealed = panel.hasAttribute('data-starting-style');
+        panel.removeAttribute('hidden');
+        heightWhenRevealed = getComputedStyle(panel).height;
+      });
+
+      fireBeforeMatch(panel);
+
+      expect(startingStyleWhenRevealed).toBe(false);
+      expect(heightWhenRevealed).not.toBe('0px');
+    });
+
     it('uses `hidden="until-found" to hide panel when true', async () => {
       const handleOpenChange = vi.fn();
 

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
@@ -1722,16 +1722,13 @@ describe('<Collapsible.Panel />', () => {
       // The browser drops `hidden` as part of revealing the match.
       panel.removeAttribute('hidden');
 
-      await act(async () => {
-        await waitForAnimationFrame();
-        await waitForAnimationFrame();
-      });
-
       // React renders the same props while the panel stays closed, so it cannot
       // restore the collapsed styles or the `hidden` state on its own.
+      await waitFor(() => {
+        expect(panel).toHaveAttribute('hidden', 'until-found');
+      });
       expect(panel).toHaveAttribute('data-starting-style');
       expect(getComputedStyle(panel).height).toBe('0px');
-      expect(panel).toHaveAttribute('hidden', 'until-found');
 
       await user.click(screen.getByRole('button', { name: 'Rerender' }));
 
@@ -1820,14 +1817,11 @@ describe('<Collapsible.Panel />', () => {
       // The browser drops `hidden` as part of revealing the match.
       panel.removeAttribute('hidden');
 
-      await act(async () => {
-        await waitForAnimationFrame();
-        await waitForAnimationFrame();
-      });
-
       // The panel returns to the fully closed state without gaining attributes
       // React does not render for it.
-      expect(panel).toHaveAttribute('hidden', 'until-found');
+      await waitFor(() => {
+        expect(panel).toHaveAttribute('hidden', 'until-found');
+      });
       expect(panel).not.toHaveAttribute('data-starting-style');
 
       // The reveal never opened the panel, so it must not consume the motion of

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
@@ -1655,6 +1655,7 @@ describe('<Collapsible.Panel />', () => {
 
     it('re-collapses the panel when the open state never arrives', async () => {
       function App() {
+        const [open, setOpen] = React.useState(false);
         const [, forceRender] = React.useState(0);
 
         return (
@@ -1678,13 +1679,23 @@ describe('<Collapsible.Panel />', () => {
               Rerender
             </button>
 
-            {/* Controlled and pinned closed: this consumer never honors `onOpenChange`. */}
-            <Collapsible.Root open={false} onOpenChange={() => {}}>
+            <Collapsible.Root
+              open={open}
+              onOpenChange={(nextOpen, eventDetails) => {
+                // Opts out of find-in-page reveals while still honoring the trigger.
+                if (eventDetails.reason === REASONS.none) {
+                  return;
+                }
+
+                setOpen(nextOpen);
+              }}
+            >
               <Collapsible.Trigger>Trigger</Collapsible.Trigger>
               <Collapsible.Panel
                 className="transition-test-panel"
                 data-testid="panel"
                 hiddenUntilFound
+                style={{ transitionDuration: '123ms' }}
               >
                 {PANEL_CONTENT}
               </Collapsible.Panel>
@@ -1717,6 +1728,13 @@ describe('<Collapsible.Panel />', () => {
 
       expect(panel).toHaveAttribute('data-starting-style');
       expect(getComputedStyle(panel).height).toBe('0px');
+
+      // The reveal never opened the panel, so it must not consume the motion of the
+      // next ordinary open.
+      await user.click(screen.getByRole('button', { name: 'Trigger' }));
+
+      expect(panel).toHaveAttribute('data-open');
+      expect(getComputedStyle(panel).transitionDuration).toBe('0.123s');
     });
 
     it('uses `hidden="until-found" to hide panel when true', async () => {

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
@@ -1584,6 +1584,9 @@ describe('<Collapsible.Panel />', () => {
       const trigger = screen.getByRole('button', { name: 'Trigger' });
 
       fireBeforeMatch(panel);
+      // The browser drops `hidden` as part of revealing the match, regardless of
+      // what the event handler decided.
+      panel.removeAttribute('hidden');
 
       expect(handleOpenChange).toHaveBeenCalledOnce();
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
@@ -1591,6 +1594,11 @@ describe('<Collapsible.Panel />', () => {
       // A canceled reveal must leave the collapsed styles in place.
       expect(panel).toHaveAttribute('data-starting-style');
       expect(getComputedStyle(panel).height).toBe('0px');
+
+      // A canceled reveal must also stay hidden and searchable.
+      await waitFor(() => {
+        expect(panel).toHaveAttribute('hidden', 'until-found');
+      });
 
       await user.click(trigger);
 
@@ -1720,9 +1728,10 @@ describe('<Collapsible.Panel />', () => {
       });
 
       // React renders the same props while the panel stays closed, so it cannot
-      // restore the collapsed styles on its own.
+      // restore the collapsed styles or the `hidden` state on its own.
       expect(panel).toHaveAttribute('data-starting-style');
       expect(getComputedStyle(panel).height).toBe('0px');
+      expect(panel).toHaveAttribute('hidden', 'until-found');
 
       await user.click(screen.getByRole('button', { name: 'Rerender' }));
 
@@ -1735,6 +1744,99 @@ describe('<Collapsible.Panel />', () => {
 
       expect(panel).toHaveAttribute('data-open');
       expect(getComputedStyle(panel).transitionDuration).toBe('0.123s');
+    });
+
+    it('re-collapses a keyframe panel when the open state never arrives', async () => {
+      function App() {
+        const [open, setOpen] = React.useState(false);
+
+        return (
+          <React.Fragment>
+            <style>{`
+              @keyframes test-panel-slide-down {
+                from { height: 0; }
+                to { height: var(--collapsible-panel-height); }
+              }
+
+              @keyframes test-panel-slide-up {
+                from { height: var(--collapsible-panel-height); }
+                to { height: 0; }
+              }
+
+              .animation-test-panel {
+                overflow: hidden;
+              }
+
+              .animation-test-panel[data-open] {
+                animation: test-panel-slide-down 100ms ease-out;
+              }
+
+              .animation-test-panel[data-closed] {
+                animation: test-panel-slide-up 100ms ease-in;
+              }
+            `}</style>
+
+            <Collapsible.Root
+              open={open}
+              onOpenChange={(nextOpen, eventDetails) => {
+                // Opts out of find-in-page reveals while still honoring the trigger.
+                if (eventDetails.reason === REASONS.none) {
+                  return;
+                }
+
+                setOpen(nextOpen);
+              }}
+            >
+              <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+              <Collapsible.Panel
+                className="animation-test-panel"
+                data-testid="panel"
+                hiddenUntilFound
+              >
+                {PANEL_CONTENT}
+              </Collapsible.Panel>
+            </Collapsible.Root>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      const panel = screen.getByTestId('panel');
+      const trigger = screen.getByRole('button', { name: 'Trigger' });
+
+      // A full open/close cycle reaches the steady state where the closed panel
+      // no longer carries `data-starting-style` (keyframe panels only hold it
+      // until the animation type has been detected).
+      await user.click(trigger);
+      await user.click(trigger);
+
+      await waitFor(() => {
+        expect(panel).toHaveAttribute('hidden', 'until-found');
+      });
+      expect(panel).not.toHaveAttribute('data-starting-style');
+
+      fireBeforeMatch(panel);
+      // The browser drops `hidden` as part of revealing the match.
+      panel.removeAttribute('hidden');
+
+      await act(async () => {
+        await waitForAnimationFrame();
+        await waitForAnimationFrame();
+      });
+
+      // The panel returns to the fully closed state without gaining attributes
+      // React does not render for it.
+      expect(panel).toHaveAttribute('hidden', 'until-found');
+      expect(panel).not.toHaveAttribute('data-starting-style');
+
+      // The reveal never opened the panel, so it must not consume the motion of
+      // the next ordinary open.
+      await user.click(trigger);
+
+      expect(panel).toHaveAttribute('data-open');
+      expect(getComputedStyle(panel).animationDuration).toBe('0.1s');
+      expect(panel.getAnimations().length).toBeGreaterThan(0);
     });
 
     it('uses `hidden="until-found" to hide panel when true', async () => {

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
@@ -1588,6 +1588,9 @@ describe('<Collapsible.Panel />', () => {
       expect(handleOpenChange).toHaveBeenCalledOnce();
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
       expect(panel).toHaveAttribute('data-closed');
+      // A canceled reveal must leave the collapsed styles in place.
+      expect(panel).toHaveAttribute('data-starting-style');
+      expect(getComputedStyle(panel).height).toBe('0px');
 
       await user.click(trigger);
 
@@ -1648,6 +1651,72 @@ describe('<Collapsible.Panel />', () => {
 
       expect(startingStyleWhenRevealed).toBe(false);
       expect(heightWhenRevealed).not.toBe('0px');
+    });
+
+    it('re-collapses the panel when the open state never arrives', async () => {
+      function App() {
+        const [, forceRender] = React.useState(0);
+
+        return (
+          <React.Fragment>
+            <style>{`
+              .transition-test-panel {
+                overflow: hidden;
+                height: var(--collapsible-panel-height);
+                transition-property: height;
+                transition-duration: 999ms;
+                transition-timing-function: linear;
+              }
+
+              .transition-test-panel[data-starting-style],
+              .transition-test-panel[data-ending-style] {
+                height: 0;
+              }
+            `}</style>
+
+            <button type="button" onClick={() => forceRender((value) => value + 1)}>
+              Rerender
+            </button>
+
+            {/* Controlled and pinned closed: this consumer never honors `onOpenChange`. */}
+            <Collapsible.Root open={false} onOpenChange={() => {}}>
+              <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+              <Collapsible.Panel
+                className="transition-test-panel"
+                data-testid="panel"
+                hiddenUntilFound
+              >
+                {PANEL_CONTENT}
+              </Collapsible.Panel>
+            </Collapsible.Root>
+          </React.Fragment>
+        );
+      }
+
+      const { user } = await render(<App />);
+
+      const panel = screen.getByTestId('panel');
+
+      expect(panel).toHaveAttribute('data-starting-style');
+
+      fireBeforeMatch(panel);
+      // The browser drops `hidden` as part of revealing the match.
+      panel.removeAttribute('hidden');
+
+      await act(async () => {
+        await waitForAnimationFrame();
+        await waitForAnimationFrame();
+      });
+
+      // React renders the same props while the panel stays closed, so it cannot
+      // restore the collapsed styles on its own.
+      expect(panel).toHaveAttribute('data-starting-style');
+      expect(getComputedStyle(panel).height).toBe('0px');
+
+      await user.click(screen.getByRole('button', { name: 'Rerender' }));
+
+      expect(panel).toHaveAttribute('data-starting-style');
+      expect(getComputedStyle(panel).height).toBe('0px');
     });
 
     it('uses `hidden="until-found" to hide panel when true', async () => {

--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -4,6 +4,7 @@ import { addEventListener } from '@base-ui/utils/addEventListener';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';
 import { AnimationFrame } from '@base-ui/utils/useAnimationFrame';
+import { Timeout } from '@base-ui/utils/useTimeout';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
 import { warn } from '@base-ui/utils/warn';
@@ -363,32 +364,47 @@ export function useCollapsiblePanel(
         return undefined;
       }
 
+      const revealDecisionTimeout = Timeout.create();
       let revertRevealFrame = -1;
 
       // Reverting must wait until the browser has measured the match, and React
       // cannot do it: it keeps rendering the same `hidden` and `data-starting-style`
       // props while the panel stays closed, so it never rewrites attributes that were
       // changed behind its back (the browser removes `hidden` as part of the reveal).
+      //
+      // Whether the open arrived is decided in a task, not a frame: `setOpen` has
+      // already scheduled React's own task by the time the timeout is queued, so the
+      // decision drains after the commit even when a busy main thread delays both,
+      // whereas a rendering update could preempt the still-queued commit and make an
+      // animation frame read a stale value. When the consumer ignores the open, no
+      // commit is ever scheduled and the decision holds. The DOM revert then runs
+      // in a frame so it stays atomic with respect to paint.
       const scheduleRevealRevert = (
         revertSkippedMotion: boolean,
         restoreStartingStyle: boolean,
       ) => {
-        revertRevealFrame = AnimationFrame.request(() => {
+        revealDecisionTimeout.start(0, () => {
           if (latestOpenRef.current) {
             return;
           }
 
-          if (revertSkippedMotion) {
-            // The open never happened, so the next one is an ordinary open that
-            // should keep its author-defined motion.
-            shouldSkipNextOpenRef.current = false;
-          }
+          revertRevealFrame = AnimationFrame.request(() => {
+            if (latestOpenRef.current) {
+              return;
+            }
 
-          if (restoreStartingStyle) {
-            panel.setAttribute(CollapsiblePanelDataAttributes.startingStyle, '');
-          }
+            if (revertSkippedMotion) {
+              // The open never happened, so the next one is an ordinary open that
+              // should keep its author-defined motion.
+              shouldSkipNextOpenRef.current = false;
+            }
 
-          panel.setAttribute('hidden', 'until-found');
+            if (restoreStartingStyle) {
+              panel.setAttribute(CollapsiblePanelDataAttributes.startingStyle, '');
+            }
+
+            panel.setAttribute('hidden', 'until-found');
+          });
         });
       };
 
@@ -426,6 +442,7 @@ export function useCollapsiblePanel(
       const cleanupBeforeMatchListener = addEventListener(panel, 'beforematch', handleBeforeMatch);
 
       return () => {
+        revealDecisionTimeout.clear();
         AnimationFrame.cancel(revertRevealFrame);
         cleanupBeforeMatchListener();
       };

--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -373,6 +373,12 @@ export function useCollapsiblePanel(
         }
 
         shouldSkipNextOpenRef.current = true;
+        // The browser removes `hidden` and measures the match in the same task that
+        // dispatches this event, while the React state update below only lands in a
+        // later one. Panels kept collapsed by persisted starting styles would still
+        // be zero-sized at that point and the match highlight is dropped, so drop
+        // those styles synchronously here.
+        panelRef.current?.removeAttribute(CollapsiblePanelDataAttributes.startingStyle);
         setOpen(true);
       }
 

--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -401,6 +401,9 @@ export function useCollapsiblePanel(
             return;
           }
 
+          // The open never happened, so the next one is an ordinary open that should
+          // keep its author-defined motion.
+          shouldSkipNextOpenRef.current = false;
           panel.setAttribute(CollapsiblePanelDataAttributes.startingStyle, '');
         });
       };

--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -363,7 +363,11 @@ export function useCollapsiblePanel(
         return undefined;
       }
 
-      function handleBeforeMatch(event: Event) {
+      let restoreStartingStyleFrame = -1;
+
+      // Declared as a `const` after the null check so `panel` stays narrowed: the
+      // handler must touch the same element the listener is attached to.
+      const handleBeforeMatch = (event: Event) => {
         const eventDetails = createChangeEventDetails(REASONS.none, event);
 
         onOpenChange(true, eventDetails);
@@ -373,18 +377,42 @@ export function useCollapsiblePanel(
         }
 
         shouldSkipNextOpenRef.current = true;
+
         // The browser removes `hidden` and measures the match in the same task that
         // dispatches this event, while the React state update below only lands in a
         // later one. Panels kept collapsed by persisted starting styles would still
         // be zero-sized at that point and the match highlight is dropped, so drop
         // those styles synchronously here.
-        panelRef.current?.removeAttribute(CollapsiblePanelDataAttributes.startingStyle);
-        setOpen(true);
-      }
+        const hadStartingStyle = panel.hasAttribute(CollapsiblePanelDataAttributes.startingStyle);
+        panel.removeAttribute(CollapsiblePanelDataAttributes.startingStyle);
 
-      return addEventListener(panel, 'beforematch', handleBeforeMatch);
+        setOpen(true);
+
+        if (!hadStartingStyle) {
+          return;
+        }
+
+        // React renders the same `data-starting-style` prop for as long as the panel
+        // stays closed, so it never rewrites the attribute removed above. Once the
+        // browser has measured the match, put it back if the open state never arrived,
+        // otherwise a controlled panel whose `onOpenChange` is ignored stays expanded.
+        restoreStartingStyleFrame = AnimationFrame.request(() => {
+          if (latestOpenRef.current) {
+            return;
+          }
+
+          panel.setAttribute(CollapsiblePanelDataAttributes.startingStyle, '');
+        });
+      };
+
+      const cleanupBeforeMatchListener = addEventListener(panel, 'beforematch', handleBeforeMatch);
+
+      return () => {
+        AnimationFrame.cancel(restoreStartingStyleFrame);
+        cleanupBeforeMatchListener();
+      };
     },
-    [onOpenChange, setOpen],
+    [latestOpenRef, onOpenChange, setOpen],
   );
 
   const shouldRender = keepMounted || hiddenUntilFound || mounted || open;

--- a/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
+++ b/packages/react/src/collapsible/panel/useCollapsiblePanel.ts
@@ -363,7 +363,34 @@ export function useCollapsiblePanel(
         return undefined;
       }
 
-      let restoreStartingStyleFrame = -1;
+      let revertRevealFrame = -1;
+
+      // Reverting must wait until the browser has measured the match, and React
+      // cannot do it: it keeps rendering the same `hidden` and `data-starting-style`
+      // props while the panel stays closed, so it never rewrites attributes that were
+      // changed behind its back (the browser removes `hidden` as part of the reveal).
+      const scheduleRevealRevert = (
+        revertSkippedMotion: boolean,
+        restoreStartingStyle: boolean,
+      ) => {
+        revertRevealFrame = AnimationFrame.request(() => {
+          if (latestOpenRef.current) {
+            return;
+          }
+
+          if (revertSkippedMotion) {
+            // The open never happened, so the next one is an ordinary open that
+            // should keep its author-defined motion.
+            shouldSkipNextOpenRef.current = false;
+          }
+
+          if (restoreStartingStyle) {
+            panel.setAttribute(CollapsiblePanelDataAttributes.startingStyle, '');
+          }
+
+          panel.setAttribute('hidden', 'until-found');
+        });
+      };
 
       // Declared as a `const` after the null check so `panel` stays narrowed: the
       // handler must touch the same element the listener is attached to.
@@ -373,6 +400,9 @@ export function useCollapsiblePanel(
         onOpenChange(true, eventDetails);
 
         if (eventDetails.isCanceled) {
+          // A canceled reveal means the panel must stay hidden, so undo the
+          // browser's removal of `hidden` and keep the content searchable.
+          scheduleRevealRevert(false, false);
           return;
         }
 
@@ -388,30 +418,15 @@ export function useCollapsiblePanel(
 
         setOpen(true);
 
-        if (!hadStartingStyle) {
-          return;
-        }
-
-        // React renders the same `data-starting-style` prop for as long as the panel
-        // stays closed, so it never rewrites the attribute removed above. Once the
-        // browser has measured the match, put it back if the open state never arrived,
-        // otherwise a controlled panel whose `onOpenChange` is ignored stays expanded.
-        restoreStartingStyleFrame = AnimationFrame.request(() => {
-          if (latestOpenRef.current) {
-            return;
-          }
-
-          // The open never happened, so the next one is an ordinary open that should
-          // keep its author-defined motion.
-          shouldSkipNextOpenRef.current = false;
-          panel.setAttribute(CollapsiblePanelDataAttributes.startingStyle, '');
-        });
+        // A controlled panel whose `onOpenChange` is ignored never receives the open
+        // state, so return it to the fully closed state once the browser has measured.
+        scheduleRevealRevert(true, hadStartingStyle);
       };
 
       const cleanupBeforeMatchListener = addEventListener(panel, 'beforematch', handleBeforeMatch);
 
       return () => {
-        AnimationFrame.cancel(restoreStartingStyleFrame);
+        AnimationFrame.cancel(revertRevealFrame);
         cleanupBeforeMatchListener();
       };
     },


### PR DESCRIPTION
Closes #5513.

Expands `hiddenUntilFound` Collapsible and Accordion panels synchronously during `beforematch`, allowing Chrome and Safari to highlight find-in-page matches when transition CSS keeps the closed panel at zero height.

If a controlled reveal is canceled or ignored, the panel restores its collapsed styles and `hidden="until-found"` state without consuming the next normal opening animation.

Covered by the Collapsible and Accordion suites in jsdom and Chromium, and manually verified in Chrome 151.