### PR TITLE
[all components] Reduce animation completion work

### DIFF
--- a/packages/react/src/avatar/image/AvatarImage.test.tsx
+++ b/packages/react/src/avatar/image/AvatarImage.test.tsx
@@ -222,8 +222,16 @@ describe('<Avatar.Image />', () => {
       globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
 
       let transitionFinished = false;
+      const getAnimations = vi.fn((): Animation[] => []);
+
       function notifyTransitionFinished() {
         transitionFinished = true;
+      }
+
+      function handleImageRef(element: HTMLImageElement | null) {
+        if (element) {
+          element.getAnimations = getAnimations;
+        }
       }
 
       const style = `
@@ -254,6 +262,7 @@ describe('<Avatar.Image />', () => {
                 className="animation-test-image"
                 data-testid="image"
                 onTransitionEnd={notifyTransitionFinished}
+                ref={handleImageRef}
                 src={showImage ? 'avatar.png' : undefined}
               />
             </Avatar.Root>
@@ -271,6 +280,7 @@ describe('<Avatar.Image />', () => {
       });
 
       expect(screen.getByTestId('image')).not.toBe(null);
+      expect(getAnimations).not.toHaveBeenCalled();
     });
 
     it('applies data-ending-style before unmount', async () => {

--- a/packages/react/src/avatar/image/AvatarImage.tsx
+++ b/packages/react/src/avatar/image/AvatarImage.tsx
@@ -59,6 +59,7 @@ export const AvatarImage = React.forwardRef(function AvatarImage(
   }, [setImageLoadingStatus]);
 
   useOpenChangeComplete({
+    enabled: !isVisible,
     open: isVisible,
     ref: imageRef,
     onComplete() {

--- a/packages/react/src/checkbox/indicator/CheckboxIndicator.test.tsx
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicator.test.tsx
@@ -202,8 +202,16 @@ describe('<Checkbox.Indicator />', () => {
       globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
 
       let transitionFinished = false;
+      const getAnimations = vi.fn((): Animation[] => []);
+
       function notifyTransitionFinished() {
         transitionFinished = true;
+      }
+
+      function handleIndicatorRef(element: HTMLSpanElement | null) {
+        if (element) {
+          element.getAnimations = getAnimations;
+        }
       }
 
       const style = `
@@ -234,6 +242,7 @@ describe('<Checkbox.Indicator />', () => {
                 className="animation-test-indicator"
                 data-testid="indicator"
                 onTransitionEnd={notifyTransitionFinished}
+                ref={handleIndicatorRef}
               />
             </Checkbox.Root>
           </div>
@@ -250,6 +259,7 @@ describe('<Checkbox.Indicator />', () => {
       });
 
       expect(screen.getByTestId('indicator')).not.toBe(null);
+      expect(getAnimations).not.toHaveBeenCalled();
     });
 
     it('applies data-ending-style before unmount', async () => {

--- a/packages/react/src/checkbox/indicator/CheckboxIndicator.test.tsx
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicator.test.tsx
@@ -301,5 +301,68 @@ describe('<Checkbox.Indicator />', () => {
         expect(screen.queryByTestId('indicator')).toBe(null);
       });
     });
+
+    it('removes all indicators in a single commit when multiple checkboxes are unchecked', async () => {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+      const style = `
+        @keyframes test-anim {
+          to {
+            opacity: 0;
+          }
+        }
+
+        .animation-test-indicator[data-ending-style] {
+          animation: test-anim 1ms;
+        }
+      `;
+
+      let commitCount = 0;
+
+      function Test() {
+        const [checked, setChecked] = React.useState(true);
+
+        function handleUncheck() {
+          setChecked(false);
+        }
+
+        return (
+          <div>
+            {/* eslint-disable-next-line react/no-danger */}
+            <style dangerouslySetInnerHTML={{ __html: style }} />
+            <button onClick={handleUncheck}>Uncheck</button>
+            <React.Profiler
+              id="checkboxes"
+              onRender={() => {
+                commitCount += 1;
+              }}
+            >
+              {Array.from({ length: 10 }, (_, index) => (
+                <Checkbox.Root checked={checked} key={index}>
+                  <Checkbox.Indicator
+                    className="animation-test-indicator"
+                    data-testid={`indicator-${index}`}
+                  />
+                </Checkbox.Root>
+              ))}
+            </React.Profiler>
+          </div>
+        );
+      }
+
+      const { user } = await render(<Test />);
+
+      const commitCountBefore = commitCount;
+
+      await user.click(screen.getByText('Uncheck'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('indicator-0')).toBe(null);
+      });
+      expect(screen.queryByTestId('indicator-9')).toBe(null);
+
+      // One commit for the uncheck itself, one batched commit removing every indicator.
+      expect(commitCount).toBe(commitCountBefore + 2);
+    });
   });
 });

