### PR TITLE
[code-infra] Make the review skill explicit opt-in

### DIFF
--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: base-ui-review
-description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, or --fix to apply findings.'
+description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use ONLY when explicitly requested by name: the user runs /base-ui-review, writes $base-ui-review, or asks for "the Base UI review skill". Do NOT use for general review requests such as "review my changes", "review this diff/branch/PR", or after finishing an implementation — handle those without this skill unless the user names it. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, or --fix to apply findings.'
 ---
 
 # Base UI Review
@@ -10,6 +10,12 @@ Review current diff. Find **regressions and correctness bugs** first. Also find
 [Effort levels](#effort-levels) for depth and subagent fan-out.
 
 Argument hint: `[low|medium|high|xhigh|max] [--fix] [--comment [inline]] [<target>]`
+
+This skill is **opt-in only**: run it when the user explicitly asks for it by
+name (`/base-ui-review`, `$base-ui-review`, "the Base UI review skill", or a CI
+job configured to use it). A plain "review my changes" or "review this PR", or
+wrapping up an implementation, is not an invocation — review without this
+workflow unless the user names it.
 
 `medium` = **precision**. Every finding actionable. `high`, `xhigh`, `max` =
 **recall**. Missed bug ships. Keep uncertain findings when mechanism is real;

--- a/.agents/skills/base-ui-review/SKILL.md
+++ b/.agents/skills/base-ui-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: base-ui-review
-description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use ONLY when explicitly requested by name: the user runs /base-ui-review, writes $base-ui-review, or asks for "the Base UI review skill". Do NOT use for general review requests such as "review my changes", "review this diff/branch/PR", or after finishing an implementation — handle those without this skill unless the user names it. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, or --fix to apply findings.'
+description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use ONLY when explicitly requested by name: the user runs /base-ui-review, writes $base-ui-review, or asks for "the Base UI review skill". Do NOT use for general review requests such as "review my changes", "review this diff/branch/PR", or after finishing an implementation — handle those without this skill unless the user names it. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, or --fix to apply findings.'
 ---
 
 # Base UI Review
@@ -12,7 +12,7 @@ Review current diff. Find **regressions and correctness bugs** first. Also find
 Argument hint: `[low|medium|high|xhigh|max] [--fix] [--comment [inline]] [<target>]`
 
 This skill is **opt-in only**: run it when the user explicitly asks for it by
-name (`/base-ui-review`, `$base-ui-review`, "the Base UI review skill", or a CI
+name (`/base-ui-review`, `$base-ui-review`, "the Base UI review skill", or a CI
 job configured to use it). A plain "review my changes" or "review this PR", or
 wrapping up an implementation, is not an invocation — review without this
 workflow unless the user names it.

--- a/.claude/skills/base-ui-review/SKILL.md
+++ b/.claude/skills/base-ui-review/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: base-ui-review
-description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use when the user asks to review changes, review a diff/branch/PR, or runs /base-ui-review. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, or --fix to apply findings.'
+description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use ONLY when explicitly requested by name: the user runs /base-ui-review, writes $base-ui-review, or asks for "the Base UI review skill". Do NOT use for general review requests such as "review my changes", "review this diff/branch/PR", or after finishing an implementation — handle those without this skill unless the user names it. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, or --fix to apply findings.'
 ---
 
 # Base UI Review
 
 This is the Claude Code entrypoint for the shared repo skill.
+
+Only run when the user explicitly asks for this skill by name
+(`/base-ui-review`, `$base-ui-review`, "the Base UI review skill", or a CI job
+configured to use it). Do not trigger on a generic "review my changes" request
+or after finishing an implementation.
 
 Before reviewing, read `.agents/skills/base-ui-review/SKILL.md` completely and
 follow that canonical workflow. Pass through any user arguments such as `low`,

--- a/.claude/skills/base-ui-review/SKILL.md
+++ b/.claude/skills/base-ui-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: base-ui-review
-description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use ONLY when explicitly requested by name: the user runs /base-ui-review, writes $base-ui-review, or asks for "the Base UI review skill". Do NOT use for general review requests such as "review my changes", "review this diff/branch/PR", or after finishing an implementation — handle those without this skill unless the user names it. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, or --fix to apply findings.'
+description: 'Review the current diff for regressions, correctness bugs, tests, simplifications, and docs issues, scaling depth to a low/medium/high/xhigh/max effort level. Use ONLY when explicitly requested by name: the user runs /base-ui-review, writes $base-ui-review, or asks for "the Base UI review skill". Do NOT use for general review requests such as "review my changes", "review this diff/branch/PR", or after finishing an implementation — handle those without this skill unless the user names it. Pass --comment to post a top-level PR comment, --comment inline for inline PR comments, or --fix to apply findings.'
 ---
 
 # Base UI Review
@@ -8,7 +8,7 @@ description: 'Review the current diff for regressions, correctness bugs, tests, 
 This is the Claude Code entrypoint for the shared repo skill.
 
 Only run when the user explicitly asks for this skill by name
-(`/base-ui-review`, `$base-ui-review`, "the Base UI review skill", or a CI job
+(`/base-ui-review`, `$base-ui-review`, "the Base UI review skill", or a CI job
 configured to use it). Do not trigger on a generic "review my changes" request
 or after finishing an implementation.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This repository contains the source code and documentation for Base UI: a headl
 
 - The shared `/base-ui-review` skill lives in `.agents/skills/base-ui-review/SKILL.md`. Update that file when the Base UI review workflow changes.
 - Claude Code discovers the same shared skill through `.claude/skills/base-ui-review/SKILL.md`, which delegates to the `.agents` copy.
+- The review skill is opt-in: only run it when the user explicitly asks for it by name (`/base-ui-review`). Do not trigger it from a generic review request or after finishing a change.
 
 ## Code guidelines
 


### PR DESCRIPTION
The `base-ui-review` skill's description told agents to use it "when the user asks to review changes, review a diff/branch/PR", so it fired on generic review requests and after finishing an implementation. This makes it opt-in.

- Both skill copies (`.agents` canonical, `.claude` entrypoint) now say to use the skill **only** when asked for by name — `/base-ui-review`, `$base-ui-review`, a request naming the skill, or a CI job configured to use it — and explicitly list the cases that should not trigger it.
- Added a matching note in each skill body and a bullet in `AGENTS.md`, so agents reading the repo guidelines don't reach for it unprompted.

The `claude-review.yml` workflow that passes `review-skill: base-ui-review` is unaffected: it invokes the skill by name, which both descriptions carve out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)