### PR TITLE
[all components] Fix prop and ref merging for lazy render elements

### DIFF
--- a/packages/react/src/internals/useRenderElement.test.tsx
+++ b/packages/react/src/internals/useRenderElement.test.tsx
@@ -514,14 +514,17 @@ describe('useRenderElement', () => {
     });
 
     // The Flight client hands a Client Component a `react.lazy` wrapper in place of a
-    // render element created in a Server Component. React 18's Children.toArray() does
-    // not unwrap lazy elements, and this shape only occurs with React 19+ anyway.
+    // render element created in a Server Component. Skipped below React 19, whose
+    // Children.toArray() is the first to unwrap lazy elements.
     describe.skipIf(reactMajor < 19)('lazy-wrapped render element (Flight shape)', () => {
-      function wrapLazy(element: React.ReactElement): React.ReactElement {
+      function wrapLazy(
+        element: React.ReactElement,
+        init: (payload: unknown) => unknown = (payload) => payload,
+      ): React.ReactElement {
         return {
           $$typeof: Symbol.for('react.lazy'),
           _payload: element,
-          _init: (payload: unknown) => payload,
+          _init: init,
         } as unknown as React.ReactElement;
       }
 
@@ -555,6 +558,43 @@ describe('useRenderElement', () => {
         const element = container.firstElementChild;
         expect(renderRef.current).toBe(element);
         expect(componentRef.current).toBe(element);
+      });
+
+      it('does not unwrap a pending element when disabled', async () => {
+        const init = vi.fn(() => {
+          throw new Promise(() => {});
+        });
+
+        function DisabledLazyComponent(props: { render: React.ReactElement }) {
+          return useRenderElement('div', props, { enabled: false });
+        }
+
+        const { container } = await render(
+          <React.Suspense fallback={<div data-testid="fallback" />}>
+            <DisabledLazyComponent render={wrapLazy(<div />, init)} />
+          </React.Suspense>,
+        );
+
+        expect(container.innerHTML).toBe('');
+        expect(init).not.toHaveBeenCalled();
+      });
+
+      it('reports a wrapper that unwraps to nothing as an invalid render element', async () => {
+        const originalEnv = process.env.NODE_ENV;
+
+        let error: Error | null = null;
+        try {
+          process.env.NODE_ENV = 'development';
+          await render(<TestComponent render={wrapLazy(null as any)} />);
+        } catch (err) {
+          error = err as Error;
+        } finally {
+          process.env.NODE_ENV = originalEnv;
+        }
+
+        expect(error?.message).toMatch(
+          /Base UI: The `render` prop was provided an invalid React element/,
+        );
       });
     });
 

--- a/packages/react/src/internals/useRenderElement.test.tsx
+++ b/packages/react/src/internals/useRenderElement.test.tsx
@@ -579,23 +579,33 @@ describe('useRenderElement', () => {
         expect(init).not.toHaveBeenCalled();
       });
 
-      it('reports a wrapper that unwraps to nothing as an invalid render element', async () => {
-        const originalEnv = process.env.NODE_ENV;
+      // `Children.toArray` drops nullish and boolean children but keeps strings and
+      // numbers, so both shapes have to survive as invalid render elements.
+      it.each([
+        ['null', null],
+        ['false', false],
+        ['the number 0', 0],
+        ['an empty string', ''],
+      ])(
+        'reports a wrapper that unwraps to %s as an invalid render element',
+        async (_, payload) => {
+          const originalEnv = process.env.NODE_ENV;
 
-        let error: Error | null = null;
-        try {
-          process.env.NODE_ENV = 'development';
-          await render(<TestComponent render={wrapLazy(null as any)} />);
-        } catch (err) {
-          error = err as Error;
-        } finally {
-          process.env.NODE_ENV = originalEnv;
-        }
+          let error: Error | null = null;
+          try {
+            process.env.NODE_ENV = 'development';
+            await render(<TestComponent render={wrapLazy(payload as any)} />);
+          } catch (err) {
+            error = err as Error;
+          } finally {
+            process.env.NODE_ENV = originalEnv;
+          }
 
-        expect(error?.message).toMatch(
-          /Base UI: The `render` prop was provided an invalid React element/,
-        );
-      });
+          expect(error?.message).toMatch(
+            /Base UI: The `render` prop was provided an invalid React element/,
+          );
+        },
+      );
     });
 
     // React 18 also log console error, React 19 fixed that. Ignoring this test for React 18.

--- a/packages/react/src/internals/useRenderElement.test.tsx
+++ b/packages/react/src/internals/useRenderElement.test.tsx
@@ -513,6 +513,51 @@ describe('useRenderElement', () => {
       expect(element?.className).toContain('test-component');
     });
 
