### PR TITLE
[navigation-menu] Add disabled data attribute to NavigationMenu.Trigger

### DIFF
--- a/docs/src/app/(docs)/react/components/navigation-menu/types.md
+++ b/docs/src/app/(docs)/react/components/navigation-menu/types.md
@@ -114,7 +114,7 @@ Renders a `<button>` element.
 | :-------------- | :--- | :------------------------------------------------------ |
 | data-popup-open | -    | Present when the corresponding navigation menu is open. |
 | data-pressed    | -    | Present when the trigger is pressed.                    |
-| data-disabled   | -    | Present when the component is disabled.                 |
+| data-disabled   | -    | Present when the trigger is disabled.                 |
 
 ### Trigger.Props
 

--- a/docs/src/app/(docs)/react/components/navigation-menu/types.md
+++ b/docs/src/app/(docs)/react/components/navigation-menu/types.md
@@ -103,6 +103,7 @@ Renders a `<button>` element.
 | Prop         | Type                                                                                                 | Default | Description                                                                                                                                                                                   |
 | :----------- | :--------------------------------------------------------------------------------------------------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | nativeButton | `boolean`                                                                                            | `true`  | Whether the component renders a native `<button>` element when replacing it&#xA;via the `render` prop.&#xA;Set to `false` if the rendered element is not a button (for example, `<div>`).     |
+| disabled     | `boolean`                                                                                            | `false` | Whether the component should ignore user interaction.                                                                                                                                         |
 | className    | `string \| ((state: NavigationMenu.Trigger.State) => string \| undefined)`                           | -       | CSS class applied to the element, or a function that&#xA;returns a class based on the component's state.                                                                                      |
 | style        | `React.CSSProperties \| ((state: NavigationMenu.Trigger.State) => React.CSSProperties \| undefined)` | -       | Style applied to the element, or a function that&#xA;returns a style object based on the component's state.                                                                                   |
 | render       | `ReactElement \| ((props: HTMLProps, state: NavigationMenu.Trigger.State) => ReactElement)`          | -       | Allows you to replace the component's HTML element&#xA;with a different tag, or compose it with another component. Accepts a `ReactElement` or a function that returns the element to render. |
@@ -113,6 +114,7 @@ Renders a `<button>` element.
 | :-------------- | :--- | :------------------------------------------------------ |
 | data-popup-open | -    | Present when the corresponding navigation menu is open. |
 | data-pressed    | -    | Present when the trigger is pressed.                    |
+| data-disabled   | -    | Present when the component is disabled.                 |
 
 ### Trigger.Props
 
@@ -124,6 +126,8 @@ Re-export of [Trigger](#trigger) props.
 type NavigationMenuTriggerState = {
   /** If `true`, the popup is open and the item is active. */
   open: boolean;
+  /** Whether the component should ignore user interaction. */
+  disabled: boolean;
 };
 ```
 

--- a/docs/src/app/(docs)/react/components/navigation-menu/types.md
+++ b/docs/src/app/(docs)/react/components/navigation-menu/types.md
@@ -114,7 +114,7 @@ Renders a `<button>` element.
 | :-------------- | :--- | :------------------------------------------------------ |
 | data-popup-open | -    | Present when the corresponding navigation menu is open. |
 | data-pressed    | -    | Present when the trigger is pressed.                    |
-| data-disabled   | -    | Present when the trigger is disabled.                 |
+| data-disabled   | -    | Present when the trigger is disabled.                   |
 
 ### Trigger.Props
 

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -1113,8 +1113,8 @@ A collection of links and menus for website navigation.
   - Navigation Menu - Root
     - Props: actionsRef, className, closeDelay, defaultValue, delay, onOpenChangeComplete, onValueChange, orientation, render, style, value
   - Navigation Menu - Trigger
-    - Props: className, nativeButton, render, style
-    - Data Attributes: data-popup-open, data-pressed
+    - Props: className, disabled, nativeButton, render, style
+    - Data Attributes: data-disabled, data-popup-open, data-pressed
   - Navigation Menu - Icon
     - Props: className, render, style
     - Data Attributes: data-popup-open

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
@@ -3,7 +3,7 @@ import { expect, vi } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
-import { screen, flushMicrotasks, waitFor, act } from '@mui/internal-test-utils';
+import { screen, flushMicrotasks, waitFor, act, fireEvent } from '@mui/internal-test-utils';
 import userEvent from '@testing-library/user-event';
 
 const rapidHoverAnimationStyles = `
@@ -134,6 +134,35 @@ describe('<NavigationMenu.Trigger />', () => {
       );
     },
   }));
+
+  it('applies the data-disabled style hook only when disabled', async () => {
+    function App() {
+      const [disabled, setDisabled] = React.useState(true);
+      return (
+        <div>
+          <NavigationMenu.Root>
+            <NavigationMenu.List>
+              <NavigationMenu.Item>
+                <NavigationMenu.Trigger disabled={disabled} data-testid="trigger">
+                  Overview
+                </NavigationMenu.Trigger>
+              </NavigationMenu.Item>
+            </NavigationMenu.List>
+          </NavigationMenu.Root>
+          <button type="button" onClick={() => setDisabled(false)}>
+            enable
+          </button>
+        </div>
+      );
+    }
+
+    await render(<App />);
+    const trigger = screen.getByTestId('trigger');
+    expect(trigger).toHaveAttribute('data-disabled', '');
+
+    fireEvent.click(screen.getByText('enable'));
+    expect(trigger).not.toHaveAttribute('data-disabled');
+  });
 
   it('opens a vertical menu with the mirrored arrow key in RTL mode', async () => {
     await render(

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.tsx
@@ -74,7 +74,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
     className,
     style,
     nativeButton = true,
-    disabled,
+    disabled = false,
     ...elementProps
   } = componentProps;
 
@@ -655,6 +655,7 @@ export const NavigationMenuTrigger = React.forwardRef(function NavigationMenuTri
 
   const state: NavigationMenuTriggerState = {
     open: isActiveItem,
+    disabled,
   };
 
   function handleSetPointerType(event: React.PointerEvent) {
@@ -807,10 +808,20 @@ export interface NavigationMenuTriggerState {
    * If `true`, the popup is open and the item is active.
    */
   open: boolean;
+  /**
+   * Whether the component should ignore user interaction.
+   */
+  disabled: boolean;
 }
 
 export interface NavigationMenuTriggerProps
-  extends NativeButtonProps, BaseUIComponentProps<'button', NavigationMenuTriggerState> {}
+  extends NativeButtonProps, BaseUIComponentProps<'button', NavigationMenuTriggerState> {
+  /**
+   * Whether the component should ignore user interaction.
+   * @default false
+   */
+  disabled?: boolean | undefined;
+}
 
 export namespace NavigationMenuTrigger {
   export type State = NavigationMenuTriggerState;

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTriggerDataAttributes.ts
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTriggerDataAttributes.ts
@@ -9,4 +9,8 @@ export enum NavigationMenuTriggerDataAttributes {
    * Present when the trigger is pressed.
    */
   pressed = CommonTriggerDataAttributes.pressed,
+  /**
+   * Present when the trigger is disabled.
+   */
+  disabled = 'data-disabled',
 }


### PR DESCRIPTION
A disabled `NavigationMenu.Trigger` didn't expose `data-disabled` (unlike every other trigger), because `disabled` was missing from its state, it was only inherited from `NativeButtonProps`, so it was also undocumented. This adds `disabled` to the state, props, enum, and generated docs, with a regression test.