### PR TITLE
[utils] Make animation frame cancellation idempotent

### DIFF
--- a/packages/utils/src/useAnimationFrame.test.ts
+++ b/packages/utils/src/useAnimationFrame.test.ts
@@ -1,0 +1,32 @@
+import { expect, vi } from 'vitest';
+import { AnimationFrame, resetAnimationFrameScheduler } from './useAnimationFrame';
+
+describe('AnimationFrame', () => {
+  beforeEach(() => {
+    resetAnimationFrameScheduler();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetAnimationFrameScheduler();
+  });
+
+  it('keeps callback accounting correct when a frame is canceled more than once', () => {
+    const callbacks: FrameRequestCallback[] = [];
+    vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((callback) => {
+      callbacks.push(callback);
+      return callbacks.length;
+    });
+
+    const firstId = AnimationFrame.request(() => {});
+    AnimationFrame.cancel(firstId);
+    AnimationFrame.cancel(firstId);
+
+    const secondCallback = vi.fn();
+    AnimationFrame.request(secondCallback);
+
+    callbacks[0]?.(0);
+
+    expect(secondCallback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/utils/src/useAnimationFrame.ts
+++ b/packages/utils/src/useAnimationFrame.ts
@@ -75,6 +75,9 @@ class Scheduler {
     if (index < 0 || index >= this.callbacks.length) {
       return;
     }
+    if (this.callbacks[index] === null) {
+      return;
+    }
     this.callbacks[index] = null;
     this.callbacksCount -= 1;
   }


### PR DESCRIPTION
Canceling an animation frame twice could prevent the next frames from running. Includes a regression test.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
