### PR TITLE
[useDismiss] Register passive touch listeners

### DIFF
--- a/packages/react/src/floating-ui-react/hooks/useDismiss.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useDismiss.test.tsx
@@ -70,6 +70,23 @@ function App(
 
 describe.skipIf(!isJSDOM)('useDismiss', () => {
   describe('default options', () => {
+    test('registers outside press touch listeners as passive', async () => {
+      const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+
+      render(<App />);
+
+      await Promise.all(
+        ['touchstart', 'touchmove', 'touchend'].map((eventName) =>
+          waitFor(() => {
+            expect(addEventListenerSpy).toHaveBeenCalledWith(eventName, expect.any(Function), {
+              capture: true,
+              passive: true,
+            });
+          }),
+        ),
+      );
+    });
+
     test('dismisses with escape key', async () => {
       render(<App />);
       fireEvent.keyDown(document.body, { key: 'Escape' });

--- a/packages/react/src/floating-ui-react/hooks/useDismiss.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useDismiss.test.tsx
@@ -73,18 +73,22 @@ describe.skipIf(!isJSDOM)('useDismiss', () => {
     test('registers outside press touch listeners as passive', async () => {
       const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
 
-      render(<App />);
+      try {
+        render(<App />);
 
-      await Promise.all(
-        ['touchstart', 'touchmove', 'touchend'].map((eventName) =>
-          waitFor(() => {
-            expect(addEventListenerSpy).toHaveBeenCalledWith(eventName, expect.any(Function), {
-              capture: true,
-              passive: true,
-            });
-          }),
-        ),
-      );
+        await Promise.all(
+          ['touchstart', 'touchmove', 'touchend'].map((eventName) =>
+            waitFor(() => {
+              expect(addEventListenerSpy).toHaveBeenCalledWith(eventName, expect.any(Function), {
+                capture: true,
+                passive: true,
+              });
+            }),
+          ),
+        );
+      } finally {
+        addEventListenerSpy.mockRestore();
+      }
     });
 
     test('dismisses with escape key', async () => {

--- a/packages/react/src/floating-ui-react/hooks/useDismiss.ts
+++ b/packages/react/src/floating-ui-react/hooks/useDismiss.ts
@@ -723,9 +723,18 @@ export function useDismiss(
           addEventListener(doc, 'pointercancel', handlePressEndCapture, true),
           addEventListener(doc, 'mousedown', closeOnPressOutsideCapture, true),
           addEventListener(doc, 'mouseup', handlePressEndCapture, true),
-          addEventListener(doc, 'touchstart', handleTouchStartCapture, true),
-          addEventListener(doc, 'touchmove', handleTouchMoveCapture, true),
-          addEventListener(doc, 'touchend', handleTouchEndCapture, true),
+          addEventListener(doc, 'touchstart', handleTouchStartCapture, {
+            capture: true,
+            passive: true,
+          }),
+          addEventListener(doc, 'touchmove', handleTouchMoveCapture, {
+            capture: true,
+            passive: true,
+          }),
+          addEventListener(doc, 'touchend', handleTouchEndCapture, {
+            capture: true,
+            passive: true,
+          }),
         ),
     );
 


### PR DESCRIPTION
Fixes #5558

The document-level `touchstart`, `touchmove`, and `touchend` capture listeners used for outside-press detection are now passive. None of these handlers prevent default scrolling, so this removes Chrome's scroll-blocking listener violation without changing dismissal behavior.

A regression test verifies that all three touch listeners keep `capture: true` while adding `passive: true`.

Tests:
- `pnpm test:jsdom useDismiss --no-watch`
- `pnpm eslint`
- `pnpm typescript`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).