### PR TITLE
[select][combobox] Fix record items label lookup reading from Object.prototype

### DIFF
--- a/packages/react/src/internals/resolveValueLabel.test.ts
+++ b/packages/react/src/internals/resolveValueLabel.test.ts
@@ -155,5 +155,10 @@ describe('resolveValueLabel', () => {
 
       expect(resolveSelectedLabel(null, items)).toBe('None');
     });
+
+    it('falls back to the stringified label when an own key has a nullish label', () => {
+      expect(resolveSelectedLabel('sans', { sans: undefined })).toBe('sans');
+      expect(resolveSelectedLabel('sans', { sans: null })).toBe('sans');
+    });
   });
 });

--- a/packages/react/src/internals/resolveValueLabel.test.ts
+++ b/packages/react/src/internals/resolveValueLabel.test.ts
@@ -133,4 +133,27 @@ describe('resolveValueLabel', () => {
       expect(hasNullItemLabel(undefined)).toBe(false);
     });
   });
+
+  describe('record items with prototype member names', () => {
+    it('falls back to the stringified label when the value matches an Object.prototype member', () => {
+      const items = { sans: 'Sans-serif', serif: 'Serif', mono: 'Monospace' };
+
+      expect(resolveSelectedLabel('constructor', items)).toBe('constructor');
+      expect(resolveSelectedLabel('toString', items)).toBe('toString');
+      expect(resolveSelectedLabel('hasOwnProperty', items)).toBe('hasOwnProperty');
+      expect(resolveSelectedLabel('__proto__', items)).toBe('__proto__');
+    });
+
+    it('resolves an own key that matches an Object.prototype member', () => {
+      const items = { constructor: 'Custom constructor', sans: 'Sans-serif' };
+
+      expect(resolveSelectedLabel('constructor', items)).toBe('Custom constructor');
+    });
+
+    it('keeps resolving the null placeholder key in a record', () => {
+      const items = { null: 'None', sans: 'Sans-serif' };
+
+      expect(resolveSelectedLabel(null, items)).toBe('None');
+    });
+  });
 });

--- a/packages/react/src/internals/resolveValueLabel.tsx
+++ b/packages/react/src/internals/resolveValueLabel.tsx
@@ -121,7 +121,7 @@ export function resolveSelectedLabel(
 
   // Items provided as plain record map
   if (items && !Array.isArray(items)) {
-    return (items as any)[value] ?? fallback();
+    return Object.hasOwn(items, value) ? (items as any)[value] : fallback();
   }
 
   // Items provided as array (flat or grouped)

--- a/packages/react/src/internals/resolveValueLabel.tsx
+++ b/packages/react/src/internals/resolveValueLabel.tsx
@@ -121,7 +121,8 @@ export function resolveSelectedLabel(
 
   // Items provided as plain record map
   if (items && !Array.isArray(items)) {
-    return Object.hasOwn(items, value) ? (items as any)[value] : fallback();
+    const label = Object.hasOwn(items, value) ? (items as any)[value] : undefined;
+    return label ?? fallback();
   }
 
   // Items provided as array (flat or grouped)


### PR DESCRIPTION
Fixes #5517

## Summary

When `items` is provided as a plain record map, `resolveSelectedLabel` read the label with `(items as any)[value] ?? fallback()`. The bracket lookup walks the prototype chain, so a selected value matching an `Object.prototype` member (`constructor`, `toString`, `hasOwnProperty`, `__proto__`, …) resolved to the inherited **function** instead of the fallback label. Since functions are never `null`/`undefined`, the `??` fallback never ran, and rendering the value via `Select.Value` / `Combobox.Value` crashed with "Functions are not valid as a React child."

The lookup now only reads own keys via `Object.hasOwn`, preserving the documented `null` placeholder key behavior (coerced to `"null"`).

## Why this is the established pattern in the codebase

This is the same prototype-chain trap that `CheckboxGroup` already guards against — checkbox values are consumer data, so a value like `constructor` must not read off `Object.prototype`:

- `checkbox-group/useCheckboxGroupParent.ts:17-18` uses a `Map` instead of an object for its value registry, with an explicit comment:
  > A `Map` rather than an object: checkbox values are consumer data, and a value like `constructor` would otherwise read straight off `Object.prototype`.
- `checkbox-group/useCheckboxGroupParent.test.tsx:258` has a dedicated test, *"does not read aria-controls ids off Object.prototype"*.

Form errors are keyed by field name (also consumer data), so the same collision is guarded with `Object.hasOwn` in `form/Form.tsx:150`, `field/root/FieldRoot.tsx:94`, and `field/error/FieldError.tsx:41`. This change brings the remaining record lookup in `resolveSelectedLabel` in line with those.

## Test plan

- Added regression tests in `resolveValueLabel.test.ts` covering:
  - prototype-member values falling back to the stringified label
  - an own record key that happens to match a prototype member still resolving
  - the `null` placeholder key in a record still resolving
- `pnpm test:jsdom resolveValueLabel --no-watch`, `SelectValue`, `ComboboxValue` — all pass
- `pnpm eslint`, `pnpm typescript`, `pnpm prettier` — clean
