### PR TITLE
[select] Focus selected item on open

### DIFF
--- a/packages/react/src/select/popup/SelectPopup.test.tsx
+++ b/packages/react/src/select/popup/SelectPopup.test.tsx
@@ -87,6 +87,33 @@ describe('<Select.Popup />', () => {
     expect(screen.getByTestId('next')).not.toHaveFocus();
   });
 
+  it('focuses the selected item instead of the first tabbable element', async () => {
+    const { user } = await render(
+      <Select.Root defaultValue="three">
+        <Select.Trigger data-testid="trigger">
+          <Select.Value />
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Positioner alignItemWithTrigger={false}>
+            <Select.Popup>
+              <Select.List tabIndex={0}>
+                <Select.Item value="one">one</Select.Item>
+                <Select.Item value="two">two</Select.Item>
+                <Select.Item value="three">three</Select.Item>
+              </Select.List>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    await user.click(screen.getByTestId('trigger'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'three' })).toHaveFocus();
+    });
+  });
+
   it('has aria attributes when no Select.List is present', async () => {
     const { user } = await render(
       <Select.Root multiple>

--- a/packages/react/src/select/popup/SelectPopup.tsx
+++ b/packages/react/src/select/popup/SelectPopup.tsx
@@ -498,6 +498,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
         context={floatingRootContext}
         modal={false}
         disabled={!mounted}
+        initialFocus={() => store.state.selectedIndex === null}
         openInteractionType={openMethod}
         returnFocus={finalFocus}
         restoreFocus


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR proposes explicitly deferring initial focus management to `useListNavigation` when the Select has a selected item.

By default, `FloatingFocusManager` focuses the first tabbable element in the popup. However, the popup may contain another tabbable element before the selected item, such as a scrollable `ScrollArea.Viewport`. In that case, focus moves to the viewport instead of the selected item when the Select opens.

Although consumers can suppress a tabbable viewport by passing `tabIndex={undefined}`, it seems preferable for Select to consistently move focus to the selected item when one exists, regardless of other tabbable elements within the popup.

When there is no selected item, the existing first-tabbable behavior is preserved.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
