### PR TITLE
[number-field] Reject dotted text that is not plausibly grouped

### DIFF
--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -2694,6 +2694,39 @@ describe('<NumberField />', () => {
       expect(onValueChange.mock.calls[0][0]).toBe(1234567.89);
     });
 
+    it('does not commit a value the input never showed for implausibly dotted text', async () => {
+      const onValueChange = vi.fn();
+      function App() {
+        const [value, setValue] = React.useState<number | null>(5);
+        return (
+          <NumberField
+            name="n"
+            value={value}
+            onValueChange={(v) => {
+              onValueChange(v);
+              setValue(v);
+            }}
+          />
+        );
+      }
+
+      await render(<App />);
+
+      const input = screen.getByRole('textbox');
+      fireEvent.change(input, { target: { value: '1.2.3' } });
+
+      // `1.2.3` is not a number in any locale, so nothing is committed and the value the form
+      // would submit is still the one the user last saw.
+      expect(onValueChange.mock.calls.length).toBe(0);
+      expect(input).toHaveValue('1.2.3');
+
+      const hiddenInput = document.querySelector<HTMLInputElement>(
+        'input[aria-hidden][type=number]',
+      );
+      expect(hiddenInput).not.toBe(null);
+      expect(hiddenInput!.value).toBe('5');
+    });
+
     it('allows composition key events (IME) without preventing default', async () => {
       await render(<NumberField />);
 

--- a/packages/react/src/number-field/utils/parse.test.ts
+++ b/packages/react/src/number-field/utils/parse.test.ts
@@ -196,6 +196,14 @@ describe('NumberField parse', () => {
       expect(parseNumber('1.234.567.89')).toBe(1234567.89);
     });
 
+    it('returns null when the extra dots are not in grouping positions', () => {
+      // Collapsing these would return a number the user never entered.
+      expect(parseNumber('1.2.3')).toBe(null);
+      expect(parseNumber('12.34.567')).toBe(null);
+      expect(parseNumber('1234.567.89')).toBe(null);
+      expect(parseNumber('.5.5')).toBe(null);
+    });
+
     it('parses number with mixed separators (FR)', () => {
       expect(parseNumber('1.234.567,89', 'fr-FR')).toBe(1234567.89);
     });

--- a/packages/react/src/number-field/utils/parse.ts
+++ b/packages/react/src/number-field/utils/parse.ts
@@ -58,6 +58,20 @@ function shiftDecimal(value: number, exponentDelta: number) {
   return Number(`${coefficient}e${Number(exponent) + exponentDelta}`);
 }
 
+// Every locale that separates thousands with '.' uses groups of exactly three digits, with one to
+// three in the leading group. Digits are ASCII and signs are stripped by the time these run.
+const LEADING_GROUP_RE = /^\d{1,3}$/;
+const GROUP_RE = /^\d{3}$/;
+
+/**
+ * Whether dot-separated text can be read as a grouped number — `['1', '234', '567', '89']` can,
+ * `['1', '2', '3']` cannot. Only the parts before the final dot are grouping candidates; the last
+ * part is the fractional digits and is left for `parseFloat` to judge.
+ */
+function isPlausiblyGrouped(parts: string[]) {
+  return LEADING_GROUP_RE.test(parts[0]) && parts.slice(1, -1).every((part) => GROUP_RE.test(part));
+}
+
 export const ANY_MINUS_RE = /[-−－‒–—﹣]/gu;
 export const ANY_PLUS_RE = /[+＋﹢]/gu;
 export const ANY_MINUS_DETECT_RE = /[-−－‒–—﹣]/;
@@ -187,10 +201,22 @@ export function parseNumber(
     return regex ? acc.replace(regex, replacement as any) : acc;
   }, input);
 
-  // Mixed-locale safety: keep only the last '.' as decimal
-  const lastDot = unformatted.lastIndexOf('.');
-  if (lastDot !== -1) {
-    unformatted = `${unformatted.slice(0, lastDot).replace(/\./g, '')}.${unformatted.slice(lastDot + 1).replace(/\./g, '')}`;
+  // Mixed-locale safety: keep only the last '.' as decimal, but only when the earlier dots sit
+  // where a group separator can sit. A European-formatted paste reaching a US-locale field
+  // arrives as `1.234.567.89`, and collapsing recovers the number the user meant. The same
+  // collapse applied to `1.2.3` invents `12.3` — a number nobody typed, committed to `value` and
+  // to the hidden input while the visible input still reads `1.2.3`. Text that is not plausibly
+  // grouped is rejected instead, which is how every other unparseable string here behaves.
+  // Runs of consecutive dots are typos rather than grouping, and squeezing them first keeps
+  // `1..5` and `....5` reading as 1.5 and 0.5.
+  const dotParts = unformatted.replace(/\.{2,}/g, '.').split('.');
+  if (dotParts.length > 2) {
+    if (!isPlausiblyGrouped(dotParts)) {
+      return null;
+    }
+    unformatted = `${dotParts.slice(0, -1).join('')}.${dotParts[dotParts.length - 1]}`;
+  } else {
+    unformatted = dotParts.join('.');
   }
 
   // Guard against Infinity inputs (ASCII and symbol)


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Fixes #5424.

## The defect

`parseNumber` keeps only the last `.` as the decimal separator and strips the rest ("Mixed-locale safety"), which is what lets a European-formatted paste like `1.234.567.89` resolve in a US-locale field. The same rule also accepted text that is not a plausible number in any locale:

```js
parseNumber('1.2.3'); // 12.3
```

Typing can't reach it — `onKeyDown` blocks a second decimal separator — but drop, IME composition, autofill and `actionsRef.current.setInputValue()` all route through the same path. The visible input then reads `1.2.3` while `value` and the hidden `<input type="number">` hold `12.3`, and the two stay divergent until blur, so a form submitted in between sends a number the user never saw.

## The change

The extra dots are collapsed only when they sit where a group separator can sit: one to three digits in the leading group, and exactly three in every group between the first and the last dot. Anything else returns `null`.

`null` is the existing rejection path, so the behaviour a user sees is the one every other unparseable string already produces: the input keeps the typed text, nothing is committed to `value` or to the hidden input, and blur restores the last committed value. Nothing new was added to the component.

Runs of consecutive dots are squeezed before the check, so the pinned typo repairs are untouched:

| input | before | after |
| --- | --- | --- |
| `1.234.567.89` | `1234567.89` | `1234567.89` |
| `1.234.567,89` (fr-FR / en-US / de-DE) | unchanged | unchanged |
| `1..5` | `1.5` | `1.5` |
| `....5` | `0.5` | `0.5` |
| `1.2.3` | `12.3` | `null` |
| `12.34.567` | `1234.567` | `null` |
| `1234.567.89` | `1234567.89` | `null` |
| `.5.5` | `5.5` | `null` |

The two leniencies the issue listed as maybe-out-of-scope are left alone: `parseNumber('1-2')` still returns `1`, and `parseNumber('5-')` still returns `-5` (deliberate accounting-style trailing sign). Happy to take either in a follow-up if you want them tightened.

## Tests

- `parse.test.ts` — a new case pinning `null` for the four implausible shapes above, beside the existing `collapses extra dots from mixed-locale inputs`.
- `NumberFieldRoot.test.tsx` — the issue notes the existing integration test asserts only the resulting value and never the visible text, which is why the divergence went unnoticed. The new test asserts the other half: after `1.2.3` arrives, `onValueChange` is not called, the input shows `1.2.3`, and the hidden `input[type=number]` still holds the value the user last saw.

Both fail on `master` and pass with the change.

```
pnpm test:jsdom NumberField --no-watch     398 passed | 17 skipped
pnpm test:chromium NumberField --no-watch  428 passed | 1 skipped
pnpm test:jsdom parse --no-watch            57 passed | 1 skipped
pnpm eslint <changed files>                 clean
pnpm typescript                             clean
```

---

*Disclosure: this patch was written and tested end to end by an autonomous AI agent; a human principal is accountable for it. [What this account is](https://github.com/sujeito-operator). Ask me anything about how it was produced and I will answer.*