### PR TITLE
[docs][accordion][collapsible] Add hiddenUntilFound demo

### DIFF
--- a/docs/scripts/generateLlmTxt/__snapshots__/mdxToMarkdown.test.mjs.snap
+++ b/docs/scripts/generateLlmTxt/__snapshots__/mdxToMarkdown.test.mjs.snap
@@ -557,6 +557,315 @@ function PlusIcon(props: React.ComponentProps<'svg'>) {
 
 \`\`\`
 
+### Find-in-page
+
+The \`hiddenUntilFound\` prop hides closed panels with [\`hidden="until-found"\`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) so the browser can search their contents and reveal the matching panel automatically. It can be set on each \`Accordion.Panel\`, or once on \`Accordion.Root\` to apply to all panels.
+
+To try it, press <kbd>Ctrl</kbd>+<kbd>F</kbd> (<kbd>Cmd</kbd>+<kbd>F</kbd> on macOS) and search for "restocking"—the browser opens the closed panel containing the match. When \`hiddenUntilFound\` is enabled, closed panels always remain mounted in the DOM, which also makes their contents indexable by search engines.
+
+Older browsers that don't support \`hidden="until-found"\` keep panels hidden until their trigger opens them, and find-in-page skips over the contents.
+
+## Demo
+
+### Tailwind
+
+This example shows how to implement the component using Tailwind CSS.
+
+\`\`\`tsx
+/* index.tsx */
+import * as React from 'react';
+import { Accordion } from '@base-ui/react/accordion';
+
+export default function ExampleAccordion() {
+  return (
+    <Accordion.Root
+      hiddenUntilFound
+      className="flex w-full max-w-80 flex-col border border-neutral-950 text-neutral-950 dark:border-white dark:text-white"
+    >
+      <Accordion.Item>
+        <Accordion.Header>
+          <Accordion.Trigger className="group flex w-full items-center justify-between gap-4 bg-transparent px-3 py-2 text-left text-sm font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 focus-visible:relative focus-visible:z-1 focus-visible:outline-2 focus-visible:outline-neutral-950 dark:focus-visible:outline-white dark:text-white dark:hover:not-data-disabled:bg-neutral-800">
+            How long does shipping take?
+            <PlusIcon className="shrink-0 transition-transform duration-100 ease-[ease-out] group-data-panel-open:rotate-45" />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-sm transition-[height] duration-150 ease-[ease-out] data-ending-style:h-0 data-starting-style:h-0">
+          <div className="px-3 py-2">
+            Standard shipping takes 3–5 business days. Express delivery arrives in 1–2 business
+            days.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item className="border-t border-neutral-950 dark:border-white">
+        <Accordion.Header>
+          <Accordion.Trigger className="group flex w-full items-center justify-between gap-4 bg-transparent px-3 py-2 text-left text-sm font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 focus-visible:relative focus-visible:z-1 focus-visible:outline-2 focus-visible:outline-neutral-950 dark:focus-visible:outline-white dark:text-white dark:hover:not-data-disabled:bg-neutral-800">
+            What is your return policy?
+            <PlusIcon className="shrink-0 transition-transform duration-100 ease-[ease-out] group-data-panel-open:rotate-45" />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-sm transition-[height] duration-150 ease-[ease-out] data-ending-style:h-0 data-starting-style:h-0">
+          <div className="px-3 py-2">
+            You can return any item within 30 days of delivery. Opened items may be subject to a 10%
+            restocking fee.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item className="border-t border-neutral-950 dark:border-white">
+        <Accordion.Header>
+          <Accordion.Trigger className="group flex w-full items-center justify-between gap-4 bg-transparent px-3 py-2 text-left text-sm font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 focus-visible:relative focus-visible:z-1 focus-visible:outline-2 focus-visible:outline-neutral-950 dark:focus-visible:outline-white dark:text-white dark:hover:not-data-disabled:bg-neutral-800">
+            Do you ship internationally?
+            <PlusIcon className="shrink-0 transition-transform duration-100 ease-[ease-out] group-data-panel-open:rotate-45" />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-sm transition-[height] duration-150 ease-[ease-out] data-ending-style:h-0 data-starting-style:h-0">
+          <div className="px-3 py-2">
+            Yes, we ship to over 40 countries. International orders typically arrive within 7–14
+            business days.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item className="border-t border-neutral-950 dark:border-white">
+        <Accordion.Header>
+          <Accordion.Trigger className="group flex w-full items-center justify-between gap-4 bg-transparent px-3 py-2 text-left text-sm font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 focus-visible:relative focus-visible:z-1 focus-visible:outline-2 focus-visible:outline-neutral-950 dark:focus-visible:outline-white dark:text-white dark:hover:not-data-disabled:bg-neutral-800">
+            How can I track my order?
+            <PlusIcon className="shrink-0 transition-transform duration-100 ease-[ease-out] group-data-panel-open:rotate-45" />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-sm transition-[height] duration-150 ease-[ease-out] data-ending-style:h-0 data-starting-style:h-0">
+          <div className="px-3 py-2">
+            Once your order ships, you’ll receive a tracking link by email. Tracking updates can
+            take up to 24 hours to appear.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+    </Accordion.Root>
+  );
+}
+
+function PlusIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="square"
+      strokeLinejoin="round"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M1.5 8h13M8 14.5v-13" />
+    </svg>
+  );
+}
+
+\`\`\`
+
+### CSS Modules
+
+This example shows how to implement the component using CSS Modules.
+
+\`\`\`css
+/* index.module.css */
+.Accordion {
+  box-sizing: border-box;
+  display: flex;
+  max-width: 20rem;
+  width: 100%;
+  flex-direction: column;
+  border: 1px solid oklch(14.5% 0 0deg);
+  color: oklch(14.5% 0 0deg);
+
+  @media (prefers-color-scheme: dark) {
+    border: 1px solid white;
+    color: white;
+  }
+}
+
+.Item {
+  & + & {
+    border-top: 1px solid oklch(14.5% 0 0deg);
+
+    @media (prefers-color-scheme: dark) {
+      border-top: 1px solid white;
+    }
+  }
+}
+
+.Header {
+  margin: 0;
+}
+
+.Trigger {
+  box-sizing: border-box;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+  color: oklch(14.5% 0 0deg);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  text-align: left;
+  -webkit-user-select: none;
+  user-select: none;
+
+  @media (prefers-color-scheme: dark) {
+    color: white;
+  }
+
+  @media (hover: hover) {
+    &:hover:not([data-disabled]) {
+      background-color: oklch(97% 0 0deg);
+
+      @media (prefers-color-scheme: dark) {
+        background-color: oklch(26.9% 0 0deg);
+      }
+    }
+  }
+
+  &:focus-visible {
+    position: relative;
+    outline: 2px solid oklch(14.5% 0 0deg);
+    z-index: 1;
+
+    @media (prefers-color-scheme: dark) {
+      outline-color: white;
+    }
+  }
+}
+
+.Icon {
+  transition: transform 100ms ease-out;
+
+  [data-panel-open] > & {
+    transform: rotate(45deg);
+  }
+}
+
+.Panel {
+  box-sizing: border-box;
+  height: var(--accordion-panel-height);
+  overflow: hidden;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  transition: height 150ms ease-out;
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    height: 0;
+  }
+}
+
+.Content {
+  padding: 0.5rem 0.75rem;
+}
+
+\`\`\`
+
+\`\`\`tsx
+/* index.tsx */
+import * as React from 'react';
+import { Accordion } from '@base-ui/react/accordion';
+import styles from './index.module.css';
+
+export default function ExampleAccordion() {
+  return (
+    <Accordion.Root className={styles.Accordion} hiddenUntilFound>
+      <Accordion.Item className={styles.Item}>
+        <Accordion.Header className={styles.Header}>
+          <Accordion.Trigger className={styles.Trigger}>
+            How long does shipping take?
+            <PlusIcon className={styles.Icon} />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className={styles.Panel}>
+          <div className={styles.Content}>
+            Standard shipping takes 3–5 business days. Express delivery arrives in 1–2 business
+            days.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item className={styles.Item}>
+        <Accordion.Header className={styles.Header}>
+          <Accordion.Trigger className={styles.Trigger}>
+            What is your return policy?
+            <PlusIcon className={styles.Icon} />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className={styles.Panel}>
+          <div className={styles.Content}>
+            You can return any item within 30 days of delivery. Opened items may be subject to a 10%
+            restocking fee.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item className={styles.Item}>
+        <Accordion.Header className={styles.Header}>
+          <Accordion.Trigger className={styles.Trigger}>
+            Do you ship internationally?
+            <PlusIcon className={styles.Icon} />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className={styles.Panel}>
+          <div className={styles.Content}>
+            Yes, we ship to over 40 countries. International orders typically arrive within 7–14
+            business days.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item className={styles.Item}>
+        <Accordion.Header className={styles.Header}>
+          <Accordion.Trigger className={styles.Trigger}>
+            How can I track my order?
+            <PlusIcon className={styles.Icon} />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className={styles.Panel}>
+          <div className={styles.Content}>
+            Once your order ships, you’ll receive a tracking link by email. Tracking updates can
+            take up to 24 hours to appear.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+    </Accordion.Root>
+  );
+}
+
+function PlusIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="square"
+      strokeLinejoin="round"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M1.5 8h13M8 14.5v-13" />
+    </svg>
+  );
+}
+
+\`\`\`
+
 ## API reference
 
 ### Root

--- a/docs/scripts/generateLlmTxt/__snapshots__/mdxToMarkdown.test.mjs.snap
+++ b/docs/scripts/generateLlmTxt/__snapshots__/mdxToMarkdown.test.mjs.snap
@@ -557,7 +557,7 @@ function PlusIcon(props: React.ComponentProps<'svg'>) {
 
 \`\`\`
 
-### Find-in-page
+### Hidden until found
 
 The \`hiddenUntilFound\` prop hides closed panels with [\`hidden="until-found"\`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) so the browser can search their contents and reveal the matching panel automatically. It can be set on each \`Accordion.Panel\`, or once on \`Accordion.Root\` to apply to all panels.
 

--- a/docs/src/app/(docs)/react/components/accordion/demos/hidden-until-found/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/accordion/demos/hidden-until-found/css-modules/index.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { Accordion } from '@base-ui/react/accordion';
+import styles from '../../_index.module.css';
+
+export default function ExampleAccordion() {
+  return (
+    <Accordion.Root className={styles.Accordion} hiddenUntilFound>
+      <Accordion.Item className={styles.Item}>
+        <Accordion.Header className={styles.Header}>
+          <Accordion.Trigger className={styles.Trigger}>
+            How long does shipping take?
+            <PlusIcon className={styles.Icon} />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className={styles.Panel}>
+          <div className={styles.Content}>
+            Standard shipping takes 3–5 business days. Express delivery arrives in 1–2 business
+            days.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item className={styles.Item}>
+        <Accordion.Header className={styles.Header}>
+          <Accordion.Trigger className={styles.Trigger}>
+            What is your return policy?
+            <PlusIcon className={styles.Icon} />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className={styles.Panel}>
+          <div className={styles.Content}>
+            You can return any item within 30 days of delivery. Opened items may be subject to a 10%
+            restocking fee.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item className={styles.Item}>
+        <Accordion.Header className={styles.Header}>
+          <Accordion.Trigger className={styles.Trigger}>
+            Do you ship internationally?
+            <PlusIcon className={styles.Icon} />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className={styles.Panel}>
+          <div className={styles.Content}>
+            Yes, we ship to over 40 countries. International orders typically arrive within 7–14
+            business days.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item className={styles.Item}>
+        <Accordion.Header className={styles.Header}>
+          <Accordion.Trigger className={styles.Trigger}>
+            How can I track my order?
+            <PlusIcon className={styles.Icon} />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className={styles.Panel}>
+          <div className={styles.Content}>
+            Once your order ships, you’ll receive a tracking link by email. Tracking updates can
+            take up to 24 hours to appear.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+    </Accordion.Root>
+  );
+}
+
+function PlusIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="square"
+      strokeLinejoin="round"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M1.5 8h13M8 14.5v-13" />
+    </svg>
+  );
+}

--- a/docs/src/app/(docs)/react/components/accordion/demos/hidden-until-found/index.ts
+++ b/docs/src/app/(docs)/react/components/accordion/demos/hidden-until-found/index.ts
@@ -1,0 +1,8 @@
+import { createDemoWithVariants } from 'docs/src/utils/createDemo';
+import CssModules from './css-modules';
+import Tailwind from './tailwind';
+
+export const DemoAccordionHiddenUntilFound = createDemoWithVariants(import.meta.url, {
+  CssModules,
+  Tailwind,
+});

--- a/docs/src/app/(docs)/react/components/accordion/demos/hidden-until-found/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/accordion/demos/hidden-until-found/tailwind/index.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { Accordion } from '@base-ui/react/accordion';
+
+export default function ExampleAccordion() {
+  return (
+    <Accordion.Root
+      hiddenUntilFound
+      className="flex w-full max-w-80 flex-col border border-neutral-950 text-neutral-950 dark:border-white dark:text-white"
+    >
+      <Accordion.Item>
+        <Accordion.Header>
+          <Accordion.Trigger className="group flex w-full items-center justify-between gap-4 bg-transparent px-3 py-2 text-left text-sm font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 focus-visible:relative focus-visible:z-1 focus-visible:outline-2 focus-visible:outline-neutral-950 dark:focus-visible:outline-white dark:text-white dark:hover:not-data-disabled:bg-neutral-800">
+            How long does shipping take?
+            <PlusIcon className="shrink-0 transition-transform duration-100 ease-[ease-out] group-data-panel-open:rotate-45" />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-sm transition-[height] duration-150 ease-[ease-out] data-ending-style:h-0 data-starting-style:h-0">
+          <div className="px-3 py-2">
+            Standard shipping takes 3–5 business days. Express delivery arrives in 1–2 business
+            days.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item className="border-t border-neutral-950 dark:border-white">
+        <Accordion.Header>
+          <Accordion.Trigger className="group flex w-full items-center justify-between gap-4 bg-transparent px-3 py-2 text-left text-sm font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 focus-visible:relative focus-visible:z-1 focus-visible:outline-2 focus-visible:outline-neutral-950 dark:focus-visible:outline-white dark:text-white dark:hover:not-data-disabled:bg-neutral-800">
+            What is your return policy?
+            <PlusIcon className="shrink-0 transition-transform duration-100 ease-[ease-out] group-data-panel-open:rotate-45" />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-sm transition-[height] duration-150 ease-[ease-out] data-ending-style:h-0 data-starting-style:h-0">
+          <div className="px-3 py-2">
+            You can return any item within 30 days of delivery. Opened items may be subject to a 10%
+            restocking fee.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item className="border-t border-neutral-950 dark:border-white">
+        <Accordion.Header>
+          <Accordion.Trigger className="group flex w-full items-center justify-between gap-4 bg-transparent px-3 py-2 text-left text-sm font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 focus-visible:relative focus-visible:z-1 focus-visible:outline-2 focus-visible:outline-neutral-950 dark:focus-visible:outline-white dark:text-white dark:hover:not-data-disabled:bg-neutral-800">
+            Do you ship internationally?
+            <PlusIcon className="shrink-0 transition-transform duration-100 ease-[ease-out] group-data-panel-open:rotate-45" />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-sm transition-[height] duration-150 ease-[ease-out] data-ending-style:h-0 data-starting-style:h-0">
+          <div className="px-3 py-2">
+            Yes, we ship to over 40 countries. International orders typically arrive within 7–14
+            business days.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+
+      <Accordion.Item className="border-t border-neutral-950 dark:border-white">
+        <Accordion.Header>
+          <Accordion.Trigger className="group flex w-full items-center justify-between gap-4 bg-transparent px-3 py-2 text-left text-sm font-normal text-neutral-950 select-none hover:not-data-disabled:bg-neutral-100 focus-visible:relative focus-visible:z-1 focus-visible:outline-2 focus-visible:outline-neutral-950 dark:focus-visible:outline-white dark:text-white dark:hover:not-data-disabled:bg-neutral-800">
+            How can I track my order?
+            <PlusIcon className="shrink-0 transition-transform duration-100 ease-[ease-out] group-data-panel-open:rotate-45" />
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className="h-[var(--accordion-panel-height)] overflow-hidden text-sm transition-[height] duration-150 ease-[ease-out] data-ending-style:h-0 data-starting-style:h-0">
+          <div className="px-3 py-2">
+            Once your order ships, you’ll receive a tracking link by email. Tracking updates can
+            take up to 24 hours to appear.
+          </div>
+        </Accordion.Panel>
+      </Accordion.Item>
+    </Accordion.Root>
+  );
+}
+
+function PlusIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="square"
+      strokeLinejoin="round"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M1.5 8h13M8 14.5v-13" />
+    </svg>
+  );
+}

--- a/docs/src/app/(docs)/react/components/accordion/page.mdx
+++ b/docs/src/app/(docs)/react/components/accordion/page.mdx
@@ -37,7 +37,7 @@ import { DemoAccordionMultiple } from './demos/multiple';
 
 <DemoAccordionMultiple />
 
-### Find-in-page
+### Hidden until found
 
 The `hiddenUntilFound` prop hides closed panels with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) so the browser can search their contents and reveal the matching panel automatically. It can be set on each `Accordion.Panel`, or once on `Accordion.Root` to apply to all panels.
 

--- a/docs/src/app/(docs)/react/components/accordion/page.mdx
+++ b/docs/src/app/(docs)/react/components/accordion/page.mdx
@@ -43,7 +43,7 @@ The `hiddenUntilFound` prop hides closed panels with [`hidden="until-found"`](ht
 
 To try it, press <kbd>Ctrl</kbd>+<kbd>F</kbd> (<kbd>Cmd</kbd>+<kbd>F</kbd> on macOS) and search for "restocking"—the browser opens the closed panel containing the match. When `hiddenUntilFound` is enabled, closed panels always remain mounted in the DOM, which also makes their contents indexable by search engines.
 
-`hidden="until-found"` is [Baseline newly available](https://web.dev/baseline), so every major browser supports it in current versions. Older browsers keep the panel hidden until its trigger opens it, and find-in-page skips over the contents.
+Older browsers that don't support `hidden="until-found"` keep panels hidden until their trigger opens them, and find-in-page skips over the contents.
 
 import { DemoAccordionHiddenUntilFound } from './demos/hidden-until-found';
 

--- a/docs/src/app/(docs)/react/components/accordion/page.mdx
+++ b/docs/src/app/(docs)/react/components/accordion/page.mdx
@@ -37,6 +37,16 @@ import { DemoAccordionMultiple } from './demos/multiple';
 
 <DemoAccordionMultiple />
 
+### Find-in-page
+
+The `hiddenUntilFound` prop hides closed panels with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) so the browser can search their contents and reveal the matching panel automatically. It can be set on each `Accordion.Panel`, or once on `Accordion.Root` to apply to all panels.
+
+To try it, press <kbd>Ctrl</kbd>+<kbd>F</kbd> (<kbd>Cmd</kbd>+<kbd>F</kbd> on macOS) and search for "restocking"—the browser opens the closed panel containing the match. When `hiddenUntilFound` is enabled, closed panels always remain mounted in the DOM, which also makes their contents indexable by search engines. In browsers without `hidden="until-found"` support (Safari before 26.2 and Firefox before 139), panels stay fully hidden until opened manually.
+
+import { DemoAccordionHiddenUntilFound } from './demos/hidden-until-found';
+
+<DemoAccordionHiddenUntilFound />
+
 ## API reference
 
 import { TypesAccordion } from './types';

--- a/docs/src/app/(docs)/react/components/accordion/page.mdx
+++ b/docs/src/app/(docs)/react/components/accordion/page.mdx
@@ -41,7 +41,9 @@ import { DemoAccordionMultiple } from './demos/multiple';
 
 The `hiddenUntilFound` prop hides closed panels with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) so the browser can search their contents and reveal the matching panel automatically. It can be set on each `Accordion.Panel`, or once on `Accordion.Root` to apply to all panels.
 
-To try it, press <kbd>Ctrl</kbd>+<kbd>F</kbd> (<kbd>Cmd</kbd>+<kbd>F</kbd> on macOS) and search for "restocking"—the browser opens the closed panel containing the match. When `hiddenUntilFound` is enabled, closed panels always remain mounted in the DOM, which also makes their contents indexable by search engines. In browsers without `hidden="until-found"` support (Safari before 26.2 and Firefox before 139), panels stay fully hidden until opened manually.
+To try it, press <kbd>Ctrl</kbd>+<kbd>F</kbd> (<kbd>Cmd</kbd>+<kbd>F</kbd> on macOS) and search for "restocking"—the browser opens the closed panel containing the match. When `hiddenUntilFound` is enabled, closed panels always remain mounted in the DOM, which also makes their contents indexable by search engines.
+
+`hidden="until-found"` is [Baseline newly available](https://web.dev/baseline), so every major browser supports it in current versions. Older browsers keep the panel hidden until its trigger opens it, and find-in-page skips over the contents.
 
 import { DemoAccordionHiddenUntilFound } from './demos/hidden-until-found';
 

--- a/docs/src/app/(docs)/react/components/collapsible/page.mdx
+++ b/docs/src/app/(docs)/react/components/collapsible/page.mdx
@@ -23,6 +23,22 @@ import { Collapsible } from '@base-ui/react/collapsible';
 </Collapsible.Root>;
 ```
 
+## Examples
+
+### Find-in-page
+
+The `hiddenUntilFound` prop hides the closed panel with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) so the browser can search its contents with find-in-page (<kbd>Ctrl</kbd>+<kbd>F</kbd>/<kbd>Cmd</kbd>+<kbd>F</kbd>) and reveal the panel when a match is found. The closed panel always remains mounted in the DOM, which also makes its contents indexable by search engines. In browsers without `hidden="until-found"` support (Safari before 26.2 and Firefox before 139), the panel stays fully hidden until opened manually.
+
+```tsx title="Searchable hidden panel"
+<Collapsible.Root>
+  <Collapsible.Trigger>Shipping details</Collapsible.Trigger>
+  {/* @highlight-text "hiddenUntilFound" */}
+  <Collapsible.Panel hiddenUntilFound>Standard shipping takes 3–5 business days.</Collapsible.Panel>
+</Collapsible.Root>
+```
+
+See the [Accordion example](/react/components/accordion#find-in-page) for an interactive demo.
+
 ## API reference
 
 import { TypesCollapsible } from './types';

--- a/docs/src/app/(docs)/react/components/collapsible/page.mdx
+++ b/docs/src/app/(docs)/react/components/collapsible/page.mdx
@@ -25,7 +25,7 @@ import { Collapsible } from '@base-ui/react/collapsible';
 
 ## Examples
 
-### Find-in-page
+### Hidden until found
 
 The `hiddenUntilFound` prop hides the closed panel with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) so the browser can search its contents with find-in-page—<kbd>Ctrl</kbd>+<kbd>F</kbd> (<kbd>Cmd</kbd>+<kbd>F</kbd> on macOS)—and reveal the panel when a match is found. The closed panel always remains mounted in the DOM, which also makes its contents indexable by search engines.
 
