### PR TITLE
[code-infra] Update CircleCI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  code-infra: https://raw.githubusercontent.com/mui/mui-public/9706e9e1881eb0c5f796765c9e55c45ddb126942/.circleci/orbs/code-infra.yml
+  code-infra: https://raw.githubusercontent.com/mui/mui-public/49ceb69d6aab71ab39f5cd9a3694d9c18faee7bc/.circleci/orbs/code-infra.yml
 
 parameters:
   browserstack-force:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  code-infra: https://raw.githubusercontent.com/mui/mui-public/00cd0db0b3f3e2bc38ac8fb6af4edbfb2d5f88f6/.circleci/orbs/code-infra.yml
+  code-infra: https://raw.githubusercontent.com/mui/mui-public/9706e9e1881eb0c5f796765c9e55c45ddb126942/.circleci/orbs/code-infra.yml
 
 parameters:
   browserstack-force:


### PR DESCRIPTION
## Summary

- update the shared `code-infra` CircleCI orb from the June 18 commit
- pin the orb to the merged change from mui/mui-public#1810
- make React-version CI jobs use the lockfile-installed `code-infra` binary instead of `pnpm dlx`

## Validation

- isolated React 18 flow: `pnpm install` followed by `pnpm code-infra set-version-overrides --pkg react@18`