### PR TITLE
[docs] Document BASE_UI_ANIMATIONS_DISABLED

### DIFF
--- a/docs/src/app/(docs)/react/handbook/animation/page.mdx
+++ b/docs/src/app/(docs)/react/handbook/animation/page.mdx
@@ -216,6 +216,37 @@ function App() {
 }
 ```
 
+## Disabling animations in tests
+
+Base UI waits for a component's animations to finish before running the work that follows them, such as unmounting a popup that has been closed.
+In a test environment that wait makes assertions racy — especially in WebKit — because the test continues before the component has settled.
+
+Set the `BASE_UI_ANIMATIONS_DISABLED` global to `true` to skip the wait. Anything that would have been deferred until animations finished runs immediately instead.
+
+```ts title="setup-tests.ts"
+globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+```
+
+Set it in a setup file that runs before your tests, such as Vitest's `setupFiles` or Jest's `setupFilesAfterEnv`.
+If TypeScript does not know about the global, declare it once:
+
+```ts title="global.d.ts"
+declare global {
+  var BASE_UI_ANIMATIONS_DISABLED: boolean;
+}
+```
+
+In Playwright the global has to exist before your application scripts run, so set it with `addInitScript`:
+
+```ts title="playwright-fixtures.ts"
+await page.addInitScript(() => {
+  globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+});
+```
+
+The flag only disables Base UI's internal waiting — it does not stop your CSS transitions and animations from playing.
+Turn those off in your own styles if you need the components to settle instantly.
+
 export const metadata = {
   keywords: [
     'Base UI Animation',
@@ -229,5 +260,6 @@ export const metadata = {
     'Transition Hooks',
     'Animated Components',
     'Keyframe Animations',
+    'Disable Animations in Tests',
   ],
 };

--- a/docs/src/app/(docs)/react/handbook/animation/page.mdx
+++ b/docs/src/app/(docs)/react/handbook/animation/page.mdx
@@ -218,7 +218,7 @@ function App() {
 
 ## Disabling animations in tests
 
-Base UI waits for a component's animations to finish before running the work that follows them, such as unmounting a popup that has been closed.
+Base UI waits for a component's animations to finish before running the work that follows them, such as unmounting a popup that has been closed.
 In a test environment that wait makes assertions racy — especially in WebKit — because the test continues before the component has settled.
 
 Set the `BASE_UI_ANIMATIONS_DISABLED` global to `true` to skip the wait. Anything that would have been deferred until animations finished runs immediately instead.
@@ -244,7 +244,7 @@ await page.addInitScript(() => {
 });
 ```
 
-The flag only disables Base UI's internal waiting — it does not stop your CSS transitions and animations from playing.
+The flag only disables Base UI's internal waiting — it does not stop your CSS transitions and animations from playing.
 Turn those off in your own styles if you need the components to settle instantly.
 
 export const metadata = {

--- a/docs/src/app/(docs)/react/handbook/page.mdx
+++ b/docs/src/app/(docs)/react/handbook/page.mdx
@@ -43,7 +43,7 @@ A guide to animating Base UI components.
 
 <summary>Outline</summary>
 
-- Keywords: Base UI Animation, React Component Animations, CSS Transition Guide, Motion Framer Integration, Animation Data Attributes, Handbook Animation, Spring Animations, Enter Exit Animations, Transition Hooks, Animated Components, Keyframe Animations
+- Keywords: Base UI Animation, React Component Animations, CSS Transition Guide, Motion Framer Integration, Animation Data Attributes, Handbook Animation, Spring Animations, Enter Exit Animations, Transition Hooks, Animated Components, Keyframe Animations, Disable Animations in Tests
 - Sections:
   - CSS transitions
   - CSS animations
@@ -52,6 +52,7 @@ A guide to animating Base UI components.
     - Animating components kept in DOM when closed with Motion
     - Animating Select component with Motion
     - Manual unmounting
+  - Disabling animations in tests
 
 </details>
 


### PR DESCRIPTION
Closes #4313.

`BASE_UI_ANIMATIONS_DISABLED` is used throughout the library's own tests (`test/setupVitest.ts`) and read in `useAnimationsFinished`, but it wasn't documented anywhere, so people writing tests against Base UI had no way to find it.

This adds a **Disabling animations in tests** section to the Animation handbook page covering:

- what the flag actually does — skips the wait for animations to finish, so the deferred work runs immediately
- setting it from a Vitest / Jest setup file
- declaring the global for TypeScript
- setting it in Playwright via `addInitScript`, since it has to exist before the app scripts run
- the limit: it disables Base UI's internal waiting, not your CSS transitions and animations

Docs-only, no source changes.
