### PR TITLE
[combobox] Render groups with the rowgroup role in grid mode

### DIFF
--- a/docs/src/app/(docs)/react/components/autocomplete/demos/grid/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/grid/css-modules/index.tsx
@@ -72,6 +72,7 @@ export default function ExampleEmojiPicker() {
                     <div className={styles.Empty}>No emojis found</div>
                   </Autocomplete.Empty>
                   <Autocomplete.List
+                    aria-label="Emoji results"
                     className={styles.List}
                     style={{ '--cols': COLUMNS } as React.CSSProperties}
                   >

--- a/docs/src/app/(docs)/react/components/autocomplete/demos/grid/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/autocomplete/demos/grid/tailwind/index.tsx
@@ -78,7 +78,10 @@ export default function ExampleEmojiPicker() {
                       No emojis found
                     </div>
                   </Autocomplete.Empty>
-                  <Autocomplete.List className="max-h-[min(calc(20.5rem-var(--input-container-height)-2px),calc(var(--available-height)-var(--input-container-height)-2px))] overflow-auto scroll-pt-1 scroll-pb-[0.35rem] overscroll-contain py-2 empty:p-0">
+                  <Autocomplete.List
+                    aria-label="Emoji results"
+                    className="max-h-[min(calc(20.5rem-var(--input-container-height)-2px),calc(var(--available-height)-var(--input-container-height)-2px))] overflow-auto scroll-pt-1 scroll-pb-[0.35rem] overscroll-contain py-2 empty:p-0"
+                  >
                     {(group: EmojiGroup) => (
                       <Autocomplete.Group key={group.value} items={group.items} className="block">
                         <Autocomplete.GroupLabel className="p-2 text-sm leading-4 text-neutral-500 select-none dark:text-neutral-400">

--- a/packages/react/src/combobox/group/ComboboxGroup.tsx
+++ b/packages/react/src/combobox/group/ComboboxGroup.tsx
@@ -1,9 +1,12 @@
 'use client';
 import * as React from 'react';
+import { useStore } from '@base-ui/utils/store';
 import { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { ComboboxGroupContext } from './ComboboxGroupContext';
 import { GroupCollectionProvider } from '../collection/GroupCollectionContext';
+import { useComboboxRootContext } from '../root/ComboboxRootContext';
+import { selectors } from '../store';
 
 /**
  * Groups related items with the corresponding label.
@@ -16,6 +19,9 @@ export const ComboboxGroup = React.forwardRef(function ComboboxGroup(
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
   const { render, className, style, items, ...elementProps } = componentProps;
+
+  const store = useComboboxRootContext();
+  const grid = useStore(store, selectors.grid);
 
   const [labelId, setLabelId] = React.useState<string | undefined>();
 
@@ -32,7 +38,9 @@ export const ComboboxGroup = React.forwardRef(function ComboboxGroup(
     ref: forwardedRef,
     props: [
       {
-        role: 'group',
+        // `group` is not a valid owned element of `grid`, and `row` must be owned
+        // by `grid`, `rowgroup`, or `treegrid`.
+        role: grid ? 'rowgroup' : 'group',
         'aria-labelledby': labelId,
       },
       elementProps,

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -6236,6 +6236,34 @@ describe('<Combobox.Root />', () => {
       const grid = screen.getByRole('grid');
       expect(grid).not.toHaveAttribute('aria-orientation');
     });
+
+    it('renders groups with the rowgroup role', async () => {
+      await render(
+        <Combobox.Root grid defaultOpen>
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  <Combobox.Group>
+                    <Combobox.GroupLabel>Fruits</Combobox.GroupLabel>
+                    <Combobox.Row>
+                      <Combobox.Item value="1">1</Combobox.Item>
+                      <Combobox.Item value="2">2</Combobox.Item>
+                    </Combobox.Row>
+                  </Combobox.Group>
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      // `grid` may only own `row`/`rowgroup` elements (axe: aria-required-children),
+      // and `row` must be owned by `grid`, `rowgroup`, or `treegrid` (axe: aria-required-parent).
+      expect(screen.queryByRole('group')).toBeNull();
+      expect(screen.getByRole('rowgroup')).toHaveAccessibleName('Fruits');
+    });
   });
 
   describe('prop: multiple', () => {


### PR DESCRIPTION
Fixes #5560

When `grid` is enabled, `Combobox.Group` rendered `role="group"` between the `role="grid"` list and its `role="row"` elements. A grid may only own `row`/`rowgroup` elements, and rows must be owned by `grid`, `rowgroup`, or `treegrid`, so axe reports `aria-required-children` and `aria-required-parent` on the documented grid examples.

## Changes

- `Combobox.Group` renders `role="rowgroup"` instead of `role="group"` when the root has `grid` enabled. `rowgroup` supports `aria-labelledby`, so `Combobox.GroupLabel` continues to name the group. Autocomplete reuses these parts. Non-grid lists are unchanged.
- Added a regression test for the grouped grid structure.
