### PR TITLE
[menu][popover] Document data-disabled on Trigger

### DIFF
--- a/docs/src/app/(docs)/react/components/menu/types.md
+++ b/docs/src/app/(docs)/react/components/menu/types.md
@@ -129,6 +129,7 @@ Renders a `<button>` element.
 | :-------------- | :--- | :------------------------------------------- |
 | data-popup-open | -    | Present when the corresponding menu is open. |
 | data-pressed    | -    | Present when the trigger is pressed.         |
+| data-disabled   | -    | Present when the trigger is disabled.        |
 
 ### Trigger.Props
 

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -968,7 +968,7 @@ A list of actions in a dropdown, enhanced with keyboard navigation.
     - Props: actionsRef, children, closeParentOnEsc, defaultOpen, defaultTriggerId, disabled, handle, highlightItemOnHover, loopFocus, modal, onOpenChange, onOpenChangeComplete, open, orientation, triggerId
   - Menu - Trigger
     - Props: children, className, closeDelay, delay, disabled, handle, nativeButton, openOnHover, payload, render, style
-    - Data Attributes: data-popup-open, data-pressed
+    - Data Attributes: data-disabled, data-popup-open, data-pressed
   - Menu - Portal
     - Props: className, container, keepMounted, render, style
   - Menu - Backdrop
@@ -1281,7 +1281,7 @@ An accessible popup anchored to a button.
     - Props: actionsRef, children, defaultOpen, defaultTriggerId, handle, modal, onOpenChange, onOpenChangeComplete, open, triggerId
   - Popover - Trigger
     - Props: className, closeDelay, delay, handle, id, nativeButton, openOnHover, payload, render, style
-    - Data Attributes: data-popup-open, data-pressed
+    - Data Attributes: data-disabled, data-popup-open, data-pressed
   - Popover - Portal
     - Props: className, container, keepMounted, render, style
   - Popover - Backdrop

--- a/docs/src/app/(docs)/react/components/popover/types.md
+++ b/docs/src/app/(docs)/react/components/popover/types.md
@@ -109,6 +109,7 @@ Renders a `<button>` element.
 | :-------------- | :--- | :---------------------------------------------- |
 | data-popup-open | -    | Present when the corresponding popover is open. |
 | data-pressed    | -    | Present when the trigger is pressed.            |
+| data-disabled   | -    | Present when the trigger is disabled.           |
 
 ### Trigger.Props
 

--- a/packages/react/src/menu/trigger/MenuTriggerDataAttributes.ts
+++ b/packages/react/src/menu/trigger/MenuTriggerDataAttributes.ts
@@ -9,4 +9,8 @@ export enum MenuTriggerDataAttributes {
    * Present when the trigger is pressed.
    */
   pressed = CommonTriggerDataAttributes.pressed,
+  /**
+   * Present when the trigger is disabled.
+   */
+  disabled = 'data-disabled',
 }

--- a/packages/react/src/popover/trigger/PopoverTriggerDataAttributes.ts
+++ b/packages/react/src/popover/trigger/PopoverTriggerDataAttributes.ts
@@ -9,4 +9,8 @@ export enum PopoverTriggerDataAttributes {
    * Present when the trigger is pressed.
    */
   pressed = CommonTriggerDataAttributes.pressed,
+  /**
+   * Present when the trigger is disabled.
+   */
+  disabled = 'data-disabled',
 }


### PR DESCRIPTION
Menu.Trigger and Popover.Trigger already emit `data-disabled` because `disabled` is part of their state, but neither DataAttributes enum declared it, so the generated docs tables omitted it.

Follow-up to #5521, matching Dialog, AlertDialog, Select, Accordion, Combobox, Autocomplete, NavigationMenu.Trigger and Menu.SubmenuTrigger.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
