### PR TITLE
[context menu] Add Backdrop API reference

### DIFF
--- a/docs/src/app/(docs)/react/components/context-menu/page.mdx
+++ b/docs/src/app/(docs)/react/components/context-menu/page.mdx
@@ -91,6 +91,10 @@ import { TypesContextMenu } from './types';
 
 <TypesContextMenu.Portal />
 
+### Backdrop
+
+<TypesContextMenu.Backdrop />
+
 ### Positioner
 
 <TypesContextMenu.Positioner />

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -561,6 +561,7 @@ A menu that appears at the pointer on right click or long press.
     - Root
     - Trigger
     - Portal
+    - Backdrop
     - Positioner
     - Popup
     - Arrow


### PR DESCRIPTION
Preview: https://deploy-preview-5522--base-ui.netlify.app/react/components/context-menu#backdrop

## Changes

- add `Backdrop` to the Context Menu API reference
- refresh the generated component index

## Why

`ContextMenu.Backdrop` is exported and included in the anatomy, but it was missing from the manually maintained API reference list.