@@ -39,7 +39,7 @@ Older browsers that don't support `hidden="until-found"` keep the panel hidden u
 </Collapsible.Root>
 ```
 
-See the [Accordion example](/react/components/accordion#find-in-page) for an interactive demo.
+See the [Accordion example](/react/components/accordion#hidden-until-found) for an interactive demo.
 
 ## API reference
 

--- a/docs/src/app/(docs)/react/components/collapsible/page.mdx
+++ b/docs/src/app/(docs)/react/components/collapsible/page.mdx
@@ -27,7 +27,9 @@ import { Collapsible } from '@base-ui/react/collapsible';
 
 ### Find-in-page
 
-The `hiddenUntilFound` prop hides the closed panel with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) so the browser can search its contents with find-in-page (<kbd>Ctrl</kbd>+<kbd>F</kbd>/<kbd>Cmd</kbd>+<kbd>F</kbd>) and reveal the panel when a match is found. The closed panel always remains mounted in the DOM, which also makes its contents indexable by search engines. In browsers without `hidden="until-found"` support (Safari before 26.2 and Firefox before 139), the panel stays fully hidden until opened manually.
+The `hiddenUntilFound` prop hides the closed panel with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) so the browser can search its contents with find-in-page (<kbd>Ctrl</kbd>+<kbd>F</kbd>/<kbd>Cmd</kbd>+<kbd>F</kbd>) and reveal the panel when a match is found. The closed panel always remains mounted in the DOM, which also makes its contents indexable by search engines.
+
+`hidden="until-found"` is [Baseline newly available](https://web.dev/baseline), so every major browser supports it in current versions. Older browsers keep the panel hidden until its trigger opens it, and find-in-page skips over the contents.
 
 ```tsx title="Searchable hidden panel"
 <Collapsible.Root>

