### PR TITLE
[combobox][autocomplete] Allow opening and browsing the popup while readOnly

### DIFF
--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -289,6 +289,47 @@ describe('<Autocomplete.Root />', () => {
     expect(input).toHaveValue('');
   });
 
+  it('drops a pending inline completion when readOnly is turned on', async () => {
+    const { user, setProps } = await render(
+      <Autocomplete.Root defaultValue="" mode="both">
+        <Autocomplete.Input data-testid="input" />
+        <Autocomplete.Portal>
+          <Autocomplete.Positioner>
+            <Autocomplete.Popup>
+              <Autocomplete.List>
+                <Autocomplete.Item value="alpha">alpha</Autocomplete.Item>
+                <Autocomplete.Item value="beta">beta</Autocomplete.Item>
+              </Autocomplete.List>
+            </Autocomplete.Popup>
+          </Autocomplete.Positioner>
+        </Autocomplete.Portal>
+      </Autocomplete.Root>,
+    );
+
+    const input = screen.getByTestId<HTMLInputElement>('input');
+    await user.click(input);
+    await user.keyboard('a');
+    await user.keyboard('{ArrowDown}');
+    expect(input).toHaveValue('alpha');
+
+    await setProps({ readOnly: true });
+    expect(input).toHaveValue('a');
+
+    // The suppressed completion must not come back when editing is restored.
+    await setProps({ readOnly: false });
+    expect(input).toHaveValue('a');
+  });
+
+  it('exposes aria-autocomplete="none" when readOnly', async () => {
+    await render(
+      <Autocomplete.Root defaultValue="" readOnly mode="both">
+        <Autocomplete.Input data-testid="input" />
+      </Autocomplete.Root>,
+    );
+
+    expect(screen.getByTestId('input')).toHaveAttribute('aria-autocomplete', 'none');
+  });
+
   it('ignores hidden-input autofill when disabled', async () => {
     const onValueChange = vi.fn();
     await render(

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -227,7 +227,7 @@ describe('<Autocomplete.Root />', () => {
     expect(input.value).toBe('');
   });
 
-  it('browses the list with the arrow keys but does not fill the input when readOnly', async () => {
+  it('opens the list with the arrow keys but does not commit on item press when readOnly', async () => {
     const onValueChange = vi.fn();
     const { user } = await render(
       <Autocomplete.Root defaultValue="" readOnly onValueChange={onValueChange}>
@@ -255,6 +255,38 @@ describe('<Autocomplete.Root />', () => {
 
     expect(onValueChange).not.toHaveBeenCalled();
     expect(input.value).toBe('');
+  });
+
+  it('does not fill the input with the highlighted item when readOnly', async () => {
+    const { user } = await render(
+      <Autocomplete.Root defaultValue="" readOnly mode="both">
+        <Autocomplete.Input data-testid="input" />
+        <Autocomplete.Portal>
+          <Autocomplete.Positioner>
+            <Autocomplete.Popup>
+              <Autocomplete.List>
+                <Autocomplete.Item value="alpha">alpha</Autocomplete.Item>
+                <Autocomplete.Item value="beta">beta</Autocomplete.Item>
+              </Autocomplete.List>
+            </Autocomplete.Popup>
+          </Autocomplete.Positioner>
+        </Autocomplete.Portal>
+      </Autocomplete.Root>,
+    );
+
+    const input = screen.getByTestId<HTMLInputElement>('input');
+    // Focused without a pointer event so the highlight is reported as keyboard-driven.
+    await act(async () => {
+      input.focus();
+    });
+
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{ArrowDown}');
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'alpha' })).toHaveAttribute('data-highlighted');
+    });
+    expect(input).toHaveValue('');
   });
 
   it('ignores hidden-input autofill when disabled', async () => {

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -227,6 +227,36 @@ describe('<Autocomplete.Root />', () => {
     expect(input.value).toBe('');
   });
 
+  it('browses the list with the arrow keys but does not fill the input when readOnly', async () => {
+    const onValueChange = vi.fn();
+    const { user } = await render(
+      <Autocomplete.Root defaultValue="" readOnly onValueChange={onValueChange}>
+        <Autocomplete.Input data-testid="input" />
+        <Autocomplete.Portal>
+          <Autocomplete.Positioner>
+            <Autocomplete.Popup>
+              <Autocomplete.List>
+                <Autocomplete.Item value="alpha">alpha</Autocomplete.Item>
+                <Autocomplete.Item value="beta">beta</Autocomplete.Item>
+              </Autocomplete.List>
+            </Autocomplete.Popup>
+          </Autocomplete.Positioner>
+        </Autocomplete.Portal>
+      </Autocomplete.Root>,
+    );
+
+    const input = screen.getByTestId<HTMLInputElement>('input');
+    await user.click(input);
+    await user.keyboard('{ArrowDown}');
+
+    expect(await screen.findByRole('listbox')).toHaveAttribute('aria-readonly', 'true');
+
+    await user.click(await screen.findByRole('option', { name: 'beta' }));
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(input.value).toBe('');
+  });
+
   it('ignores hidden-input autofill when disabled', async () => {
     const onValueChange = vi.fn();
     await render(

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
@@ -54,10 +54,10 @@ export function AutocompleteRoot<ItemValue>(
   const [inlineInputValue, setInlineInputValue] = React.useState('');
 
   React.useEffect(() => {
-    if (isControlled) {
+    if (isControlled || !enableInline) {
       setInlineInputValue('');
     }
-  }, [value, isControlled]);
+  }, [value, isControlled, enableInline]);
 
   // Compose the input value shown to the user: inline value takes precedence when present.
   let resolvedInputValue: typeof value;

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.tsx
@@ -43,7 +43,8 @@ export function AutocompleteRoot<ItemValue>(
     ...other
   } = props;
 
-  const enableInline = mode === 'inline' || mode === 'both';
+  // Inline completion writes the highlighted label into the input, which `readOnly` must prevent.
+  const enableInline = (mode === 'inline' || mode === 'both') && !props.readOnly;
   const staticItems = mode === 'inline' || mode === 'none';
 
   // Mirror the typed value for uncontrolled usage so we can compose the temporary

--- a/packages/react/src/combobox/chip/ComboboxChip.test.tsx
+++ b/packages/react/src/combobox/chip/ComboboxChip.test.tsx
@@ -195,19 +195,19 @@ describe('<Combobox.Chip />', () => {
       expect(screen.getByTestId('chip-banana')).not.toBe(null);
     });
 
-    it('should focus when readOnly', async () => {
+    it('moves focus to the input when a chip is pressed', async () => {
       const { user } = await render(
-        <Combobox.Root multiple readOnly>
+        <Combobox.Root multiple readOnly defaultValue={['apple']}>
           <Combobox.Chips>
             <Combobox.Chip data-testid="chip">apple</Combobox.Chip>
+            <Combobox.Input data-testid="input" />
           </Combobox.Chips>
         </Combobox.Root>,
       );
 
-      const chip = screen.getByTestId('chip');
-      await user.click(chip);
+      await user.click(screen.getByTestId('chip'));
 
-      expect(chip).toHaveFocus();
+      expect(screen.getByTestId('input')).toHaveFocus();
     });
   });
 

--- a/packages/react/src/combobox/chip/ComboboxChip.test.tsx
+++ b/packages/react/src/combobox/chip/ComboboxChip.test.tsx
@@ -195,7 +195,7 @@ describe('<Combobox.Chip />', () => {
       expect(screen.getByTestId('chip-banana')).not.toBe(null);
     });
 
-    it('moves focus to the input when a chip is pressed', async () => {
+    it('moves focus to the input when a chip is pressed while readOnly', async () => {
       const { user } = await render(
         <Combobox.Root multiple readOnly defaultValue={['apple']}>
           <Combobox.Chips>

--- a/packages/react/src/combobox/chips/ComboboxChips.test.tsx
+++ b/packages/react/src/combobox/chips/ComboboxChips.test.tsx
@@ -218,7 +218,7 @@ describe('<Combobox.Chips />', () => {
     expect(screen.queryByRole('listbox')).toBe(null);
   });
 
-  it('does not focus or open when readOnly', async () => {
+  it('focuses the input and opens when readOnly', async () => {
     await render(
       <Combobox.Root items={['apple', 'banana']} multiple readOnly defaultValue={['apple']}>
         <Combobox.Chips data-testid="chips">
@@ -240,8 +240,8 @@ describe('<Combobox.Chips />', () => {
 
     fireEvent.mouseDown(screen.getByTestId('chips'));
 
-    expect(screen.getByTestId('input')).not.toHaveFocus();
-    expect(screen.queryByRole('listbox')).toBe(null);
+    expect(screen.getByTestId('input')).toHaveFocus();
+    expect(screen.queryByRole('listbox')).not.toBe(null);
   });
 
   it('opens and focuses an input rendered inside the popup when the chips area is pressed', async () => {

--- a/packages/react/src/combobox/chips/ComboboxChips.tsx
+++ b/packages/react/src/combobox/chips/ComboboxChips.tsx
@@ -43,7 +43,7 @@ export const ComboboxChips = React.forwardRef(function ComboboxChips(
       hasSelectionChips ? { role: 'toolbar' } : EMPTY_OBJECT,
       {
         onMouseDown(event) {
-          handleInputPress(event, store, store.state.disabled, store.state.readOnly);
+          handleInputPress(event, store, store.state.disabled);
         },
       },
       elementProps,

--- a/packages/react/src/combobox/input-group/ComboboxInputGroup.test.tsx
+++ b/packages/react/src/combobox/input-group/ComboboxInputGroup.test.tsx
@@ -165,7 +165,7 @@ describe('<Combobox.InputGroup />', () => {
     expect(screen.queryByRole('listbox')).toBe(null);
   });
 
-  it('does not focus or open when readOnly', async () => {
+  it('focuses the input and opens when readOnly', async () => {
     await render(
       <Combobox.Root items={['a', 'b']} multiple readOnly defaultValue={['a']}>
         <Combobox.InputGroup data-testid="group" style={{ padding: 10 }}>
@@ -190,8 +190,8 @@ describe('<Combobox.InputGroup />', () => {
 
     fireEvent.mouseDown(screen.getByTestId('group'));
 
-    expect(screen.getByTestId('input')).not.toHaveFocus();
-    expect(screen.queryByRole('listbox')).toBe(null);
+    expect(screen.getByTestId('input')).toHaveFocus();
+    expect(screen.queryByRole('listbox')).not.toBe(null);
   });
 
   it('has role prop', async () => {

--- a/packages/react/src/combobox/input-group/ComboboxInputGroup.tsx
+++ b/packages/react/src/combobox/input-group/ComboboxInputGroup.tsx
@@ -58,7 +58,7 @@ export const ComboboxInputGroup = React.forwardRef(function ComboboxInputGroup(
       {
         role: 'group',
         onMouseDown(event) {
-          handleInputPress(event, store, disabled, readOnly, (target) => {
+          handleInputPress(event, store, disabled, (target) => {
             return contains(store.context.chipsContainerRef.current, target);
           });
         },

--- a/packages/react/src/combobox/input/ComboboxInput.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.test.tsx
@@ -196,7 +196,7 @@ describe('<Combobox.Input />', () => {
       expect(input).toHaveAttribute('readonly');
     });
 
-    it('should not open popup when readOnly', async () => {
+    it('should open popup when readOnly', async () => {
       const { user } = await render(
         <Combobox.Root readOnly>
           <Combobox.Input data-testid="input" />
@@ -216,12 +216,13 @@ describe('<Combobox.Input />', () => {
       const input = screen.getByTestId('input');
       await user.click(input);
 
-      expect(screen.queryByRole('listbox')).toBe(null);
+      expect(await screen.findByRole('listbox')).toHaveAttribute('aria-readonly', 'true');
     });
 
-    it('should prevent keyboard interactions when readOnly', async () => {
+    it('should not change the input value when typing while readOnly', async () => {
+      const onInputValueChange = vi.fn();
       const { user } = await render(
-        <Combobox.Root readOnly>
+        <Combobox.Root readOnly onInputValueChange={onInputValueChange}>
           <Combobox.Input data-testid="input" />
           <Combobox.Portal>
             <Combobox.Positioner>
@@ -239,7 +240,9 @@ describe('<Combobox.Input />', () => {
       const input = screen.getByTestId('input');
 
       await user.type(input, 'a');
-      expect(screen.queryByRole('listbox')).toBe(null);
+
+      expect(input).toHaveValue('');
+      expect(onInputValueChange).not.toHaveBeenCalled();
     });
 
     it('allows interactions when readOnly={false}', async () => {

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -345,6 +345,10 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
           store.context.keyboardActiveRef.current = true;
 
           if (disabled || readOnly) {
+            // Browsing can highlight an item, and Enter there must not submit the form.
+            if (readOnly && event.key === 'Enter' && open && store.state.activeIndex !== null) {
+              stopEvent(event);
+            }
             return;
           }
 

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -337,15 +337,17 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
           }
         },
         onKeyDown(event) {
-          if (disabled || readOnly) {
-            return;
-          }
-
           if (event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) {
             return;
           }
 
+          // Tracked before the guards so `readOnly` browsing reports keyboard highlight reasons.
           store.context.keyboardActiveRef.current = true;
+
+          if (disabled || readOnly) {
+            return;
+          }
+
           const input = event.currentTarget;
           const scrollAmount = input.scrollWidth - input.clientWidth;
           const isRTL = direction === 'rtl';

--- a/packages/react/src/combobox/list/ComboboxList.test.tsx
+++ b/packages/react/src/combobox/list/ComboboxList.test.tsx
@@ -1,5 +1,6 @@
 import { expect, vi } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
+import { Autocomplete } from '@base-ui/react/autocomplete';
 import { createRenderer, describeConformance } from '#test-utils';
 import { act, screen } from '@mui/internal-test-utils';
 
@@ -30,6 +31,60 @@ describe('<Combobox.List />', () => {
 
     const list = screen.getByRole('listbox');
     expect(list).toHaveAttribute('aria-multiselectable', 'true');
+  });
+
+  it('sets aria-readonly on the listbox when the root is readOnly', async () => {
+    await render(
+      <Combobox.Root readOnly defaultOpen>
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.List>
+                <Combobox.Item value="a">a</Combobox.Item>
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    expect(screen.getByRole('listbox')).toHaveAttribute('aria-readonly', 'true');
+  });
+
+  it('does not set aria-readonly on the listbox by default', async () => {
+    await render(
+      <Combobox.Root defaultOpen>
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.List>
+                <Combobox.Item value="a">a</Combobox.Item>
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    expect(screen.getByRole('listbox')).not.toHaveAttribute('aria-readonly');
+  });
+
+  it('sets aria-readonly on the Autocomplete listbox when the root is readOnly', async () => {
+    await render(
+      <Autocomplete.Root readOnly defaultOpen>
+        <Autocomplete.Portal>
+          <Autocomplete.Positioner>
+            <Autocomplete.Popup>
+              <Autocomplete.List>
+                <Autocomplete.Item value="a">a</Autocomplete.Item>
+              </Autocomplete.List>
+            </Autocomplete.Popup>
+          </Autocomplete.Positioner>
+        </Autocomplete.Portal>
+      </Autocomplete.Root>,
+    );
+
+    expect(screen.getByRole('listbox')).toHaveAttribute('aria-readonly', 'true');
   });
 
   it('does not prevent Enter when no item is highlighted', async () => {

--- a/packages/react/src/combobox/list/ComboboxList.test.tsx
+++ b/packages/react/src/combobox/list/ComboboxList.test.tsx
@@ -51,6 +51,29 @@ describe('<Combobox.List />', () => {
     expect(screen.getByRole('listbox')).toHaveAttribute('aria-readonly', 'true');
   });
 
+  it('does not set aria-readonly on the grid when the root is readOnly', async () => {
+    await render(
+      <Combobox.Root readOnly defaultOpen grid>
+        <Combobox.Input data-testid="input" />
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.List>
+                <Combobox.Row>
+                  <Combobox.Item value="a">a</Combobox.Item>
+                </Combobox.Row>
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    // `aria-readonly` on a grid describes cell editability, so the combobox carries the state.
+    expect(screen.getByRole('grid')).not.toHaveAttribute('aria-readonly');
+    expect(screen.getByTestId('input')).toHaveAttribute('aria-readonly', 'true');
+  });
+
   it('does not set aria-readonly on the listbox by default', async () => {
     await render(
       <Combobox.Root defaultOpen>

--- a/packages/react/src/combobox/list/ComboboxList.tsx
+++ b/packages/react/src/combobox/list/ComboboxList.tsx
@@ -33,6 +33,7 @@ export const ComboboxList = React.forwardRef(function ComboboxList(
 
   const selectionMode = store.useState('selectionMode');
   const grid = store.useState('grid');
+  const readOnly = store.useState('readOnly');
   const listProps = store.useState('listProps');
   const virtualized = store.useState('virtualized');
   const forceMounted = store.useState('forceMounted');
@@ -76,6 +77,7 @@ export const ComboboxList = React.forwardRef(function ComboboxList(
         id: floatingId,
         role: grid ? 'grid' : 'listbox',
         'aria-multiselectable': multiple ? 'true' : undefined,
+        'aria-readonly': readOnly || undefined,
         onKeyDown(event) {
           if (store.state.disabled || store.state.readOnly) {
             return;

--- a/packages/react/src/combobox/list/ComboboxList.tsx
+++ b/packages/react/src/combobox/list/ComboboxList.tsx
@@ -77,7 +77,9 @@ export const ComboboxList = React.forwardRef(function ComboboxList(
         id: floatingId,
         role: grid ? 'grid' : 'listbox',
         'aria-multiselectable': multiple ? 'true' : undefined,
-        'aria-readonly': readOnly || undefined,
+        // On a grid the attribute describes cell editability, not selection, so it's left to the
+        // combobox element in that mode.
+        'aria-readonly': !grid && readOnly ? true : undefined,
         onKeyDown(event) {
           if (store.state.disabled || store.state.readOnly) {
             return;

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -1297,8 +1297,12 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
     };
   }, [inputElement, expanded, ariaExpanded, ariaHasPopup, listElement?.id, autoComplete]);
 
+  // `readOnly` locks the value, not the interaction: the popup can be opened and browsed so the
+  // user can see the available options and which one is selected. Committing a value is blocked
+  // separately in `ComboboxItem`, in the parts that clear or remove values, and in the hidden
+  // input's autofill handler.
   const click = useClick(floatingRootContext, {
-    enabled: !readOnly && !disabled && openOnInputClick,
+    enabled: !disabled && openOnInputClick,
     event: 'mousedown-only',
     toggle: false,
     // Apply a small delay for touch to let mobile viewport/keyboard positioning settle.
@@ -1308,7 +1312,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
   });
 
   const dismiss = useDismiss(floatingRootContext, {
-    enabled: !readOnly && !disabled && !inline,
+    enabled: !disabled && !inline,
     outsidePressEvent: {
       mouse: 'sloppy',
       // The visual viewport (affected by the mobile software keyboard) can be
@@ -1330,7 +1334,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
   });
 
   const listNavigation = useListNavigation(floatingRootContext, {
-    enabled: !readOnly && !disabled,
+    enabled: !disabled,
     id,
     listRef,
     activeIndex,

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -1297,10 +1297,9 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
     };
   }, [inputElement, expanded, ariaExpanded, ariaHasPopup, listElement?.id, autoComplete]);
 
-  // `readOnly` locks the value, not the interaction: the popup can be opened and browsed so the
-  // user can see the available options and which one is selected. Committing a value is blocked
-  // separately in `ComboboxItem`, in the parts that clear or remove values, and in the hidden
-  // input's autofill handler.
+  // `readOnly` locks the value, not the interaction: the popup opens and can be browsed.
+  // Value changes stay blocked in `ComboboxItem`, `ComboboxInput`'s keydown, `ComboboxTrigger`'s
+  // typeahead, the clear/remove parts, and the hidden input's autofill handler.
   const click = useClick(floatingRootContext, {
     enabled: !disabled && openOnInputClick,
     event: 'mousedown-only',

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -1288,14 +1288,15 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
       reference['aria-expanded'] = ariaExpanded;
       reference['aria-haspopup'] = ariaHasPopup;
       reference['aria-controls'] = expanded ? listElement?.id : undefined;
-      reference['aria-autocomplete'] = autoComplete;
+      // `readOnly` accepts no input, so no completion of any kind is offered.
+      reference['aria-autocomplete'] = readOnly ? 'none' : autoComplete;
     }
 
     return {
       reference,
       floating: { role: 'presentation' },
     };
-  }, [inputElement, expanded, ariaExpanded, ariaHasPopup, listElement?.id, autoComplete]);
+  }, [inputElement, expanded, ariaExpanded, ariaHasPopup, listElement?.id, autoComplete, readOnly]);
 
   // `readOnly` locks the value, not the interaction: the popup opens and can be browsed.
   // Value changes stay blocked in `ComboboxItem`, `ComboboxInput`'s keydown, `ComboboxTrigger`'s

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -4718,6 +4718,45 @@ describe('<Combobox.Root />', () => {
       expect(handleValueChange.mock.calls.length).toBe(0);
     });
 
+    it('should not submit the form with Enter on a highlighted item when readOnly', async () => {
+      const onSubmit = vi.fn();
+      const { user } = await render(
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            onSubmit();
+          }}
+        >
+          <Combobox.Root readOnly>
+            <Combobox.Input data-testid="input" />
+            <Combobox.Portal>
+              <Combobox.Positioner>
+                <Combobox.Popup>
+                  <Combobox.List>
+                    <Combobox.Item value="a">a</Combobox.Item>
+                    <Combobox.Item value="b">b</Combobox.Item>
+                  </Combobox.List>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>
+          <button type="submit">Submit</button>
+        </form>,
+      );
+
+      await user.click(screen.getByTestId('input'));
+      await screen.findByRole('listbox');
+
+      await user.keyboard('{ArrowDown}');
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('data-highlighted');
+      });
+
+      await user.keyboard('{Enter}');
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
     it('should report arrow-key highlights as keyboard-driven when readOnly', async () => {
       const onItemHighlighted = vi.fn();
       const { user } = await render(

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -4559,40 +4559,20 @@ describe('<Combobox.Root />', () => {
   });
 
   describe('prop: readOnly', () => {
-    it('should render readOnly state on the input and disable interactions', async () => {
-      const { user } = await render(
+    it('should render readOnly state on the input', async () => {
+      await render(
         <Combobox.Root readOnly>
           <Combobox.Input data-testid="input" />
-          <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
-          <Combobox.Portal>
-            <Combobox.Positioner>
-              <Combobox.Popup>
-                <Combobox.List>
-                  <Combobox.Item value="a" data-testid="item-a">
-                    a
-                  </Combobox.Item>
-                  <Combobox.Item value="b" data-testid="item-b">
-                    b
-                  </Combobox.Item>
-                </Combobox.List>
-              </Combobox.Popup>
-            </Combobox.Positioner>
-          </Combobox.Portal>
         </Combobox.Root>,
       );
 
       const input = screen.getByTestId('input');
-      const trigger = screen.getByTestId('trigger');
 
       expect(input).toHaveAttribute('aria-readonly', 'true');
       expect(input).toHaveAttribute('readonly');
-
-      // Verify interactions are disabled
-      await user.click(trigger);
-      expect(screen.queryByRole('listbox')).toBe(null);
     });
 
-    it('should not open popup when readOnly', async () => {
+    it('should open the popup from the input and the trigger when readOnly', async () => {
       const { user } = await render(
         <Combobox.Root readOnly>
           <Combobox.Input data-testid="input" />
@@ -4610,19 +4590,54 @@ describe('<Combobox.Root />', () => {
         </Combobox.Root>,
       );
 
-      const input = screen.getByTestId('input');
-      const trigger = screen.getByTestId('trigger');
+      await user.click(screen.getByTestId('input'));
+      expect(await screen.findByRole('listbox')).toHaveAttribute('aria-readonly', 'true');
 
-      await user.click(input);
-      expect(screen.queryByRole('listbox')).toBe(null);
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).toBe(null);
+      });
 
-      await user.click(trigger);
-      expect(screen.queryByRole('listbox')).toBe(null);
+      await user.click(screen.getByTestId('trigger'));
+      expect(await screen.findByRole('listbox')).not.toBe(null);
     });
 
-    it('should prevent keyboard interactions when readOnly', async () => {
+    it('should browse the items with the arrow keys when readOnly', async () => {
       const { user } = await render(
         <Combobox.Root readOnly>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="a">a</Combobox.Item>
+                  <Combobox.Item value="b">b</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(input);
+      await screen.findByRole('listbox');
+
+      await user.keyboard('{ArrowDown}');
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('data-highlighted');
+      });
+
+      await user.keyboard('{ArrowDown}');
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'b' })).toHaveAttribute('data-highlighted');
+      });
+    });
+
+    it('should not change the input value when typing while readOnly', async () => {
+      const onInputValueChange = vi.fn();
+      const { user } = await render(
+        <Combobox.Root readOnly onInputValueChange={onInputValueChange}>
           <Combobox.Input data-testid="input" />
           <Combobox.Portal>
             <Combobox.Positioner>
@@ -4640,7 +4655,9 @@ describe('<Combobox.Root />', () => {
       const input = screen.getByTestId('input');
 
       await user.type(input, 'a');
-      expect(screen.queryByRole('listbox')).toBe(null);
+
+      expect(input).toHaveValue('');
+      expect(onInputValueChange).not.toHaveBeenCalled();
     });
 
     it('should set readOnly attribute on hidden input', async () => {
@@ -4689,6 +4706,35 @@ describe('<Combobox.Root />', () => {
       await user.click(itemA);
 
       expect(handleValueChange.mock.calls.length).toBe(0);
+    });
+
+    it('should not commit a value with Enter on a highlighted item when readOnly', async () => {
+      const handleValueChange = vi.fn();
+      const { user } = await render(
+        <Combobox.Root readOnly onValueChange={handleValueChange}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="a">a</Combobox.Item>
+                  <Combobox.Item value="b">b</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByTestId('input');
+      await user.click(input);
+      await screen.findByRole('listbox');
+
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{Enter}');
+
+      expect(handleValueChange.mock.calls.length).toBe(0);
+      expect(input).toHaveValue('');
     });
   });
 

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -4708,6 +4708,39 @@ describe('<Combobox.Root />', () => {
       expect(handleValueChange.mock.calls.length).toBe(0);
     });
 
+    it('should report arrow-key highlights as keyboard-driven when readOnly', async () => {
+      const onItemHighlighted = vi.fn();
+      const { user } = await render(
+        <Combobox.Root readOnly onItemHighlighted={onItemHighlighted}>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="a">a</Combobox.Item>
+                  <Combobox.Item value="b">b</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      // Opening by pointer marks pointer activity, which the arrow key must clear.
+      await user.click(screen.getByTestId('input'));
+      await screen.findByRole('listbox');
+      onItemHighlighted.mockClear();
+
+      await user.keyboard('{ArrowDown}');
+
+      await waitFor(() => {
+        expect(onItemHighlighted).toHaveBeenCalledWith(
+          'a',
+          expect.objectContaining({ reason: 'keyboard' }),
+        );
+      });
+    });
+
     it('should not commit a value with Enter on a highlighted item when readOnly', async () => {
       const handleValueChange = vi.fn();
       const { user } = await render(
@@ -4731,6 +4764,10 @@ describe('<Combobox.Root />', () => {
       await screen.findByRole('listbox');
 
       await user.keyboard('{ArrowDown}');
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'a' })).toHaveAttribute('data-highlighted');
+      });
+
       await user.keyboard('{Enter}');
 
       expect(handleValueChange.mock.calls.length).toBe(0);

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -4572,6 +4572,16 @@ describe('<Combobox.Root />', () => {
       expect(input).toHaveAttribute('readonly');
     });
 
+    it('should expose aria-autocomplete="none" when readOnly', async () => {
+      await render(
+        <Combobox.Root readOnly>
+          <Combobox.Input data-testid="input" />
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByTestId('input')).toHaveAttribute('aria-autocomplete', 'none');
+    });
+
     it('should open the popup from the input and the trigger when readOnly', async () => {
       const { user } = await render(
         <Combobox.Root readOnly>

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
@@ -799,6 +799,34 @@ describe('<Combobox.Trigger />', () => {
       expect(trigger).not.toHaveAttribute('aria-required');
     });
 
+    it('sets aria-readonly attribute when readOnly (input inside popup)', async () => {
+      await render(
+        <Combobox.Root readOnly>
+          <Combobox.Trigger data-testid="trigger" />
+        </Combobox.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      expect(trigger).toHaveAttribute('role', 'combobox');
+      expect(trigger).toHaveAttribute('aria-readonly', 'true');
+    });
+
+    it('does not set aria-readonly attribute when the input is outside the popup', async () => {
+      await render(
+        <Combobox.Root readOnly>
+          <Combobox.Input data-testid="input" />
+          <Combobox.Trigger data-testid="trigger" />
+        </Combobox.Root>,
+      );
+
+      // Without the `combobox` role the trigger is a plain button, so `aria-readonly` wouldn't
+      // apply to it. The input carries the state instead.
+      const trigger = screen.getByTestId('trigger');
+      expect(trigger).not.toHaveAttribute('role');
+      expect(trigger).not.toHaveAttribute('aria-readonly');
+      expect(screen.getByTestId('input')).toHaveAttribute('aria-readonly', 'true');
+    });
+
     it('sets all aria attributes on the input when closed', async () => {
       await render(
         <Combobox.Root>

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
@@ -240,7 +240,7 @@ describe('<Combobox.Trigger />', () => {
       expect(trigger).not.toHaveAttribute('data-readonly');
     });
 
-    it('should not open popup when readOnly', async () => {
+    it('opens the popup when readOnly', async () => {
       const { user } = await render(
         <Combobox.Root readOnly>
           <Combobox.Trigger data-testid="trigger">Open</Combobox.Trigger>
@@ -260,10 +260,15 @@ describe('<Combobox.Trigger />', () => {
       const trigger = screen.getByTestId('trigger');
       await user.click(trigger);
 
-      expect(screen.queryByRole('listbox')).toBe(null);
+      expect(await screen.findByRole('listbox')).toHaveAttribute('aria-readonly', 'true');
     });
 
-    it.each(['ArrowDown', 'ArrowUp'])('does not open on %s when readOnly', async (key) => {
+    it.each([
+      { name: 'ArrowDown', key: '{ArrowDown}' },
+      { name: 'ArrowUp', key: '{ArrowUp}' },
+      { name: 'Enter', key: '{Enter}' },
+      { name: 'Space', key: '[Space]' },
+    ])('opens on $name when readOnly', async ({ key }) => {
       const onOpenChange = vi.fn();
       const { user } = await render(
         <Combobox.Root readOnly onOpenChange={onOpenChange}>
@@ -283,10 +288,38 @@ describe('<Combobox.Trigger />', () => {
 
       const trigger = screen.getByTestId('trigger');
       trigger.focus();
-      await user.keyboard(`{${key}}`);
+      await user.keyboard(key);
 
-      expect(onOpenChange).not.toHaveBeenCalled();
-      expect(screen.queryByRole('listbox')).toBe(null);
+      expect(onOpenChange).toHaveBeenCalledTimes(1);
+      expect(await screen.findByRole('listbox')).not.toBe(null);
+    });
+
+    it('does not commit a value with typeahead on a closed trigger', async () => {
+      const onValueChange = vi.fn();
+      const { user } = await render(
+        <Combobox.Root readOnly onValueChange={onValueChange}>
+          <Combobox.Trigger data-testid="trigger">
+            <Combobox.Value />
+          </Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Item value="apple">apple</Combobox.Item>
+                  <Combobox.Item value="banana">banana</Combobox.Item>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const trigger = screen.getByTestId('trigger');
+      trigger.focus();
+      await user.keyboard('b');
+
+      expect(onValueChange).not.toHaveBeenCalled();
+      expect(trigger).toHaveAttribute('data-placeholder');
     });
 
     it('should not toggle when readOnly=false (control)', async () => {

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -104,6 +104,8 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
   }
 
   const { reference: triggerTypeaheadProps } = useTypeahead(floatingRootContext, {
+    // Typeahead on a closed trigger commits a value rather than moving a highlight, so it stays
+    // gated on `readOnly`.
     enabled: !open && !readOnly && !comboboxDisabled && selectionMode === 'single',
     listRef: store.context.labelsRef,
     activeIndex,
@@ -117,7 +119,7 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
   });
 
   const { reference: triggerClickProps } = useClick(floatingRootContext, {
-    enabled: !readOnly && !comboboxDisabled,
+    enabled: !comboboxDisabled,
     event: 'mousedown',
   });
 
@@ -164,7 +166,7 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
         onFocus() {
           setFocused(true);
 
-          if (disabled || readOnly) {
+          if (disabled) {
             return;
           }
 
@@ -185,7 +187,7 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
           }
         },
         onMouseDown(event) {
-          if (disabled || readOnly) {
+          if (disabled) {
             return;
           }
 
@@ -240,10 +242,6 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
           }
         },
         onKeyDown(event) {
-          if (readOnly) {
-            return;
-          }
-
           if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
             stopEvent(event);
             store.context.setOpen(

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.tsx
@@ -155,6 +155,9 @@ export const ComboboxTrigger = React.forwardRef(function ComboboxTrigger(
         'aria-haspopup': inputInsidePopup ? 'dialog' : 'listbox',
         'aria-controls': ariaControls,
         'aria-required': inputInsidePopup ? required || undefined : undefined,
+        // Only valid alongside the `combobox` role; without it the trigger is a plain button, and
+        // the `Combobox.Input` outside the popup already carries `aria-readonly`.
+        'aria-readonly': inputInsidePopup ? readOnly || undefined : undefined,
         'aria-labelledby': ariaLabelledBy,
         onPointerDown: trackPointerType,
         onPointerEnter: trackPointerType,

--- a/packages/react/src/combobox/utils/handleInputPress.test.ts
+++ b/packages/react/src/combobox/utils/handleInputPress.test.ts
@@ -24,7 +24,7 @@ describe('handleInputPress', () => {
       },
     } as unknown as ComboboxStore;
 
-    handleInputPress(event, store, false, false);
+    handleInputPress(event, store, false);
 
     expect(preventDefault).toHaveBeenCalledOnce();
     expect(focus).toHaveBeenCalledOnce();

--- a/packages/react/src/combobox/utils/handleInputPress.ts
+++ b/packages/react/src/combobox/utils/handleInputPress.ts
@@ -9,10 +9,9 @@ export function handleInputPress(
   event: React.MouseEvent<HTMLElement> & { baseUIHandlerPrevented?: boolean | undefined },
   store: ComboboxStore,
   disabled: boolean,
-  readOnly: boolean,
   shouldIgnoreTarget?: ((target: Element | null) => boolean) | undefined,
 ) {
-  if (event.baseUIHandlerPrevented || readOnly) {
+  if (event.baseUIHandlerPrevented) {
     return;
   }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #5584

Follow-up to #5531 / #5530.

`readOnly` locks the value, not the interaction. #5531 made that true for `Select`. `Combobox` and `Autocomplete` still refused to open at all, so this brings them in line and adds the read-only ARIA state that was missing from the listbox and the trigger.

## Behavior

Pointer and keyboard now open the popup and move the highlight while `readOnly`, so the user can see the available options and which one is selected. `useDismiss` was gated on `readOnly` too, so a `defaultOpen` read-only combobox could not be closed by `Escape` or an outside press. It now can.

Nothing commits a value. Item press, `Enter` on a highlighted item, closed-trigger typeahead, `Clear`, `ChipRemove`, chip removal with `Backspace`, `Escape`-to-clear, and hidden-input autofill stay gated on `readOnly`. The input keeps its native `readonly` attribute, so typing and filtering stay off.

One consequence worth naming: the popup stays open on `Enter` and on item press while `readOnly`. Those paths close it only as a side effect of committing a value, and nothing commits here. Dismissal is untouched, so `Escape`, an outside press, and the trigger all still close it.

## ARIA

- **`Combobox.List`**: `aria-readonly` when the root is `readOnly` and the list renders `role="listbox"`, which [the attribute is defined for](https://www.w3.org/TR/wai-aria-1.2/#aria-readonly). In `grid` mode it is deliberately omitted: on a grid the attribute speaks to cell editability rather than selection, and the combobox element carries the read-only state anyway. `Combobox.List` is the family's only listbox, since `Combobox.Popup` always renders `dialog` or `presentation`. Covers `Autocomplete.List` too, since it's the same component.
- **`Combobox.Trigger`**: `aria-readonly`, but **only when it renders with `role="combobox"`** (`inputInsidePopup`), mirroring how `aria-required` is already gated on the same condition. Without that role the trigger is a plain button, where the attribute wouldn't apply (that's what #3907 removed from `Clear` and `Popup`), and in that composition the `Combobox.Input` outside the popup already exposes `aria-readonly`.
- **`Combobox.Input`**: `aria-autocomplete="none"` while `readOnly`. The input accepts no text, so no completion of any kind is on offer.
