### PR TITLE
[drawer] Ignore the page scroller when starting a swipe

### DIFF
--- a/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
@@ -1355,35 +1355,36 @@ describe('<Drawer.Viewport />', () => {
       // overflow propagate to the viewport.
       html.style.cssText = 'height: 100%; overflow-y: auto';
       body.style.cssText = 'height: 100%; overflow-y: auto';
-      const filler = body.appendChild(document.createElement('div'));
-      filler.style.height = '5000px';
 
       try {
         await render(
-          <Drawer.Root open modal={false} swipeDirection="down" snapPoints={[300, 100]}>
-            <Drawer.Portal>
-              <Drawer.Backdrop data-testid="backdrop" />
-              <Drawer.Viewport style={{ position: 'fixed', inset: 0, pointerEvents: 'none' }}>
-                <Drawer.Popup
-                  data-testid="popup"
-                  style={{
-                    position: 'absolute',
-                    left: 0,
-                    right: 0,
-                    bottom: 0,
-                    height: 300,
-                    pointerEvents: 'auto',
-                    transform:
-                      'translateY(calc(var(--drawer-snap-point-offset) + var(--drawer-swipe-movement-y)))',
-                  }}
-                >
-                  <div data-testid="drag" style={{ height: 100 }}>
-                    Drag
-                  </div>
-                </Drawer.Popup>
-              </Drawer.Viewport>
-            </Drawer.Portal>
-          </Drawer.Root>,
+          <React.Fragment>
+            <div style={{ height: 5000 }} />
+            <Drawer.Root open modal={false} swipeDirection="down" snapPoints={[300, 100]}>
+              <Drawer.Portal>
+                <Drawer.Backdrop data-testid="backdrop" />
+                <Drawer.Viewport style={{ position: 'fixed', inset: 0, pointerEvents: 'none' }}>
+                  <Drawer.Popup
+                    data-testid="popup"
+                    style={{
+                      position: 'absolute',
+                      left: 0,
+                      right: 0,
+                      bottom: 0,
+                      height: 300,
+                      pointerEvents: 'auto',
+                      transform:
+                        'translateY(calc(var(--drawer-snap-point-offset) + var(--drawer-swipe-movement-y)))',
+                    }}
+                  >
+                    <div data-testid="drag" style={{ height: 100 }}>
+                      Drag
+                    </div>
+                  </Drawer.Popup>
+                </Drawer.Viewport>
+              </Drawer.Portal>
+            </Drawer.Root>
+          </React.Fragment>,
         );
 
         const popup = screen.getByTestId('popup');
@@ -1394,6 +1395,8 @@ describe('<Drawer.Viewport />', () => {
           expect(popup.style.getPropertyValue('--drawer-snap-point-offset')).toBe('0px');
         });
 
+        // The old code refused swipes away from the page scroll edge, so being at the top
+        // with a scrollable body is the precondition that made the up-swipe fail.
         expect(body.scrollTop).toBe(0);
         expect(body.scrollHeight).toBeGreaterThan(body.clientHeight);
 
@@ -1414,7 +1417,6 @@ describe('<Drawer.Viewport />', () => {
           changedTouches: [createTouch(drag, { clientX, clientY: clientY - 30 })],
         });
       } finally {
-        filler.remove();
         html.style.cssText = previousHtmlStyle;
         body.style.cssText = previousBodyStyle;
       }

--- a/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
@@ -1344,6 +1344,83 @@ describe('<Drawer.Viewport />', () => {
     }
   });
 
+  it.skipIf(isJSDOM)(
+    'starts a swipe away from the page scroll edge when the body is a scroll container',
+    async () => {
+      const html = document.documentElement;
+      const { body } = document;
+      const previousHtmlStyle = html.style.cssText;
+      const previousBodyStyle = body.style.cssText;
+      // A common reset that turns `body` into a real scroll container instead of letting its
+      // overflow propagate to the viewport.
+      html.style.cssText = 'height: 100%; overflow-y: auto';
+      body.style.cssText = 'height: 100%; overflow-y: auto';
+      const filler = body.appendChild(document.createElement('div'));
+      filler.style.height = '5000px';
+
+      try {
+        await render(
+          <Drawer.Root open modal={false} swipeDirection="down" snapPoints={[300, 100]}>
+            <Drawer.Portal>
+              <Drawer.Backdrop data-testid="backdrop" />
+              <Drawer.Viewport style={{ position: 'fixed', inset: 0, pointerEvents: 'none' }}>
+                <Drawer.Popup
+                  data-testid="popup"
+                  style={{
+                    position: 'absolute',
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    height: 300,
+                    pointerEvents: 'auto',
+                    transform:
+                      'translateY(calc(var(--drawer-snap-point-offset) + var(--drawer-swipe-movement-y)))',
+                  }}
+                >
+                  <div data-testid="drag" style={{ height: 100 }}>
+                    Drag
+                  </div>
+                </Drawer.Popup>
+              </Drawer.Viewport>
+            </Drawer.Portal>
+          </Drawer.Root>,
+        );
+
+        const popup = screen.getByTestId('popup');
+        const drag = screen.getByTestId('drag');
+        const backdrop = screen.getByTestId('backdrop');
+
+        await waitFor(() => {
+          expect(popup.style.getPropertyValue('--drawer-snap-point-offset')).toBe('0px');
+        });
+
+        expect(body.scrollTop).toBe(0);
+        expect(body.scrollHeight).toBeGreaterThan(body.clientHeight);
+
+        const rect = drag.getBoundingClientRect();
+        const clientX = rect.left + 20;
+        const clientY = rect.top + 80;
+
+        fireEvent.touchStart(drag, { touches: [createTouch(drag, { clientX, clientY })] });
+        fireEvent.touchMove(drag, {
+          touches: [createTouch(drag, { clientX, clientY: clientY - 30 })],
+        });
+
+        await waitFor(() => {
+          expect(backdrop).toHaveAttribute('data-swiping', '');
+        });
+
+        fireEvent.touchEnd(drag, {
+          changedTouches: [createTouch(drag, { clientX, clientY: clientY - 30 })],
+        });
+      } finally {
+        filler.remove();
+        html.style.cssText = previousHtmlStyle;
+        body.style.cssText = previousBodyStyle;
+      }
+    },
+  );
+
   it('prevents touchmove when there is no scroll container', async () => {
     await render(
       <Drawer.Root open swipeDirection="down">

--- a/packages/react/src/utils/useSwipeDismiss.test.tsx
+++ b/packages/react/src/utils/useSwipeDismiss.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import * as React from 'react';
 import { fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
-import { createRenderer, firePointer } from '#test-utils';
+import { createRenderer, firePointer, isJSDOM } from '#test-utils';
 import { useSwipeDismiss } from './useSwipeDismiss';
 
 function SwipeBox() {
@@ -134,6 +134,136 @@ describe('useSwipeDismiss', () => {
       document.elementFromPoint = originalElementFromPoint;
     }
   });
+
+  it.skipIf(isJSDOM)('starts a touch swipe when the page scroller is `body`', async () => {
+    const onSwipeStart = vi.fn();
+
+    function SwipeBoxFixed() {
+      const ref = React.useRef<HTMLDivElement>(null);
+      const swipe = useSwipeDismiss({
+        enabled: true,
+        directions: ['down'],
+        elementRef: ref,
+        movementCssVars: { x: '--x', y: '--y' },
+        onSwipeStart,
+      });
+
+      return (
+        <div
+          data-testid="el"
+          ref={ref}
+          style={{ ...swipe.getDragStyles(), position: 'fixed', inset: 0 }}
+          {...swipe.getTouchProps()}
+        />
+      );
+    }
+
+    const { body } = document;
+    const html = document.documentElement;
+    const previousBodyStyle = body.style.cssText;
+    const previousHtmlStyle = html.style.cssText;
+    // A reset that turns `body` into a real scroll container instead of letting its overflow
+    // propagate to the viewport.
+    html.style.cssText = 'height: 100%; overflow-y: auto';
+    body.style.cssText = 'height: 100%; overflow-y: auto';
+
+    try {
+      await render(
+        <React.Fragment>
+          <div style={{ height: 5000 }} />
+          <SwipeBoxFixed />
+        </React.Fragment>,
+      );
+
+      // Being at the start edge is what made the upward move fail: it can only pass the
+      // scroll-edge gate when the container is scrolled to the end.
+      expect(body.scrollTop).toBe(0);
+      expect(body.scrollHeight).toBeGreaterThan(body.clientHeight);
+
+      const element = screen.getByTestId('el');
+      fireEvent.touchStart(element, {
+        touches: [createTouch(element, { clientX: 50, clientY: 300 })],
+      });
+      fireEvent.touchMove(element, {
+        touches: [createTouch(element, { clientX: 50, clientY: 260 })],
+      });
+
+      expect(onSwipeStart).toHaveBeenCalledTimes(1);
+    } finally {
+      body.style.cssText = previousBodyStyle;
+      html.style.cssText = previousHtmlStyle;
+    }
+  });
+
+  it.skipIf(isJSDOM)(
+    'keeps gating on a scrollable descendant of the other axis when `body` scrolls the page',
+    async () => {
+      const onSwipeStart = vi.fn();
+
+      function SwipeBoxCrossAxis() {
+        const ref = React.useRef<HTMLDivElement>(null);
+        const swipe = useSwipeDismiss({
+          enabled: true,
+          directions: ['down', 'right'],
+          elementRef: ref,
+          movementCssVars: { x: '--x', y: '--y' },
+          onSwipeStart,
+        });
+
+        return (
+          <div
+            data-testid="el"
+            ref={ref}
+            style={{ ...swipe.getDragStyles(), position: 'fixed', inset: 0 }}
+            {...swipe.getTouchProps()}
+          >
+            <div
+              data-testid="scroll"
+              style={{ overflowX: 'auto', overflowY: 'hidden', width: '100%', height: '100%' }}
+            >
+              <div style={{ width: 5000, height: 20 }} />
+            </div>
+          </div>
+        );
+      }
+
+      const { body } = document;
+      const html = document.documentElement;
+      const previousBodyStyle = body.style.cssText;
+      const previousHtmlStyle = html.style.cssText;
+      html.style.cssText = 'height: 100%; overflow-y: auto';
+      body.style.cssText = 'height: 100%; overflow-y: auto';
+
+      try {
+        await render(
+          <React.Fragment>
+            <div style={{ height: 5000 }} />
+            <SwipeBoxCrossAxis />
+          </React.Fragment>,
+        );
+
+        const scroll = screen.getByTestId('scroll');
+        // Away from the start edge, so the horizontal scroller must refuse the rightward swipe.
+        scroll.scrollLeft = 20;
+
+        expect(body.scrollHeight).toBeGreaterThan(body.clientHeight);
+        expect(scroll.scrollWidth).toBeGreaterThan(scroll.clientWidth);
+        expect(scroll.scrollLeft).toBeGreaterThan(0);
+
+        fireEvent.touchStart(scroll, {
+          touches: [createTouch(scroll, { clientX: 50, clientY: 300 })],
+        });
+        fireEvent.touchMove(scroll, {
+          touches: [createTouch(scroll, { clientX: 90, clientY: 300 })],
+        });
+
+        expect(onSwipeStart).not.toHaveBeenCalled();
+      } finally {
+        body.style.cssText = previousBodyStyle;
+        html.style.cssText = previousHtmlStyle;
+      }
+    },
+  );
 
   it('does not prevent touch scrolling during swipe interactions', async () => {
     await render(<SwipeBox />);

--- a/packages/react/src/utils/useSwipeDismiss.ts
+++ b/packages/react/src/utils/useSwipeDismiss.ts
@@ -331,28 +331,24 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
     target: EventTarget | null,
     root: HTMLElement,
   ): HTMLElement | null {
-    let scrollTarget: HTMLElement | null;
-    if (hasHorizontal && !hasVertical) {
-      scrollTarget = findScrollableTouchTarget(target, root, 'horizontal');
-    } else if (hasVertical && !hasHorizontal) {
-      scrollTarget = findScrollableTouchTarget(target, root, 'vertical');
-    } else {
-      scrollTarget =
-        findScrollableTouchTarget(target, root, 'vertical') ??
-        findScrollableTouchTarget(target, root, 'horizontal');
-    }
-
     // The swiped element is positioned relative to the viewport, so the page scroller must not
-    // gate the gesture. Otherwise a page that overflows (for example with
-    // `html, body { height: 100%; overflow: auto }`) blocks swipes away from its scroll edge.
-    if (scrollTarget) {
+    // gate the gesture (a reset like `html, body { height: 100%; overflow: auto }` makes `body`
+    // a real scroll container). The drawer viewport's native touchmove handler already ignores it.
+    const find = (axis: ScrollAxis) => {
+      const scrollTarget = findScrollableTouchTarget(target, root, axis);
       const doc = ownerDocument(scrollTarget);
-      if (scrollTarget === doc.body || scrollTarget === doc.documentElement) {
-        return null;
-      }
-    }
+      return scrollTarget === doc.body || scrollTarget === doc.documentElement
+        ? null
+        : scrollTarget;
+    };
 
-    return scrollTarget;
+    if (hasHorizontal && !hasVertical) {
+      return find('horizontal');
+    }
+    if (hasVertical && !hasHorizontal) {
+      return find('vertical');
+    }
+    return find('vertical') ?? find('horizontal');
   }
 
   function startSwipeAtPosition(

--- a/packages/react/src/utils/useSwipeDismiss.ts
+++ b/packages/react/src/utils/useSwipeDismiss.ts
@@ -331,18 +331,28 @@ export function useSwipeDismiss(options: UseSwipeDismissOptions): UseSwipeDismis
     target: EventTarget | null,
     root: HTMLElement,
   ): HTMLElement | null {
+    let scrollTarget: HTMLElement | null;
     if (hasHorizontal && !hasVertical) {
-      return findScrollableTouchTarget(target, root, 'horizontal');
+      scrollTarget = findScrollableTouchTarget(target, root, 'horizontal');
+    } else if (hasVertical && !hasHorizontal) {
+      scrollTarget = findScrollableTouchTarget(target, root, 'vertical');
+    } else {
+      scrollTarget =
+        findScrollableTouchTarget(target, root, 'vertical') ??
+        findScrollableTouchTarget(target, root, 'horizontal');
     }
 
-    if (hasVertical && !hasHorizontal) {
-      return findScrollableTouchTarget(target, root, 'vertical');
+    // The swiped element is positioned relative to the viewport, so the page scroller must not
+    // gate the gesture. Otherwise a page that overflows (for example with
+    // `html, body { height: 100%; overflow: auto }`) blocks swipes away from its scroll edge.
+    if (scrollTarget) {
+      const doc = ownerDocument(scrollTarget);
+      if (scrollTarget === doc.body || scrollTarget === doc.documentElement) {
+        return null;
+      }
     }
 
-    return (
-      findScrollableTouchTarget(target, root, 'vertical') ??
-      findScrollableTouchTarget(target, root, 'horizontal')
-    );
+    return scrollTarget;
   }
 
   function startSwipeAtPosition(


### PR DESCRIPTION
Closes #5566

`useSwipeDismiss` looks for a scrollable element between the touch target and `document.body`, and refuses to start (or gates the start on the scroll edge) when it finds one. That search also tests `body` itself. With a reset such as `html, body { height: 100%; overflow: auto }`, `body` is a real scroll container, so a non-modal drawer on a long page can be swiped down but not back up from a lower snap point. `Drawer.Viewport` already treats `body` and `documentElement` as "no scroll container" in its native touchmove handler, so this makes the hook do the same. The page scroller is filtered per axis, so a genuine inner scroller on the other axis still gates the gesture.

The added Chromium test reproduces the reset and fails before the change.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
