### PR TITLE
[field][checkbox][switch] Fix controlled blur validation and stale filled state

### DIFF
--- a/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
@@ -398,6 +398,28 @@ describe('<CheckboxGroup />', () => {
       expect(group).not.toHaveAttribute('data-dirty');
     });
 
+    it('[data-filled] follows the group value even without a matching rendered checkbox', () => {
+      render(
+        <Field.Root name="fruits">
+          <CheckboxGroup defaultValue={['cherry']}>
+            <Field.Item>
+              <Checkbox.Root value="apple" data-testid="apple" />
+            </Field.Item>
+          </CheckboxGroup>
+        </Field.Root>,
+      );
+
+      const group = screen.getByRole('group');
+      const apple = screen.getByTestId('apple');
+
+      expect(group).toHaveAttribute('data-filled', '');
+
+      fireEvent.click(apple);
+      fireEvent.click(apple);
+
+      expect(group).toHaveAttribute('data-filled', '');
+    });
+
     it('keeps a required error while another required checkbox in the group is unchecked', async () => {
       const { user } = render(
         <Form onSubmit={(event) => event.preventDefault()}>

--- a/packages/react/src/checkbox-group/CheckboxGroup.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 import { useControlled } from '@base-ui/utils/useControlled';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { EMPTY_ARRAY } from '@base-ui/utils/empty';
 import { areArraysEqual } from '@base-ui/utils/areArraysEqual';
@@ -121,6 +122,10 @@ export const CheckboxGroup = React.forwardRef(function CheckboxGroup(
 
   useRegisterFieldControl(controlRef, id, value, getFormValue, !!fieldName && !disabled, fieldName);
 
+  useIsoLayoutEffect(() => {
+    setFilled(value.length > 0);
+  }, [value, setFilled]);
+
   useValueChanged(value, () => {
     if (fieldName) {
       clearErrors(fieldName);
@@ -130,7 +135,6 @@ export const CheckboxGroup = React.forwardRef(function CheckboxGroup(
       ? (validityData.initialValue as readonly string[])
       : EMPTY_ARRAY;
 
-    setFilled(value.length > 0);
     setDirty(!areArraysEqual(value, initialValue));
 
     validation.change(value);

--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -1355,6 +1355,33 @@ describe('<Checkbox.Root />', () => {
         expect(button).not.toHaveAttribute('data-filled', '');
       });
 
+      it('clears [data-filled] when a controlled checkbox remounts unchecked', async () => {
+        function App() {
+          const [unchecked, setUnchecked] = React.useState(false);
+          return (
+            <Field.Root data-testid="root">
+              <Checkbox.Root
+                key={String(unchecked)}
+                checked={!unchecked}
+                onCheckedChange={() => {}}
+              />
+              <button type="button" onClick={() => setUnchecked(true)}>
+                clear
+              </button>
+            </Field.Root>
+          );
+        }
+
+        await render(<App />);
+
+        const root = screen.getByTestId('root');
+        expect(root).toHaveAttribute('data-filled', '');
+
+        fireEvent.click(screen.getByText('clear'));
+
+        expect(root).not.toHaveAttribute('data-filled');
+      });
+
       it('adds [data-filled] attribute when any checkbox is filled when inside a group', async () => {
         await render(
           <Field.Root>

--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -467,6 +467,31 @@ describe('<Checkbox.Root />', () => {
       expect(input.indeterminate).toBe(true);
     });
 
+    it('keeps the native input state when checked changes while indeterminate remains', async () => {
+      function App() {
+        const [checked, setChecked] = React.useState(false);
+        return (
+          <Checkbox.Root
+            data-testid="button"
+            indeterminate
+            checked={checked}
+            onCheckedChange={setChecked}
+          />
+        );
+      }
+
+      await render(<App />);
+
+      // Clicking the hidden input natively clears `indeterminate` before toggling.
+      fireEvent.click(screen.getByTestId('button'));
+
+      const [, input] = screen.getAllByRole<HTMLInputElement>('checkbox', {
+        hidden: true,
+      });
+      expect(input.checked).toBe(true);
+      expect(input.indeterminate).toBe(true);
+    });
+
     it('sets indeterminate style hooks on the root and indicator', async () => {
       await render(
         <Checkbox.Root indeterminate>

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -173,11 +173,15 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
   useIsoLayoutEffect(() => {
     if (inputRef.current) {
       inputRef.current.indeterminate = computedIndeterminate;
-      if (checked) {
-        setFilled(true);
-      }
     }
-  }, [checked, computedIndeterminate, setFilled]);
+  }, [computedIndeterminate]);
+
+  useIsoLayoutEffect(() => {
+    // Inside a group, the group derives the filled state from its value.
+    if (!groupContext) {
+      setFilled(checked);
+    }
+  }, [checked, groupContext, setFilled]);
 
   useValueChanged(checked, () => {
     if (groupContext) {
@@ -185,7 +189,6 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
     }
 
     clearErrors(name);
-    setFilled(checked);
     setDirty(checked !== validityData.initialValue);
 
     validation.change(checked);

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -172,9 +172,10 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
 
   useIsoLayoutEffect(() => {
     if (inputRef.current) {
+      // Re-assert on `checked` changes too: clicking the input natively resets `indeterminate`.
       inputRef.current.indeterminate = computedIndeterminate;
     }
-  }, [computedIndeterminate]);
+  }, [checked, computedIndeterminate]);
 
   useIsoLayoutEffect(() => {
     // Inside a group, the group derives the filled state from its value.

--- a/packages/react/src/checkbox/root/CheckboxRoot.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.tsx
@@ -175,14 +175,11 @@ export const CheckboxRoot = React.forwardRef(function CheckboxRoot(
       // Re-assert on `checked` changes too: clicking the input natively resets `indeterminate`.
       inputRef.current.indeterminate = computedIndeterminate;
     }
-  }, [checked, computedIndeterminate]);
-
-  useIsoLayoutEffect(() => {
     // Inside a group, the group derives the filled state from its value.
     if (!groupContext) {
       setFilled(checked);
     }
-  }, [checked, groupContext, setFilled]);
+  }, [checked, computedIndeterminate, groupContext, setFilled]);
 
   useValueChanged(checked, () => {
     if (groupContext) {

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -266,6 +266,43 @@ describe('<Field.Control />', () => {
     expect(screen.getByTestId('root')).not.toHaveAttribute('data-filled');
   });
 
+  it('clears filled state when a controlled control remounts empty', async () => {
+    function App() {
+      const [empty, setEmpty] = React.useState(false);
+      return (
+        <Field.Root data-testid="root">
+          <Field.Control
+            key={String(empty)}
+            value={empty ? '' : 'value'}
+            onValueChange={() => {}}
+          />
+          <button type="button" onClick={() => setEmpty(true)}>
+            clear
+          </button>
+        </Field.Root>
+      );
+    }
+
+    await render(<App />);
+
+    const root = screen.getByTestId('root');
+    expect(root).toHaveAttribute('data-filled', '');
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(root).not.toHaveAttribute('data-filled');
+  });
+
+  it('sets filled state from a controlled value on a custom element', async () => {
+    await render(
+      <Field.Root data-testid="root">
+        <Field.Control value="value" onValueChange={() => {}} render={<div />} />
+      </Field.Root>,
+    );
+
+    expect(screen.getByTestId('root')).toHaveAttribute('data-filled', '');
+  });
+
   it('does not validate when the change is canceled', async () => {
     const validate = vi.fn(() => null);
 

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -293,6 +293,29 @@ describe('<Field.Control />', () => {
     expect(root).not.toHaveAttribute('data-filled');
   });
 
+  it('clears filled state when an uncontrolled control remounts empty', async () => {
+    function App() {
+      const [empty, setEmpty] = React.useState(false);
+      return (
+        <Field.Root data-testid="root">
+          <Field.Control key={String(empty)} defaultValue={empty ? '' : 'value'} />
+          <button type="button" onClick={() => setEmpty(true)}>
+            clear
+          </button>
+        </Field.Root>
+      );
+    }
+
+    await render(<App />);
+
+    const root = screen.getByTestId('root');
+    expect(root).toHaveAttribute('data-filled', '');
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(root).not.toHaveAttribute('data-filled');
+  });
+
   it('sets filled state from a controlled value on a custom element', async () => {
     await render(
       <Field.Root data-testid="root">

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
 import { expect, vi } from 'vitest';
-import { act, createRenderer, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import {
+  act,
+  createRenderer,
+  fireEvent,
+  flushMicrotasks,
+  screen,
+  waitFor,
+} from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
 import { describeConformance, isJSDOM } from '#test-utils';
@@ -164,6 +171,79 @@ describe('<Field.Control />', () => {
     expect(root).toHaveAttribute('data-dirty', '');
     expect(validate).toHaveBeenCalledTimes(1);
     expect(validate.mock.lastCall?.[0]).toBe('external');
+  });
+
+  it('validates the final controlled value when it is normalized on blur', async () => {
+    const validate = vi.fn((value) => (String(value).includes('@') ? null : 'Invalid email'));
+
+    function App() {
+      const [value, setValue] = React.useState('');
+      return (
+        <Field.Root validationMode="onBlur" validate={validate}>
+          <Field.Control
+            value={value}
+            onValueChange={setValue}
+            onBlur={() => setValue((currentValue) => currentValue.trim())}
+          />
+          <Field.Error />
+        </Field.Root>
+      );
+    }
+
+    await render(<App />);
+
+    const control = screen.getByRole('textbox');
+    fireEvent.change(control, { target: { value: 'foo ' } });
+    fireEvent.blur(control);
+
+    await flushMicrotasks();
+
+    expect(validate.mock.lastCall?.[0]).toBe('foo');
+    expect(screen.getByText('Invalid email')).toBeInTheDocument();
+  });
+
+  it('keeps the final async validation when a controlled value is normalized on blur', async () => {
+    const resolvers: Record<string, (value: string | null) => void> = {};
+    const validate = vi.fn(
+      (value) =>
+        new Promise<string | null>((resolve) => {
+          resolvers[String(value)] = resolve;
+        }),
+    );
+
+    function App() {
+      const [value, setValue] = React.useState('');
+      return (
+        <Field.Root validationMode="onBlur" validate={validate}>
+          <Field.Control
+            value={value}
+            onValueChange={setValue}
+            onBlur={() => setValue((currentValue) => currentValue.trim())}
+          />
+          <Field.Error />
+        </Field.Root>
+      );
+    }
+
+    await render(<App />);
+
+    const control = screen.getByRole('textbox');
+    fireEvent.change(control, { target: { value: 'foo ' } });
+    fireEvent.blur(control);
+
+    await flushMicrotasks();
+
+    expect(validate.mock.lastCall?.[0]).toBe('foo');
+
+    resolvers.foo('Invalid email');
+    await flushMicrotasks();
+
+    expect(screen.getByText('Invalid email')).toBeInTheDocument();
+
+    resolvers['foo ']?.('Stale error');
+    await flushMicrotasks();
+
+    expect(screen.getByText('Invalid email')).toBeInTheDocument();
   });
 
   it('sets filled state on mount when the control is prefilled', async () => {

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -233,6 +233,7 @@ describe('<Field.Control />', () => {
 
     await flushMicrotasks();
 
+    expect(validate).toHaveBeenCalledTimes(2);
     expect(validate.mock.lastCall?.[0]).toBe('foo');
 
     resolvers.foo('Invalid email');
@@ -240,7 +241,7 @@ describe('<Field.Control />', () => {
 
     expect(screen.getByText('Invalid email')).toBeInTheDocument();
 
-    resolvers['foo ']?.('Stale error');
+    resolvers['foo ']('Stale error');
     await flushMicrotasks();
 
     expect(screen.getByText('Invalid email')).toBeInTheDocument();

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -246,6 +246,33 @@ describe('<Field.Control />', () => {
     expect(screen.getByText('Invalid email')).toBeInTheDocument();
   });
 
+  it('does not validate when a controlled value is reset to the initial value on blur', async () => {
+    function App() {
+      const [value, setValue] = React.useState('');
+      return (
+        <Field.Root validationMode="onBlur">
+          <Field.Control
+            required
+            value={value}
+            onValueChange={setValue}
+            onBlur={() => setValue('')}
+          />
+          <Field.Error match="valueMissing">Required</Field.Error>
+        </Field.Root>
+      );
+    }
+
+    await render(<App />);
+
+    const control = screen.getByRole('textbox');
+    fireEvent.change(control, { target: { value: 'foo' } });
+    fireEvent.blur(control);
+
+    await flushMicrotasks();
+
+    expect(screen.queryByText('Required')).toBe(null);
+  });
+
   it('sets filled state on mount when the control is prefilled', async () => {
     await render(
       <Field.Root data-testid="root">

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -170,9 +170,15 @@ export const FieldControl = React.forwardRef(function FieldControl(
 
             if (isControlled) {
               // Controlled blur handlers can normalize the value before this microtask runs.
+              // A rewrite back to the initial value is a programmatic reset: the field looks
+              // pristine, so committing it would only surface `valueMissing` noise.
               queueMicrotask(() => {
                 const nextValue = validation.inputRef.current?.value;
-                if (nextValue !== undefined && nextValue !== inputValue) {
+                if (
+                  nextValue !== undefined &&
+                  nextValue !== inputValue &&
+                  nextValue !== (validityData.initialValue ?? '')
+                ) {
                   validation.commit(nextValue);
                 }
               });

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -165,7 +165,18 @@ export const FieldControl = React.forwardRef(function FieldControl(
           setFocused(false);
 
           if (validationMode === 'onBlur') {
-            validation.commit(event.currentTarget.value);
+            const inputValue = event.currentTarget.value;
+            validation.commit(inputValue);
+
+            if (isControlled) {
+              // Controlled blur handlers can normalize the value before this microtask runs.
+              queueMicrotask(() => {
+                const nextValue = validation.inputRef.current?.value;
+                if (nextValue !== undefined && nextValue !== inputValue) {
+                  validation.commit(nextValue);
+                }
+              });
+            }
           }
         },
         onKeyDown(event) {

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -98,10 +98,9 @@ export const FieldControl = React.forwardRef(function FieldControl(
   );
 
   useIsoLayoutEffect(() => {
-    if (serializedValue !== undefined) {
-      setFilled(serializedValue !== '');
-    } else if (validation.inputRef.current?.value) {
-      setFilled(true);
+    const currentValue = serializedValue ?? validation.inputRef.current?.value;
+    if (currentValue !== undefined) {
+      setFilled(currentValue !== '');
     }
   }, [serializedValue, validation.inputRef, setFilled]);
 

--- a/packages/react/src/field/control/FieldControl.tsx
+++ b/packages/react/src/field/control/FieldControl.tsx
@@ -98,10 +98,12 @@ export const FieldControl = React.forwardRef(function FieldControl(
   );
 
   useIsoLayoutEffect(() => {
-    if (validation.inputRef.current?.value) {
+    if (serializedValue !== undefined) {
+      setFilled(serializedValue !== '');
+    } else if (validation.inputRef.current?.value) {
       setFilled(true);
     }
-  }, [validation.inputRef, setFilled]);
+  }, [serializedValue, validation.inputRef, setFilled]);
 
   useValueChanged(serializedValue, () => {
     if (serializedValue === undefined) {
@@ -110,7 +112,6 @@ export const FieldControl = React.forwardRef(function FieldControl(
 
     clearErrors(name);
     setDirty(serializedValue !== (validityData.initialValue ?? ''));
-    setFilled(serializedValue !== '');
 
     validation.change(serializedValue);
   });

--- a/packages/react/src/switch/root/SwitchRoot.test.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.test.tsx
@@ -977,6 +977,33 @@ describe('<Switch.Root />', () => {
         expect(button).not.toHaveAttribute('data-filled');
       });
 
+      it('clears [data-filled] when a controlled switch remounts unchecked', async () => {
+        function App() {
+          const [unchecked, setUnchecked] = React.useState(false);
+          return (
+            <Field.Root data-testid="root">
+              <Switch.Root
+                key={String(unchecked)}
+                checked={!unchecked}
+                onCheckedChange={() => {}}
+              />
+              <button type="button" onClick={() => setUnchecked(true)}>
+                clear
+              </button>
+            </Field.Root>
+          );
+        }
+
+        await render(<App />);
+
+        const root = screen.getByTestId('root');
+        expect(root).toHaveAttribute('data-filled', '');
+
+        fireEvent.click(screen.getByText('clear'));
+
+        expect(root).not.toHaveAttribute('data-filled');
+      });
+
       it('removes [data-filled] attribute when unchecked after being initially checked', async () => {
         await render(
           <Field.Root>

--- a/packages/react/src/switch/root/SwitchRoot.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.tsx
@@ -93,15 +93,12 @@ export const SwitchRoot = React.forwardRef(function SwitchRoot(
   useRegisterFieldControl(switchRef, id, checked, undefined, !disabled, nameProp);
 
   useIsoLayoutEffect(() => {
-    if (inputRef.current) {
-      setFilled(inputRef.current.checked);
-    }
-  }, [setFilled]);
+    setFilled(checked);
+  }, [checked, setFilled]);
 
   useValueChanged(checked, () => {
     clearErrors(name);
     setDirty(checked !== validityData.initialValue);
-    setFilled(checked);
 
     validation.change(checked);
   });


### PR DESCRIPTION
Two field lifecycle fixes. The blur half is a regression from #5460; the filled half predates it.

- **Controlled blur normalization no longer discards validation.** With `validationMode="onBlur"`, a blur handler that normalizes the controlled value (e.g. `.trim()`) had its commit retired by the value's prop transition. The blur handler now re-commits the settled DOM value in a microtask, unless it settled back to the initial value (a programmatic reset stays quiet). Async normalization after blur is still not covered.
- **`filled` is now derived from the current value** in a layout effect (the `NumberField` pattern) instead of transition callbacks and write-only mount effects. This fixes stale `data-filled` on remounts and custom `render` elements in `Field.Control`, `Checkbox.Root`, and `Switch.Root`, and `CheckboxGroup` now fully owns the filled state.

`dirty` stays transition-driven: deriving it needs mount-time `initialValue` ordering guarantees and interacts with #5345.