--- a/docs/src/app/(docs)/react/components/collapsible/page.mdx
+++ b/docs/src/app/(docs)/react/components/collapsible/page.mdx
@@ -27,7 +27,7 @@ import { Collapsible } from '@base-ui/react/collapsible';
 
 ### Find-in-page
 
-The `hiddenUntilFound` prop hides the closed panel with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) so the browser can search its contents with find-in-page (<kbd>Ctrl</kbd>+<kbd>F</kbd>/<kbd>Cmd</kbd>+<kbd>F</kbd>) and reveal the panel when a match is found. The closed panel always remains mounted in the DOM, which also makes its contents indexable by search engines.
+The `hiddenUntilFound` prop hides the closed panel with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) so the browser can search its contents with find-in-page—<kbd>Ctrl</kbd>+<kbd>F</kbd> (<kbd>Cmd</kbd>+<kbd>F</kbd> on macOS)—and reveal the panel when a match is found. The closed panel always remains mounted in the DOM, which also makes its contents indexable by search engines.
 
 Older browsers that don't support `hidden="until-found"` keep the panel hidden until its trigger opens it, and find-in-page skips over the contents.
 

--- a/docs/src/app/(docs)/react/components/collapsible/page.mdx
+++ b/docs/src/app/(docs)/react/components/collapsible/page.mdx
@@ -29,7 +29,7 @@ import { Collapsible } from '@base-ui/react/collapsible';
 
 The `hiddenUntilFound` prop hides the closed panel with [`hidden="until-found"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden) so the browser can search its contents with find-in-page (<kbd>Ctrl</kbd>+<kbd>F</kbd>/<kbd>Cmd</kbd>+<kbd>F</kbd>) and reveal the panel when a match is found. The closed panel always remains mounted in the DOM, which also makes its contents indexable by search engines.
 
-`hidden="until-found"` is [Baseline newly available](https://web.dev/baseline), so every major browser supports it in current versions. Older browsers keep the panel hidden until its trigger opens it, and find-in-page skips over the contents.
+Older browsers that don't support `hidden="until-found"` keep the panel hidden until its trigger opens it, and find-in-page skips over the contents.
 
 ```tsx title="Searchable hidden panel"
 <Collapsible.Root>

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -55,6 +55,7 @@ A set of collapsible panels with headings.
   - Anatomy
   - Examples
     - Open multiple panels
+    - Find-in-page
   - API reference
     - Root
     - Item
@@ -386,6 +387,8 @@ A collapsible panel controlled by a button.
 - Keywords: React Collapsible, Collapsible Component, Expandable Panel, Toggle Panel Button, Disclosure Widget, Show/Hide Content, Accordion Item, Accessible Disclosure, Headless React Components, Collapsible Trigger Panel, Base UI
 - Sections:
   - Anatomy
+  - Examples
+    - Find-in-page
   - API reference
     - Root
     - Trigger

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -55,7 +55,7 @@ A set of collapsible panels with headings.
   - Anatomy
   - Examples
     - Open multiple panels
-    - Find-in-page
+    - Hidden until found
   - API reference
     - Root
     - Item
@@ -388,7 +388,7 @@ A collapsible panel controlled by a button.
 - Sections:
   - Anatomy
   - Examples
-    - Find-in-page
+    - Hidden until found
   - API reference
     - Root
     - Trigger


### PR DESCRIPTION
Part of #3027

Adds a `hiddenUntilFound` demo to the Accordion docs and a companion section on the Collapsible page.

`beforematch` can't be dispatched programmatically — only real find-in-page or a scroll-to-text fragment triggers it — so the demo is written to be driven by the reader.

## Notes for review

- The instruction names the keyword, so `restocking` also appears in the surrounding prose and is
  the first find-in-page match; the panel's copy is the second. Pressing <kbd>Enter</kbd> while focusing the browser's search field or <kbd>Cmd</kbd>+<kbd>G</kbd> once more
  reaches it. Any wording that tells the reader what to search for has this property, so I left it
  as is — happy to reword if you'd prefer.
- If the revealed text is not highlighted on the first try, it's because https://github.com/mui/base-ui/issues/5513 (fix in https://github.com/mui/base-ui/pull/5514), not something specific to this demo. The panel itself opens correctly, and the demo behaves fully once that lands.