### PR TITLE
[typescript] Stop the react build and typecheck projects overwriting each other

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .netlify
 build/
 build-tests/
+build-typecheck/
 node_modules/
 package-lock.json
 size-snapshot.json

--- a/.lintignore
+++ b/.lintignore
@@ -7,6 +7,7 @@
 /packages/react/**/*.min.*
 build
 build-tests
+build-typecheck
 node_modules
 pnpm-lock.yaml
 routeTree.gen.ts

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -119,7 +119,7 @@
     }
   },
   "scripts": {
-    "prebuild": "rimraf --glob build build-tests published-docs \"*.tsbuildinfo\" && node ./scripts/stagePublishedDocs.mjs",
+    "prebuild": "rimraf --glob build build-tests build-typecheck published-docs \"*.tsbuildinfo\" && node ./scripts/stagePublishedDocs.mjs",
     "build": "code-infra build --ignore \"**/*.template.js\" --copy .npmignore --copy \"published-docs/**:docs\" --tsgo",
     "test:package": "publint --pack pnpm && attw --pack ./build --exclude-entrypoints package.json",
     "release": "pnpm build && pnpm publish",

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -2,6 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "references": [
     {
+      "path": "./tsconfig.build.json"
+    },
+    {
       "path": "./tsconfig.typecheck.json"
     },
     {

--- a/packages/react/tsconfig.typecheck.json
+++ b/packages/react/tsconfig.typecheck.json
@@ -2,8 +2,10 @@
   "extends": "./tsconfig.build.json",
   // Keep internals available to workspace project references. The published package build uses
   // `tsconfig.build.json`, where `stripInternal` is enabled.
+  // Emits to a separate directory so the two projects never overwrite each other's declarations.
   "compilerOptions": {
-    "stripInternal": false
+    "stripInternal": false,
+    "outDir": "build-typecheck"
   },
   "references": [{ "path": "../utils/tsconfig.build.json" }]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,5 +21,12 @@
       "docs/*": ["./docs/*"]
     }
   },
-  "exclude": ["**/.*/", "**/build", "**/build-tests", "**/node_modules", "docs/export"]
+  "exclude": [
+    "**/.*/",
+    "**/build",
+    "**/build-tests",
+    "**/build-typecheck",
+    "**/node_modules",
+    "docs/export"
+  ]
 }


### PR DESCRIPTION
`pnpm typescript` failed with `@internal` members going missing from `@base-ui/react`:

```
docs/src/app/(private)/experiments/menu/triggers.tsx(190,23): error TS2741:
  Property 'store' is missing in type 'MenuHandle<...>' but required in type 'StoreOwner'.
packages/react/src/floating-ui-react/hooks/useDismiss.test.tsx(11,3): error TS2305:
  Module '"../index"' has no exported member 'FloatingPortal'.
```

`packages/react/tsconfig.typecheck.json` extends `tsconfig.build.json` and inherited its `outDir: "build"` while setting `stripInternal: false`. Both projects are in the root build graph, so `tsgo -b tsconfig.json` ran both and they overwrote each other's declarations — leaving whichever emitted last on disk for the downstream projects to read.

Gave the typecheck project its own `outDir` (`build-typecheck`), plus the housekeeping that needs: `.gitignore`, `.lintignore`, the `exclude` in `tsconfig.base.json`, and the `prebuild` rimraf glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
