### PR TITLE
[drawer] Respect canceled snap point dismissal

### DIFF
--- a/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.test.tsx
@@ -3566,6 +3566,108 @@ describe('<Drawer.Viewport />', () => {
     }
   });
 
+  it('does not start swipe dismissal when closing the snap point is canceled', async () => {
+    const handleOpenChange = vi.fn();
+    const handleSnapPointChange = vi.fn(
+      (
+        nextSnapPoint: Drawer.Root.SnapPoint | null,
+        eventDetails: Drawer.Root.SnapPointChangeEventDetails,
+      ) => {
+        if (nextSnapPoint === null) {
+          eventDetails.cancel();
+        }
+      },
+    );
+
+    vi.useFakeTimers();
+    try {
+      await render(
+        <Drawer.Root
+          open
+          defaultSnapPoint="100px"
+          onOpenChange={handleOpenChange}
+          onSnapPointChange={handleSnapPointChange}
+          snapPoints={['100px', '200px']}
+          snapToSequentialPoints
+          swipeDirection="down"
+        >
+          <Drawer.Portal>
+            <Drawer.Viewport data-testid="viewport" ref={(element) => setHeight(element, 400)}>
+              <Drawer.Popup data-testid="popup" ref={(element) => setHeight(element, 300)}>
+                Drawer
+              </Drawer.Popup>
+            </Drawer.Viewport>
+          </Drawer.Portal>
+        </Drawer.Root>,
+      );
+
+      const viewport = screen.getByTestId('viewport');
+      const popup = screen.getByTestId('popup');
+      const releaseAttributes: string[] = [];
+      const observer = new MutationObserver((records) => {
+        records.forEach((record) => {
+          if (record.attributeName) {
+            releaseAttributes.push(record.attributeName);
+          }
+        });
+      });
+      observer.observe(popup, {
+        attributeFilter: ['data-ending-style', 'data-swipe-dismiss'],
+        attributes: true,
+      });
+
+      const originalElementFromPoint = document.elementFromPoint;
+      document.elementFromPoint = () => popup;
+
+      try {
+        firePointer.down(viewport, {
+          button: 0,
+          buttons: 1,
+          pointerId: 1,
+          clientX: 100,
+          clientY: 10,
+          pointerType: 'mouse',
+          timeStamp: 1000,
+        });
+        firePointer.move(viewport, {
+          buttons: 1,
+          pointerId: 1,
+          clientX: 100,
+          clientY: 30,
+          pointerType: 'mouse',
+          timeStamp: 1050,
+        });
+        firePointer.move(viewport, {
+          buttons: 1,
+          pointerId: 1,
+          clientX: 100,
+          clientY: 80,
+          pointerType: 'mouse',
+          timeStamp: 1100,
+        });
+        firePointer.up(viewport, {
+          pointerId: 1,
+          clientX: 100,
+          clientY: 100,
+          pointerType: 'mouse',
+          timeStamp: 1120,
+        });
+        await flushMicrotasks();
+      } finally {
+        document.elementFromPoint = originalElementFromPoint;
+        observer.disconnect();
+      }
+
+      expect(handleSnapPointChange).toHaveBeenCalledWith(null, expect.anything());
+      expect(handleOpenChange).not.toHaveBeenCalled();
+      expect(releaseAttributes).toEqual([]);
+      expect(popup).not.toHaveAttribute('data-ending-style');
+      expect(popup).not.toHaveAttribute('data-swipe-dismiss');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('settles on the nearest snap point when an unattributed drag ends past the last snap point', async () => {
     const handleOpenChange = vi.fn();
     const handleSnapPointChange = vi.fn();

--- a/packages/react/src/drawer/viewport/DrawerViewport.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.tsx
@@ -536,8 +536,14 @@ export const DrawerViewport = React.forwardRef(function DrawerViewport(
         if (!direction) {
           return settleOnSnapPoint(fallbackSnapPoint);
         }
-        pendingSwipeCloseSnapPointRef.current = activeSnapPoint;
         setActiveSnapPoint(null, snapPointEventDetails);
+        if (snapPointEventDetails.isCanceled) {
+          // A canceled null snap point rejects dismissal before exit styles start.
+          applySwipeProgress(0, true, true);
+          clearSwipeRelease();
+          return false;
+        }
+        pendingSwipeCloseSnapPointRef.current = activeSnapPoint;
         startSwipeRelease(swipeDirection);
         return true;
       };

--- a/packages/react/src/drawer/viewport/DrawerViewport.tsx
+++ b/packages/react/src/drawer/viewport/DrawerViewport.tsx
@@ -520,13 +520,17 @@ export const DrawerViewport = React.forwardRef(function DrawerViewport(
         : clamp(dragTargetOffset + velocityOffset, 0, popupHeight);
       const snapPointEventDetails = createChangeEventDetails(REASONS.swipe, event);
 
-      const settleOnSnapPoint = (snapPoint: ResolvedDrawerSnapPoint) => {
-        setActiveSnapPoint(snapPoint.value, snapPointEventDetails);
+      const settleInPlace = () => {
         // Reset nested swipe state now: the hook's trailing progress update is deduped
         // when the drag never produced dismissal progress, so it may not fire.
         applySwipeProgress(0, true, true);
         clearSwipeRelease();
         return false;
+      };
+
+      const settleOnSnapPoint = (snapPoint: ResolvedDrawerSnapPoint) => {
+        setActiveSnapPoint(snapPoint.value, snapPointEventDetails);
+        return settleInPlace();
       };
 
       const closeFromSnapPoints = (fallbackSnapPoint: ResolvedDrawerSnapPoint) => {
@@ -539,9 +543,7 @@ export const DrawerViewport = React.forwardRef(function DrawerViewport(
         setActiveSnapPoint(null, snapPointEventDetails);
         if (snapPointEventDetails.isCanceled) {
           // A canceled null snap point rejects dismissal before exit styles start.
-          applySwipeProgress(0, true, true);
-          clearSwipeRelease();
-          return false;
+          return settleInPlace();
         }
         pendingSwipeCloseSnapPointRef.current = activeSnapPoint;
         startSwipeRelease(swipeDirection);


### PR DESCRIPTION
Fixes #5570

With `snapPoints`, a swipe dismissal first proposes `null` through `onSnapPointChange`. Consumers can cancel this change, but `closeFromSnapPoints` currently continues into the swipe release even when the event details are canceled.

This temporarily applies the popup's exit state and can request `onOpenChange(false)`. When a controlled consumer rejects that close as well, the popup fades out before being restored to its previous snap point.

## Reproduction

Both examples use the same controlled Drawer scenario and the same Base UI preview packages. The fixed example applies this change through a Yarn patch.

- [Before — reproduction](https://stackblitz.com/github/radist2s/base-ui-drawer-canceled-swipe-repro/tree/reproduction?file=README.md)
- [After — fixed](https://stackblitz.com/github/radist2s/base-ui-drawer-canceled-swipe-repro/tree/fixed?file=README.md)

Steps:

1. Wait for the Drawer to open at the collapsed snap point.
2. Quickly drag the handle downward past the lowest snap point and release.
3. Compare the popup behavior and the event log.

Before:

```text
onSnapPointChange(null) canceled
onOpenChange(false) canceled
onSnapPointChange(0.26) accepted
```

The popup can briefly fade out before returning.

After:

```text
onSnapPointChange(null) canceled
```

The canceled dismissal settles immediately without entering the exit state.

## Changes

- Check `snapPointEventDetails.isCanceled` immediately after proposing the `null` snap point.
- Reset swipe progress and clear the release state when the proposal is canceled.
- Return before storing a pending close snap point or starting the swipe release.
- Add a regression test that verifies `onOpenChange` is not called and that neither `data-ending-style` nor `data-swipe-dismiss` is applied, including transient attribute changes.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).