--- a/packages/react/src/checkbox/indicator/CheckboxIndicator.test.tsx
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicator.test.tsx
@@ -317,7 +317,7 @@ describe('<Checkbox.Indicator />', () => {
         }
       `;
 
-      let commitCount = 0;
+      const indicatorCounts: number[] = [];
 
       function Test() {
         const [checked, setChecked] = React.useState(true);
@@ -334,7 +334,9 @@ describe('<Checkbox.Indicator />', () => {
             <React.Profiler
               id="checkboxes"
               onRender={() => {
-                commitCount += 1;
+                indicatorCounts.push(
+                  document.querySelectorAll('[data-testid^="indicator-"]').length,
+                );
               }}
             >
               {Array.from({ length: 10 }, (_, index) => (
@@ -352,7 +354,7 @@ describe('<Checkbox.Indicator />', () => {
 
       const { user } = await render(<Test />);
 
-      const commitCountBefore = commitCount;
+      const commitsBeforeUncheck = indicatorCounts.length;
 
       await user.click(screen.getByText('Uncheck'));
 
@@ -361,8 +363,9 @@ describe('<Checkbox.Indicator />', () => {
       });
       expect(screen.queryByTestId('indicator-9')).toBe(null);
 
-      // One commit for the uncheck itself, one batched commit removing every indicator.
-      expect(commitCount).toBe(commitCountBefore + 2);
+      const countsAfterUncheck = indicatorCounts.slice(commitsBeforeUncheck);
+      expect(countsAfterUncheck).toContain(0);
+      expect(countsAfterUncheck.every((count) => count === 0 || count === 10)).toBe(true);
     });
   });
 });

--- a/packages/react/src/checkbox/indicator/CheckboxIndicator.tsx
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicator.tsx
@@ -36,6 +36,7 @@ export const CheckboxIndicator = React.forwardRef(function CheckboxIndicator(
   };
 
   useOpenChangeComplete({
+    batch: true,
     open: rendered,
     ref: indicatorRef,
     onComplete() {

--- a/packages/react/src/checkbox/indicator/CheckboxIndicator.tsx
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicator.tsx
@@ -37,6 +37,7 @@ export const CheckboxIndicator = React.forwardRef(function CheckboxIndicator(
 
   useOpenChangeComplete({
     batch: true,
+    enabled: !rendered,
     open: rendered,
     ref: indicatorRef,
     onComplete() {

--- a/packages/react/src/combobox/item-indicator/ComboboxItemIndicator.tsx
+++ b/packages/react/src/combobox/item-indicator/ComboboxItemIndicator.tsx
@@ -63,6 +63,7 @@ const Inner = React.memo(
 
       useOpenChangeComplete({
         batch: true,
+        enabled: !selected,
         open: selected,
         ref: indicatorRef,
         onComplete() {

--- a/packages/react/src/combobox/item-indicator/ComboboxItemIndicator.tsx
+++ b/packages/react/src/combobox/item-indicator/ComboboxItemIndicator.tsx
@@ -62,6 +62,7 @@ const Inner = React.memo(
       });
 
       useOpenChangeComplete({
+        batch: true,
         open: selected,
         ref: indicatorRef,
         onComplete() {

--- a/packages/react/src/internals/useAnimationsFinished.test.tsx
+++ b/packages/react/src/internals/useAnimationsFinished.test.tsx
@@ -203,69 +203,6 @@ describe('useAnimationsFinished', () => {
     }
   });
 
-  it('runs every batched callback when one throws', async () => {
-    const animationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
-    globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
-
-    const first = createAnimation();
-    const second = createAnimation();
-    const error = new Error('test');
-    const onSecondFinished = vi.fn();
-    const firstGetAnimations = vi.fn(() => [first.animation]);
-    const secondGetAnimations = vi.fn(() => [second.animation]);
-
-    try {
-      await render(
-        <React.Fragment>
-          <Test
-            batch
-            getAnimations={firstGetAnimations}
-            onFinished={() => {
-              throw error;
-            }}
-          />
-          <Test batch getAnimations={secondGetAnimations} onFinished={onSecondFinished} />
-        </React.Fragment>,
-      );
-
-      await waitFor(() => {
-        expect(firstGetAnimations).toHaveBeenCalled();
-      });
-      await waitFor(() => {
-        expect(secondGetAnimations).toHaveBeenCalled();
-      });
-
-      const queued: VoidFunction[] = [];
-      vi.spyOn(globalThis, 'queueMicrotask').mockImplementation((callback) => {
-        queued.push(callback);
-      });
-
-      await act(async () => {
-        first.finish();
-        second.finish();
-        await flushMicrotasks();
-      });
-
-      expect(queued.length).toBeGreaterThan(0);
-
-      const thrown: unknown[] = [];
-      while (queued.length > 0) {
-        const callback = queued.shift()!;
-        try {
-          callback();
-        } catch (caught) {
-          thrown.push(caught);
-        }
-      }
-
-      expect(thrown).toContain(error);
-      expect(onSecondFinished).toHaveBeenCalledTimes(1);
-    } finally {
-      vi.restoreAllMocks();
-      globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
-    }
-  });
-
   it('skips a callback whose signal aborts while the batch is flushing', async () => {
     const animationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
     globalThis.BASE_UI_ANIMATIONS_DISABLED = false;

--- a/packages/react/src/internals/useAnimationsFinished.test.tsx
+++ b/packages/react/src/internals/useAnimationsFinished.test.tsx
@@ -28,9 +28,10 @@ function createAnimation() {
 interface TestProps {
   getAnimations: () => Animation[];
   onFinished: () => void;
+  signal?: AbortSignal;
 }
 
-function Test({ getAnimations, onFinished }: TestProps) {
+function Test({ getAnimations, onFinished, signal }: TestProps) {
   const ref = React.useRef<HTMLDivElement>(null);
   const runOnceAnimationsFinish = useAnimationsFinished(ref);
 
@@ -41,8 +42,8 @@ function Test({ getAnimations, onFinished }: TestProps) {
   }, [getAnimations]);
 
   React.useEffect(() => {
-    runOnceAnimationsFinish(onFinished);
-  }, [onFinished, runOnceAnimationsFinish]);
+    runOnceAnimationsFinish(onFinished, signal ?? null);
+  }, [onFinished, runOnceAnimationsFinish, signal]);
 
   return <div ref={ref} />;
 }
@@ -210,7 +211,6 @@ describe('useAnimationsFinished', () => {
     const onSecondFinished = vi.fn();
     const firstGetAnimations = vi.fn(() => [first.animation]);
     const secondGetAnimations = vi.fn(() => [second.animation]);
-    let flushQueuedCallbacks: VoidFunction | undefined;
 
     try {
       await render(
@@ -232,8 +232,9 @@ describe('useAnimationsFinished', () => {
         expect(secondGetAnimations).toHaveBeenCalled();
       });
 
+      const queued: VoidFunction[] = [];
       vi.spyOn(globalThis, 'queueMicrotask').mockImplementation((callback) => {
-        flushQueuedCallbacks = callback;
+        queued.push(callback);
       });
 
       await act(async () => {
@@ -242,11 +243,66 @@ describe('useAnimationsFinished', () => {
         await flushMicrotasks();
       });
 
-      expect(flushQueuedCallbacks).not.toBeUndefined();
-      expect(() => flushQueuedCallbacks!()).toThrow(error);
+      expect(queued.length).toBeGreaterThan(0);
+
+      const thrown: unknown[] = [];
+      while (queued.length > 0) {
+        const callback = queued.shift()!;
+        try {
+          callback();
+        } catch (caught) {
+          thrown.push(caught);
+        }
+      }
+
+      expect(thrown).toContain(error);
       expect(onSecondFinished).toHaveBeenCalledTimes(1);
     } finally {
       vi.restoreAllMocks();
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
+    }
+  });
+
+  it('skips a callback whose signal aborts while the batch is flushing', async () => {
+    const animationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
+    globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+    const first = createAnimation();
+    const second = createAnimation();
+    const secondController = new AbortController();
+    const onFirstFinished = vi.fn(() => secondController.abort());
+    const onSecondFinished = vi.fn();
+    const firstGetAnimations = vi.fn(() => [first.animation]);
+    const secondGetAnimations = vi.fn(() => [second.animation]);
+
+    try {
+      await render(
+        <React.Fragment>
+          <Test getAnimations={firstGetAnimations} onFinished={onFirstFinished} />
+          <Test
+            getAnimations={secondGetAnimations}
+            onFinished={onSecondFinished}
+            signal={secondController.signal}
+          />
+        </React.Fragment>,
+      );
+
+      await waitFor(() => {
+        expect(firstGetAnimations).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(secondGetAnimations).toHaveBeenCalled();
+      });
+
+      await act(async () => {
+        first.finish();
+        second.finish();
+        await flushMicrotasks();
+      });
+
+      expect(onFirstFinished).toHaveBeenCalledTimes(1);
+      expect(onSecondFinished).not.toHaveBeenCalled();
+    } finally {
       globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
     }
   });

--- a/packages/react/src/internals/useAnimationsFinished.test.tsx
+++ b/packages/react/src/internals/useAnimationsFinished.test.tsx
@@ -199,4 +199,55 @@ describe('useAnimationsFinished', () => {
       globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
     }
   });
+
+  it('runs every batched callback when one throws', async () => {
+    const animationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
+    globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+    const first = createAnimation();
+    const second = createAnimation();
+    const error = new Error('test');
+    const onSecondFinished = vi.fn();
+    const firstGetAnimations = vi.fn(() => [first.animation]);
+    const secondGetAnimations = vi.fn(() => [second.animation]);
+    let flushQueuedCallbacks: VoidFunction | undefined;
+
+    try {
+      await render(
+        <React.Fragment>
+          <Test
+            getAnimations={firstGetAnimations}
+            onFinished={() => {
+              throw error;
+            }}
+          />
+          <Test getAnimations={secondGetAnimations} onFinished={onSecondFinished} />
+        </React.Fragment>,
+      );
+
+      await waitFor(() => {
+        expect(firstGetAnimations).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(secondGetAnimations).toHaveBeenCalled();
+      });
+
+      vi.spyOn(globalThis, 'queueMicrotask').mockImplementation((callback) => {
+        flushQueuedCallbacks = callback;
+      });
+
+      await act(async () => {
+        first.finish();
+        second.finish();
+        await flushMicrotasks();
+      });
+
+      expect(flushQueuedCallbacks).not.toBeUndefined();
+      expect(() => flushQueuedCallbacks!()).toThrow(error);
+      expect(onSecondFinished).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.restoreAllMocks();
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
+    }
+  });
 });

--- a/packages/react/src/internals/useAnimationsFinished.test.tsx
+++ b/packages/react/src/internals/useAnimationsFinished.test.tsx
@@ -1,6 +1,6 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
-import { act, flushMicrotasks, waitFor } from '@mui/internal-test-utils';
+import { act, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { createRenderer } from '#test-utils';
 import { useAnimationsFinished } from './useAnimationsFinished';
@@ -129,6 +129,72 @@ describe('useAnimationsFinished', () => {
       });
 
       expect(onFinished).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
+    }
+  });
+
+  it('batches callbacks that finish in the same microtask into a single commit', async () => {
+    const animationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
+    globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+    const first = createAnimation();
+    const second = createAnimation();
+    const getAnimationsCallCounts = [0, 0];
+    let commitCount = 0;
+
+    function Item({ index, animation }: { index: number; animation: Animation }) {
+      const ref = React.useRef<HTMLDivElement>(null);
+      const runOnceAnimationsFinish = useAnimationsFinished(ref);
+      const [mounted, setMounted] = React.useState(true);
+
+      useIsoLayoutEffect(() => {
+        if (ref.current) {
+          ref.current.getAnimations = () => {
+            getAnimationsCallCounts[index] += 1;
+            return [animation];
+          };
+        }
+      });
+
+      React.useEffect(() => {
+        runOnceAnimationsFinish(() => setMounted(false));
+      }, [runOnceAnimationsFinish]);
+
+      return mounted ? <div data-testid={`item-${index}`} ref={ref} /> : null;
+    }
+
+    try {
+      await render(
+        <React.Profiler
+          id="test"
+          onRender={() => {
+            commitCount += 1;
+          }}
+        >
+          <Item index={0} animation={first.animation} />
+          <Item index={1} animation={second.animation} />
+        </React.Profiler>,
+      );
+
+      await waitFor(() => {
+        expect(getAnimationsCallCounts[0]).toBeGreaterThan(0);
+      });
+      await waitFor(() => {
+        expect(getAnimationsCallCounts[1]).toBeGreaterThan(0);
+      });
+
+      const commitCountBefore = commitCount;
+
+      await act(async () => {
+        first.finish();
+        second.finish();
+        await flushMicrotasks();
+      });
+
+      expect(screen.queryByTestId('item-0')).toBeNull();
+      expect(screen.queryByTestId('item-1')).toBeNull();
+      expect(commitCount).toBe(commitCountBefore + 1);
     } finally {
       globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
     }

--- a/packages/react/src/internals/useAnimationsFinished.test.tsx
+++ b/packages/react/src/internals/useAnimationsFinished.test.tsx
@@ -2,6 +2,7 @@ import { expect, vi } from 'vitest';
 import * as React from 'react';
 import { act, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
+import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { createRenderer } from '#test-utils';
 import { useAnimationsFinished } from './useAnimationsFinished';
 
@@ -29,11 +30,12 @@ interface TestProps {
   getAnimations: () => Animation[];
   onFinished: () => void;
   signal?: AbortSignal;
+  batch?: boolean;
 }
 
-function Test({ getAnimations, onFinished, signal }: TestProps) {
+function Test({ getAnimations, onFinished, signal, batch }: TestProps) {
   const ref = React.useRef<HTMLDivElement>(null);
-  const runOnceAnimationsFinish = useAnimationsFinished(ref);
+  const runOnceAnimationsFinish = useAnimationsFinished(ref, false, batch);
 
   useIsoLayoutEffect(() => {
     if (ref.current) {
@@ -135,7 +137,7 @@ describe('useAnimationsFinished', () => {
     }
   });
 
-  it('batches callbacks that finish in the same microtask into a single commit', async () => {
+  it('batches opted-in callbacks that finish in the same microtask into a single commit', async () => {
     const animationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
     globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
 
@@ -146,7 +148,7 @@ describe('useAnimationsFinished', () => {
 
     function Item({ index, animation }: { index: number; animation: Animation }) {
       const ref = React.useRef<HTMLDivElement>(null);
-      const runOnceAnimationsFinish = useAnimationsFinished(ref);
+      const runOnceAnimationsFinish = useAnimationsFinished(ref, false, true);
       const [mounted, setMounted] = React.useState(true);
 
       useIsoLayoutEffect(() => {
@@ -216,12 +218,13 @@ describe('useAnimationsFinished', () => {
       await render(
         <React.Fragment>
           <Test
+            batch
             getAnimations={firstGetAnimations}
             onFinished={() => {
               throw error;
             }}
           />
-          <Test getAnimations={secondGetAnimations} onFinished={onSecondFinished} />
+          <Test batch getAnimations={secondGetAnimations} onFinished={onSecondFinished} />
         </React.Fragment>,
       );
 
@@ -278,8 +281,9 @@ describe('useAnimationsFinished', () => {
     try {
       await render(
         <React.Fragment>
-          <Test getAnimations={firstGetAnimations} onFinished={onFirstFinished} />
+          <Test batch getAnimations={firstGetAnimations} onFinished={onFirstFinished} />
           <Test
+            batch
             getAnimations={secondGetAnimations}
             onFinished={onSecondFinished}
             signal={secondController.signal}
@@ -302,6 +306,91 @@ describe('useAnimationsFinished', () => {
 
       expect(onFirstFinished).toHaveBeenCalledTimes(1);
       expect(onSecondFinished).not.toHaveBeenCalled();
+    } finally {
+      globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
+    }
+  });
+
+  it('commits each callback separately by default so later callbacks observe earlier updates', async () => {
+    const animationsDisabled = globalThis.BASE_UI_ANIMATIONS_DISABLED;
+    globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
+
+    const first = createAnimation();
+    const second = createAnimation();
+    const firstGetAnimations = vi.fn(() => [first.animation]);
+    const secondGetAnimations = vi.fn(() => [second.animation]);
+    const onSecondUnmount = vi.fn();
+
+    interface PopupProps {
+      open: boolean;
+      getAnimations: () => Animation[];
+      onCloseComplete: () => void;
+    }
+
+    // Mirrors `useOpenChangeComplete`: the completion reads the latest `open` and only
+    // unmounts while the popup is still closed.
+    function Popup({ open, getAnimations, onCloseComplete }: PopupProps) {
+      const ref = React.useRef<HTMLDivElement>(null);
+      const runOnceAnimationsFinish = useAnimationsFinished(ref);
+
+      const onComplete = useStableCallback(() => {
+        if (!open) {
+          onCloseComplete();
+        }
+      });
+
+      useIsoLayoutEffect(() => {
+        if (ref.current) {
+          ref.current.getAnimations = getAnimations;
+        }
+      }, [getAnimations]);
+
+      React.useEffect(() => {
+        const abortController = new AbortController();
+        runOnceAnimationsFinish(onComplete, abortController.signal);
+        return () => abortController.abort();
+      }, [open, onComplete, runOnceAnimationsFinish]);
+
+      return <div ref={ref} />;
+    }
+
+    function App() {
+      const [secondOpen, setSecondOpen] = React.useState(false);
+      return (
+        <React.Fragment>
+          <Popup
+            open={false}
+            getAnimations={firstGetAnimations}
+            onCloseComplete={() => setSecondOpen(true)}
+          />
+          <Popup
+            open={secondOpen}
+            getAnimations={secondGetAnimations}
+            onCloseComplete={onSecondUnmount}
+          />
+        </React.Fragment>
+      );
+    }
+
+    try {
+      await render(<App />);
+
+      await waitFor(() => {
+        expect(firstGetAnimations).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(secondGetAnimations).toHaveBeenCalled();
+      });
+
+      // Both popups are closing. The first popup's close completion reopens the second,
+      // which must prevent the second popup's queued completion from unmounting it.
+      await act(async () => {
+        first.finish();
+        second.finish();
+        await flushMicrotasks();
+      });
+
+      expect(onSecondUnmount).not.toHaveBeenCalled();
     } finally {
       globalThis.BASE_UI_ANIMATIONS_DISABLED = animationsDisabled;
     }

--- a/packages/react/src/internals/useAnimationsFinished.ts
+++ b/packages/react/src/internals/useAnimationsFinished.ts
@@ -25,13 +25,27 @@ function flushBeforePaint(fn: () => void, signal: AbortSignal | null) {
     pendingCallbacks = callbacks;
     queueMicrotask(() => {
       pendingCallbacks = null;
+      let firstError: unknown;
+      let didError = false;
+
       ReactDOM.flushSync(() => {
         for (const callback of callbacks) {
           if (!callback.signal?.aborted) {
-            callback.fn();
+            try {
+              callback.fn();
+            } catch (error) {
+              if (!didError) {
+                firstError = error;
+                didError = true;
+              }
+            }
           }
         }
       });
+
+      if (didError) {
+        throw firstError;
+      }
     });
   }
   pendingCallbacks.push({ fn, signal });

--- a/packages/react/src/internals/useAnimationsFinished.ts
+++ b/packages/react/src/internals/useAnimationsFinished.ts
@@ -42,11 +42,15 @@ function flushBeforePaint(fn: () => void) {
  * If an animation is canceled, waits for any replacement animations before executing.
  * @param elementOrRef - The element to watch for animations.
  * @param waitForStartingStyleRemoved - Whether to wait for [data-starting-style] to be removed before checking for animations.
+ * @param batch - Whether completions ready in the same microtask may be coalesced into a single
+ * commit. A batched callback runs before earlier callbacks' React updates have committed, so only
+ * opt in when the callback doesn't read state that another completion can change.
  * @returns A function that takes a callback to execute once all animations have finished, and an optional AbortSignal to abort the callback
  */
 export function useAnimationsFinished(
   elementOrRef: React.RefObject<HTMLElement | null> | HTMLElement | null,
   waitForStartingStyleRemoved = false,
+  batch = false,
 ) {
   const frame = useAnimationFrame();
 
@@ -73,6 +77,15 @@ export function useAnimationsFinished(
       const resolvedElement = element;
 
       const done = () => {
+        if (!batch) {
+          // Synchronously flush the unmounting of the component so that the browser doesn't
+          // paint: https://github.com/mui/base-ui/issues/979
+          // Each callback gets its own commit so that later completions observe the React
+          // updates caused by earlier ones.
+          ReactDOM.flushSync(fnToExecute);
+          return;
+        }
+
         flushBeforePaint(() => {
           // Re-check at flush time: the signal may abort between queueing and the flush.
           if (!signal?.aborted) {

--- a/packages/react/src/internals/useAnimationsFinished.ts
+++ b/packages/react/src/internals/useAnimationsFinished.ts
@@ -5,12 +5,7 @@ import { useAnimationFrame } from '@base-ui/utils/useAnimationFrame';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { resolveRef } from '../utils/resolveRef';
 
-interface PendingCallback {
-  fn: () => void;
-  signal: AbortSignal | null;
-}
-
-let pendingCallbacks: PendingCallback[] | null = null;
+let pendingCallbacks: Array<() => void> | null = null;
 
 /**
  * Runs the callback in a synchronous flush before the browser paints, so that the
@@ -19,36 +14,27 @@ let pendingCallbacks: PendingCallback[] | null = null;
  * whose animations finish together) are batched into a single commit:
  * https://github.com/mui/base-ui/issues/5481
  */
-function flushBeforePaint(fn: () => void, signal: AbortSignal | null) {
-  if (pendingCallbacks === null) {
-    const callbacks: PendingCallback[] = [];
+function flushBeforePaint(fn: () => void) {
+  if (!pendingCallbacks) {
+    const callbacks: Array<() => void> = [];
     pendingCallbacks = callbacks;
     queueMicrotask(() => {
       pendingCallbacks = null;
-      let firstError: unknown;
-      let didError = false;
-
       ReactDOM.flushSync(() => {
         for (const callback of callbacks) {
-          if (!callback.signal?.aborted) {
-            try {
-              callback.fn();
-            } catch (error) {
-              if (!didError) {
-                firstError = error;
-                didError = true;
-              }
-            }
+          try {
+            callback();
+          } catch (error) {
+            // Rethrow asynchronously so one callback's error can't drop the rest of the batch.
+            queueMicrotask(() => {
+              throw error;
+            });
           }
         }
       });
-
-      if (didError) {
-        throw firstError;
-      }
     });
   }
-  pendingCallbacks.push({ fn, signal });
+  pendingCallbacks.push(fn);
 }
 
 /**
@@ -87,7 +73,12 @@ export function useAnimationsFinished(
       const resolvedElement = element;
 
       const done = () => {
-        flushBeforePaint(fnToExecute, signal);
+        flushBeforePaint(() => {
+          // Re-check at flush time: the signal may abort between queueing and the flush.
+          if (!signal?.aborted) {
+            fnToExecute();
+          }
+        });
       };
 
       if (

--- a/packages/react/src/internals/useAnimationsFinished.ts
+++ b/packages/react/src/internals/useAnimationsFinished.ts
@@ -5,6 +5,38 @@ import { useAnimationFrame } from '@base-ui/utils/useAnimationFrame';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { resolveRef } from '../utils/resolveRef';
 
+interface PendingCallback {
+  fn: () => void;
+  signal: AbortSignal | null;
+}
+
+let pendingCallbacks: PendingCallback[] | null = null;
+
+/**
+ * Runs the callback in a synchronous flush before the browser paints, so that the
+ * browser doesn't paint an intermediate frame: https://github.com/mui/base-ui/issues/979
+ * Callbacks that become ready within the same microtask checkpoint (e.g. multiple elements
+ * whose animations finish together) are batched into a single commit:
+ * https://github.com/mui/base-ui/issues/5481
+ */
+function flushBeforePaint(fn: () => void, signal: AbortSignal | null) {
+  if (pendingCallbacks === null) {
+    const callbacks: PendingCallback[] = [];
+    pendingCallbacks = callbacks;
+    queueMicrotask(() => {
+      pendingCallbacks = null;
+      ReactDOM.flushSync(() => {
+        for (const callback of callbacks) {
+          if (!callback.signal?.aborted) {
+            callback.fn();
+          }
+        }
+      });
+    });
+  }
+  pendingCallbacks.push({ fn, signal });
+}
+
 /**
  * Executes a function once all animations have finished on the provided element.
  * If an animation is canceled, waits for any replacement animations before executing.
@@ -41,9 +73,7 @@ export function useAnimationsFinished(
       const resolvedElement = element;
 
       const done = () => {
-        // Synchronously flush the unmounting of the component so that the browser doesn't
-        // paint: https://github.com/mui/base-ui/issues/979
-        ReactDOM.flushSync(fnToExecute);
+        flushBeforePaint(fnToExecute, signal);
       };
 
       if (

--- a/packages/react/src/internals/useAnimationsFinished.ts
+++ b/packages/react/src/internals/useAnimationsFinished.ts
@@ -22,14 +22,7 @@ function flushBeforePaint(fn: () => void) {
       pendingCallbacks = null;
       ReactDOM.flushSync(() => {
         for (const callback of callbacks) {
-          try {
-            callback();
-          } catch (error) {
-            // Rethrow asynchronously so one callback's error can't drop the rest of the batch.
-            queueMicrotask(() => {
-              throw error;
-            });
-          }
+          callback();
         }
       });
     });

--- a/packages/react/src/internals/useOpenChangeComplete.tsx
+++ b/packages/react/src/internals/useOpenChangeComplete.tsx
@@ -7,10 +7,10 @@ import { useAnimationsFinished } from './useAnimationsFinished';
  * Calls the provided function when the CSS open/close animation or transition completes.
  */
 export function useOpenChangeComplete(parameters: UseOpenChangeCompleteParameters) {
-  const { enabled = true, open, ref, onComplete: onCompleteParam } = parameters;
+  const { enabled = true, open, ref, batch = false, onComplete: onCompleteParam } = parameters;
 
   const onComplete = useStableCallback(onCompleteParam);
-  const runOnceAnimationsFinish = useAnimationsFinished(ref, open);
+  const runOnceAnimationsFinish = useAnimationsFinished(ref, open, batch);
 
   React.useEffect(() => {
     if (!enabled) {
@@ -41,6 +41,12 @@ export interface UseOpenChangeCompleteParameters {
    * Ref to the element being closed.
    */
   ref: React.RefObject<HTMLElement | null>;
+  /**
+   * Whether completions ready in the same microtask may be coalesced into a single commit.
+   * Only safe when `onComplete` doesn't read state that another completion can change.
+   * @default false
+   */
+  batch?: boolean | undefined;
   /**
    * Function to call when the animation completes (or there is no animation).
    */

--- a/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.tsx
+++ b/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.tsx
@@ -26,6 +26,7 @@ export const MenuCheckboxItemIndicator = React.forwardRef(function MenuCheckboxI
   const { transitionStatus, mounted, setMounted } = useTransitionStatus(item.checked);
 
   useOpenChangeComplete({
+    batch: true,
     open: item.checked,
     ref: indicatorRef,
     onComplete() {

--- a/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.tsx
+++ b/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.tsx
@@ -27,6 +27,7 @@ export const MenuCheckboxItemIndicator = React.forwardRef(function MenuCheckboxI
 
   useOpenChangeComplete({
     batch: true,
+    enabled: !item.checked,
     open: item.checked,
     ref: indicatorRef,
     onComplete() {

--- a/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.tsx
+++ b/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.tsx
@@ -26,6 +26,7 @@ export const MenuRadioItemIndicator = React.forwardRef(function MenuRadioItemInd
   const { transitionStatus, mounted, setMounted } = useTransitionStatus(item.checked);
 
   useOpenChangeComplete({
+    batch: true,
     open: item.checked,
     ref: indicatorRef,
     onComplete() {

--- a/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.tsx
+++ b/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.tsx
@@ -27,6 +27,7 @@ export const MenuRadioItemIndicator = React.forwardRef(function MenuRadioItemInd
 
   useOpenChangeComplete({
     batch: true,
+    enabled: !item.checked,
     open: item.checked,
     ref: indicatorRef,
     onComplete() {

--- a/packages/react/src/radio/indicator/RadioIndicator.tsx
+++ b/packages/react/src/radio/indicator/RadioIndicator.tsx
@@ -43,6 +43,7 @@ export const RadioIndicator = React.forwardRef(function RadioIndicator(
   });
 
   useOpenChangeComplete({
+    batch: true,
     open: rendered,
     ref: indicatorRef,
     onComplete() {

--- a/packages/react/src/radio/indicator/RadioIndicator.tsx
+++ b/packages/react/src/radio/indicator/RadioIndicator.tsx
@@ -44,6 +44,7 @@ export const RadioIndicator = React.forwardRef(function RadioIndicator(
 
   useOpenChangeComplete({
     batch: true,
+    enabled: !rendered,
     open: rendered,
     ref: indicatorRef,
     onComplete() {

--- a/packages/react/src/select/item-indicator/SelectItemIndicator.tsx
+++ b/packages/react/src/select/item-indicator/SelectItemIndicator.tsx
@@ -63,6 +63,7 @@ const Inner = React.memo(
 
       useOpenChangeComplete({
         batch: true,
+        enabled: !selected,
         open: selected,
         ref: indicatorRef,
         onComplete() {

--- a/packages/react/src/select/item-indicator/SelectItemIndicator.tsx
+++ b/packages/react/src/select/item-indicator/SelectItemIndicator.tsx
@@ -62,6 +62,7 @@ const Inner = React.memo(
       });
 
       useOpenChangeComplete({
+        batch: true,
         open: selected,
         ref: indicatorRef,
         onComplete() {


### PR DESCRIPTION
Fixes #5481

When multiple animation watchers finish together, each currently runs its own `flushSync`. Queue callbacks that become ready in the same microtask and flush them once before paint, while continuing to respect aborted callbacks. `Avatar.Image` now only watches exit animations because its completion callback only performs work on exit.

## Performance

Synthetic Chromium benchmark with a 1 ms CSS animation:

| Scenario | Before | After |
| --- | ---: | ---: |
| 100 Checkbox indicators: commits after uncheck | 101 | 2 |
| 500 Avatar images entering: worst frame gap | ~542 ms | ~25 ms |

The shared queue retains one callback record until the next microtask. Avatar enter animations no longer call `getAnimations()`.