+    // The Flight client hands a Client Component a `react.lazy` wrapper in place of a
+    // render element created in a Server Component. React 18's Children.toArray() does
+    // not unwrap lazy elements, and this shape only occurs with React 19+ anyway.
+    describe.skipIf(reactMajor < 19)('lazy-wrapped render element (Flight shape)', () => {
+      function wrapLazy(element: React.ReactElement): React.ReactElement {
+        return {
+          $$typeof: Symbol.for('react.lazy'),
+          _payload: element,
+          _init: (payload: unknown) => payload,
+        } as unknown as React.ReactElement;
+      }
+
+      it('merges props with the same precedence as a plain render element', async () => {
+        const { container } = await render(
+          <TestComponent
+            active
+            data-slot="component"
+            render={wrapLazy(
+              <div className="render-class" style={{ fontSize: '16px' }} data-slot="render" />,
+            )}
+          />,
+        );
+
+        const element = container.firstElementChild as HTMLElement;
+        expect(element.getAttribute('data-slot')).toBe('render');
+        expect(element.className).toContain('render-class');
+        expect(element.className).toContain('test-component');
+        expect(element.style.fontSize).toBe('16px');
+        expect(element.style.padding).toBe('10px');
+      });
+
+      it('attaches the render element ref', async () => {
+        const renderRef = React.createRef<HTMLDivElement>();
+        const componentRef = React.createRef<HTMLDivElement>();
+
+        const { container } = await render(
+          <TestComponent ref={componentRef} render={wrapLazy(<div ref={renderRef} />)} />,
+        );
+
+        const element = container.firstElementChild;
+        expect(renderRef.current).toBe(element);
+        expect(componentRef.current).toBe(element);
+      });
+    });
+
     // React 18 also log console error, React 19 fixed that. Ignoring this test for React 18.
     it.skipIf(reactMajor < 19)(
       'throws error for invalid render element in development',

--- a/packages/react/src/internals/useRenderElement.tsx
+++ b/packages/react/src/internals/useRenderElement.tsx
@@ -149,9 +149,10 @@ function unwrapLazyRenderProp<State>(
   if ((render as { $$typeof?: symbol | undefined } | undefined)?.$$typeof !== REACT_LAZY_TYPE) {
     return render;
   }
-  // Keep the wrapper when it unwraps to nothing, so an invalid render prop is still
+  // Keep the wrapper unless it unwraps to an element, so an invalid render prop is still
   // reported as one instead of silently falling back to the default element.
-  return (React.Children.toArray(render as React.ReactNode)[0] as React.ReactElement) ?? render;
+  const unwrapped = React.Children.toArray(render as React.ReactNode)[0];
+  return React.isValidElement(unwrapped) ? unwrapped : render;
 }
 
 function evaluateRenderProp<T extends React.ElementType, S>(

--- a/packages/react/src/internals/useRenderElement.tsx
+++ b/packages/react/src/internals/useRenderElement.tsx
@@ -57,8 +57,8 @@ function useRenderElementProps<
   Enabled extends boolean | undefined,
 >(
   componentProps: UseRenderElementComponentProps<State>,
-  params: UseRenderElementParameters<State, RenderedElementType, TagName, Enabled> = {},
-  renderProp?: UseRenderElementComponentProps<State>['render'],
+  params: UseRenderElementParameters<State, RenderedElementType, TagName, Enabled>,
+  renderProp: UseRenderElementComponentProps<State>['render'],
 ): React.HTMLAttributes<any> & React.RefAttributes<any> {
   const { className: classNameProp, style: styleProp } = componentProps;
 
@@ -146,11 +146,12 @@ function unwrapLazyRenderProp<State>(
   render: UseRenderElementComponentProps<State>['render'],
 ): UseRenderElementComponentProps<State>['render'] {
   // `$$typeof` is a React internal, absent from the public element types.
-  const maybeLazy = render as { $$typeof?: symbol | undefined } | undefined;
-  if (typeof render === 'object' && maybeLazy?.$$typeof === REACT_LAZY_TYPE) {
-    return React.Children.toArray(render)[0] as React.ReactElement;
+  if ((render as { $$typeof?: symbol | undefined } | undefined)?.$$typeof !== REACT_LAZY_TYPE) {
+    return render;
   }
-  return render;
+  // Keep the wrapper when it unwraps to nothing, so an invalid render prop is still
+  // reported as one instead of silently falling back to the default element.
+  return (React.Children.toArray(render as React.ReactNode)[0] as React.ReactElement) ?? render;
 }
 
 function evaluateRenderProp<T extends React.ElementType, S>(

--- a/packages/react/src/internals/useRenderElement.tsx
+++ b/packages/react/src/internals/useRenderElement.tsx
@@ -29,8 +29,14 @@ export function useRenderElement<
   componentProps: UseRenderElementComponentProps<State>,
   params: UseRenderElementParameters<State, RenderedElementType, TagName, Enabled> = {},
 ): Enabled extends false ? null : React.ReactElement {
-  const renderProp = componentProps.render;
-  const outProps = useRenderElementProps(componentProps, params);
+  let renderProp = componentProps.render;
+  if (params.enabled !== false) {
+    // A pending lazy element suspends when unwrapped, so leave it wrapped while disabled.
+    renderProp = unwrapLazyRenderProp(renderProp);
+  }
+
+  const outProps = useRenderElementProps(componentProps, params, renderProp);
+
   if (params.enabled === false) {
     return null as Enabled extends false ? null : React.ReactElement;
   }
@@ -52,8 +58,9 @@ function useRenderElementProps<
 >(
   componentProps: UseRenderElementComponentProps<State>,
   params: UseRenderElementParameters<State, RenderedElementType, TagName, Enabled> = {},
+  renderProp?: UseRenderElementComponentProps<State>['render'],
 ): React.HTMLAttributes<any> & React.RefAttributes<any> {
-  const { className: classNameProp, style: styleProp, render: renderProp } = componentProps;
+  const { className: classNameProp, style: styleProp } = componentProps;
 
   const {
     state = EMPTY_OBJECT as State,
@@ -129,6 +136,23 @@ const REACT_LAZY_TYPE = Symbol.for('react.lazy');
 const COMPONENT_IDENTIFIER_PATTERN = /^[A-Z][A-Za-z0-9$]*$/;
 const LOWERCASE_CHARACTER_PATTERN = /[a-z]/;
 
+// Workaround for https://github.com/react/react/issues/32392
+// The Flight client hands over a lazy wrapper in place of a render element created in a
+// Server Component. The wrapper exposes no `.props` or `.ref`, so it must be unwrapped
+// before those are read. This works because the toArray() logic unwraps the lazy
+// element type in
+// https://github.com/react/react/blob/a0566250b210499b4c5677f5ac2eedbd71d51a1b/packages/react/src/ReactChildren.js#L186
+function unwrapLazyRenderProp<State>(
+  render: UseRenderElementComponentProps<State>['render'],
+): UseRenderElementComponentProps<State>['render'] {
+  // `$$typeof` is a React internal, absent from the public element types.
+  const maybeLazy = render as { $$typeof?: symbol | undefined } | undefined;
+  if (typeof render === 'object' && maybeLazy?.$$typeof === REACT_LAZY_TYPE) {
+    return React.Children.toArray(render)[0] as React.ReactElement;
+  }
+  return render;
+}
+
 function evaluateRenderProp<T extends React.ElementType, S>(
   element: IntrinsicTagName | undefined,
   render: BaseUIComponentProps<T, S>['render'],
@@ -147,15 +171,6 @@ function evaluateRenderProp<T extends React.ElementType, S>(
 
     mergedProps.ref = props.ref;
 
-    let newElement = render;
-    // Workaround for https://github.com/react/react/issues/32392
-    // This works because the toArray() logic unwrap lazy element type in
-    // https://github.com/react/react/blob/a0566250b210499b4c5677f5ac2eedbd71d51a1b/packages/react/src/ReactChildren.js#L186
-    if (newElement?.$$typeof === REACT_LAZY_TYPE) {
-      const children = React.Children.toArray(render);
-      newElement = children[0] as BaseUIComponentProps<T, S>['render'];
-    }
-
     // There is a high number of indirections, the error message thrown by React.cloneElement() is
     // hard to use for developers, this logic provides a better context.
     //
@@ -163,7 +178,7 @@ function evaluateRenderProp<T extends React.ElementType, S>(
     // However, React.cloneElement() throws if React.isValidElement() is false,
     // so we can throw before with custom message.
     if (process.env.NODE_ENV !== 'production') {
-      if (!React.isValidElement(newElement)) {
+      if (!React.isValidElement(render)) {
         // TODO: fix mui/no-guarded-throw
         // eslint-disable-next-line mui/no-guarded-throw
         throw new Error(
@@ -176,7 +191,7 @@ function evaluateRenderProp<T extends React.ElementType, S>(
       }
     }
 
-    return React.cloneElement(newElement, mergedProps);
+    return React.cloneElement(render, mergedProps);
   }
   if (element) {
     if (typeof element === 'string') {


### PR DESCRIPTION
Fixes #5431
Fixes #5561

`useRenderElement` read the render element's props (`mergeProps(props, render.props)`) and its ref (`getReactElementRef`) before the #3856 lazy unwrap. A lazy render element, which is what the Flight client hands a Client Component when a Server Component element gets deferred into its own payload row, has no `.props` or `.ref`. Its props therefore lost the documented precedence (the component's own props silently won) and its ref was never attached. Since Flight defers based on payload size, the server and client passes could disagree, which surfaced as hydration mismatches in Next.js App Router apps.

## Changes

- Unwrap the lazy element once at the top of `useRenderElement`, before the ref extraction and the prop merge, instead of just before `cloneElement`. The unwrap is skipped when `enabled: false`, since unwrapping a pending lazy element suspends and the disabled path never suspended before.
- Added regression tests using the Flight lazy element shape, gated to React 19+ because `Children.toArray` only unwraps lazy elements there (which also means the #3856 workaround was already React 19-only).