### PR TITLE
[combobox][select] Anchor multiple selection to first selected item

### DIFF
--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -116,25 +116,20 @@ function ComboboxItemInner(props: ComboboxItemInnerProps) {
     // like closed-trigger typeahead in sync when the rendered order changes.
     const selectedValue = store.state.selectedValue;
 
+    let nextIndex = store.state.selectedIndex;
     if (store.state.selectionMode === 'multiple' && Array.isArray(selectedValue)) {
-      const currentIndex = store.state.selectedIndex;
-      const nextIndex = resolveSelectedIndex(
+      nextIndex = resolveSelectedIndex(
         index,
         itemValue,
         store.context.valuesRef.current,
         selectedValue,
         isItemEqualToValue,
-        currentIndex,
+        nextIndex,
       );
-      if (nextIndex !== currentIndex) {
-        store.set('selectedIndex', nextIndex);
-      }
-      return;
+    } else if (compareItemEquality(itemValue, selectedValue, isItemEqualToValue)) {
+      nextIndex = index;
     }
-
-    if (compareItemEquality(itemValue, selectedValue, isItemEqualToValue)) {
-      store.set('selectedIndex', index);
-    }
+    store.set('selectedIndex', nextIndex);
   }, [hasRegistered, hasItems, store, index, itemValue, isItemEqualToValue]);
 
   const { getButtonProps, buttonRef } = useButton({

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -117,8 +117,6 @@ function ComboboxItemInner(props: ComboboxItemInnerProps) {
     const selectedValue = store.state.selectedValue;
 
     if (store.state.selectionMode === 'multiple' && Array.isArray(selectedValue)) {
-      // The first selected item in rendered order owns the index, so the anchor does not
-      // depend on the order in which the values were added to the array.
       if (
         shouldClaimSelectedIndex(
           index,

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -13,7 +13,11 @@ import { useRenderElement } from '../../internals/useRenderElement';
 import { ComboboxItemContext } from './ComboboxItemContext';
 import { useButton } from '../../internals/use-button';
 import { useComboboxRowContext } from '../row/ComboboxRowContext';
-import { compareItemEquality, findItemIndex } from '../../internals/itemEquality';
+import {
+  compareItemEquality,
+  findItemIndex,
+  shouldClaimSelectedIndex,
+} from '../../internals/itemEquality';
 
 interface ComboboxItemInnerProps {
   componentProps: ComboboxItem.Props;
@@ -111,11 +115,26 @@ function ComboboxItemInner(props: ComboboxItemInnerProps) {
     // force-mount) so the index tracks the item's composite position, keeping features
     // like closed-trigger typeahead in sync when the rendered order changes.
     const selectedValue = store.state.selectedValue;
-    const lastSelectedValue = Array.isArray(selectedValue)
-      ? selectedValue[selectedValue.length - 1]
-      : selectedValue;
 
-    if (compareItemEquality(itemValue, lastSelectedValue, isItemEqualToValue)) {
+    if (store.state.selectionMode === 'multiple' && Array.isArray(selectedValue)) {
+      // The first selected item in rendered order owns the index, so the anchor does not
+      // depend on the order in which the values were added to the array.
+      if (
+        shouldClaimSelectedIndex(
+          index,
+          itemValue,
+          store.context.valuesRef.current,
+          selectedValue,
+          isItemEqualToValue,
+          store.state.selectedIndex,
+        )
+      ) {
+        store.set('selectedIndex', index);
+      }
+      return;
+    }
+
+    if (compareItemEquality(itemValue, selectedValue, isItemEqualToValue)) {
       store.set('selectedIndex', index);
     }
   }, [hasRegistered, hasItems, store, index, itemValue, isItemEqualToValue]);

--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -16,7 +16,7 @@ import { useComboboxRowContext } from '../row/ComboboxRowContext';
 import {
   compareItemEquality,
   findItemIndex,
-  shouldClaimSelectedIndex,
+  resolveSelectedIndex,
 } from '../../internals/itemEquality';
 
 interface ComboboxItemInnerProps {
@@ -117,17 +117,17 @@ function ComboboxItemInner(props: ComboboxItemInnerProps) {
     const selectedValue = store.state.selectedValue;
 
     if (store.state.selectionMode === 'multiple' && Array.isArray(selectedValue)) {
-      if (
-        shouldClaimSelectedIndex(
-          index,
-          itemValue,
-          store.context.valuesRef.current,
-          selectedValue,
-          isItemEqualToValue,
-          store.state.selectedIndex,
-        )
-      ) {
-        store.set('selectedIndex', index);
+      const currentIndex = store.state.selectedIndex;
+      const nextIndex = resolveSelectedIndex(
+        index,
+        itemValue,
+        store.context.valuesRef.current,
+        selectedValue,
+        isItemEqualToValue,
+        currentIndex,
+      );
+      if (nextIndex !== currentIndex) {
+        store.set('selectedIndex', nextIndex);
       }
       return;
     }

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -1095,32 +1095,32 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
                 ? currentSelectedValue.length > 0
                 : store.state.selectionMode !== 'none' && currentSelectedValue != null;
 
-            if (hasSelection || clearedBySelection) {
+            if (hasSelection) {
               const registry =
                 hasItems || hasFilteredItemsProp ? flatFilteredValues : valuesRef.current;
-              let nextIndex: number | null = null;
-              if (hasSelection) {
-                // A selection-driven clear keeps the just-selected item highlighted;
-                // otherwise return to the open anchor. A selection that is no longer in
-                // the list drops the highlight rather than leaving it on whichever item
-                // now occupies that index.
-                // `findItemIndex` resolves to -1 when no value was toggled.
-                const toggledIndex = findItemIndex(
-                  registry,
-                  pendingHighlight.toggledValue,
-                  store.state.isItemEqualToValue,
-                );
-                nextIndex =
-                  toggledIndex !== -1
-                    ? toggledIndex
-                    : findSelectionIndex(
-                        registry,
-                        currentSelectedValue,
-                        store.state.isItemEqualToValue,
-                        isMultiple,
-                      );
-              }
-              store.set('activeIndex', nextIndex);
+              // A selection-driven clear keeps the just-selected item highlighted;
+              // otherwise return to the open anchor. A selection that is no longer in
+              // the list drops the highlight rather than leaving it on whichever item
+              // now occupies that index.
+              // `findItemIndex` resolves to -1 when no value was toggled.
+              const toggledIndex = findItemIndex(
+                registry,
+                pendingHighlight.toggledValue,
+                store.state.isItemEqualToValue,
+              );
+              store.set(
+                'activeIndex',
+                toggledIndex !== -1
+                  ? toggledIndex
+                  : findSelectionIndex(
+                      registry,
+                      currentSelectedValue,
+                      store.state.isItemEqualToValue,
+                      isMultiple,
+                    ),
+              );
+            } else if (clearedBySelection) {
+              store.set('activeIndex', null);
             } else if (autoHighlightMode === 'always') {
               store.set('activeIndex', 0);
             }

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -901,7 +901,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
           // A newly selected item stays highlighted through the clear; a deselection
           // falls back to the standard selection anchor.
           const pendingHighlight = pendingQueryHighlightRef.current;
-          if (pendingHighlight?.selection && !isCurrentlySelected) {
+          if (pendingHighlight && !isCurrentlySelected) {
             pendingHighlight.toggledValue = itemValue;
           }
         } else {
@@ -1064,7 +1064,6 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
         pendingQueryHighlightRef.current = null;
         if (listIsNavigable) {
           const clearedBySelection = pendingHighlight.selection;
-          const toggledValue = pendingHighlight.toggledValue;
           if (
             autoHighlightMode === 'always' &&
             !clearedBySelection &&
@@ -1092,10 +1091,9 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
             const currentSelectedValue = store.state.selectedValue;
             const isMultiple = store.state.selectionMode === 'multiple';
             const hasSelection =
-              store.state.selectionMode !== 'none' &&
-              (isMultiple && Array.isArray(currentSelectedValue)
+              isMultiple && Array.isArray(currentSelectedValue)
                 ? currentSelectedValue.length > 0
-                : currentSelectedValue != null);
+                : store.state.selectionMode !== 'none' && currentSelectedValue != null;
 
             if (hasSelection || clearedBySelection) {
               const registry =
@@ -1106,10 +1104,12 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
                 // otherwise return to the open anchor. A selection that is no longer in
                 // the list drops the highlight rather than leaving it on whichever item
                 // now occupies that index.
-                const toggledIndex =
-                  toggledValue === undefined
-                    ? -1
-                    : findItemIndex(registry, toggledValue, store.state.isItemEqualToValue);
+                // `findItemIndex` resolves to -1 when no value was toggled.
+                const toggledIndex = findItemIndex(
+                  registry,
+                  pendingHighlight.toggledValue,
+                  store.state.isItemEqualToValue,
+                );
                 nextIndex =
                   toggledIndex !== -1
                     ? toggledIndex

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -61,6 +61,7 @@ import {
 import {
   compareItemEquality,
   defaultItemEquality,
+  findItemIndex,
   findSelectionIndex,
   isSelectedValueDirty,
   removeItem,
@@ -259,6 +260,9 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
   const pendingQueryHighlightRef = React.useRef<null | {
     hasQuery: boolean;
     selection?: boolean | undefined;
+    // The value a selection-driven clear just added, so the restore can keep it
+    // highlighted instead of returning to the open anchor.
+    toggledValue?: any;
   }>(null);
 
   /**
@@ -894,6 +898,12 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
               isItemPress: true,
             }),
           );
+          // A newly selected item stays highlighted through the clear; a deselection
+          // falls back to the standard selection anchor.
+          const pendingHighlight = pendingQueryHighlightRef.current;
+          if (pendingHighlight?.selection && !isCurrentlySelected) {
+            pendingHighlight.toggledValue = itemValue;
+          }
         } else {
           setOpen(false, eventDetails);
         }
@@ -1054,6 +1064,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
         pendingQueryHighlightRef.current = null;
         if (listIsNavigable) {
           const clearedBySelection = pendingHighlight.selection;
+          const toggledValue = pendingHighlight.toggledValue;
           if (
             autoHighlightMode === 'always' &&
             !clearedBySelection &&
@@ -1080,28 +1091,36 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
             // re-running this effect on every render.
             const currentSelectedValue = store.state.selectedValue;
             const isMultiple = store.state.selectionMode === 'multiple';
-            const lastSelectedValue =
-              isMultiple && Array.isArray(currentSelectedValue)
-                ? currentSelectedValue[currentSelectedValue.length - 1]
-                : currentSelectedValue;
-            const hasSelection = store.state.selectionMode !== 'none' && lastSelectedValue != null;
+            const hasSelection =
+              store.state.selectionMode !== 'none' &&
+              (isMultiple && Array.isArray(currentSelectedValue)
+                ? currentSelectedValue.length > 0
+                : currentSelectedValue != null);
 
             if (hasSelection || clearedBySelection) {
               const registry =
                 hasItems || hasFilteredItemsProp ? flatFilteredValues : valuesRef.current;
-              // A selection that is no longer in the list drops the highlight rather than
-              // leaving it on whichever item now occupies that index.
-              store.set(
-                'activeIndex',
-                hasSelection
-                  ? findSelectionIndex(
-                      registry,
-                      currentSelectedValue,
-                      store.state.isItemEqualToValue,
-                      isMultiple,
-                    )
-                  : null,
-              );
+              let nextIndex: number | null = null;
+              if (hasSelection) {
+                // A selection-driven clear keeps the just-selected item highlighted;
+                // otherwise return to the open anchor. A selection that is no longer in
+                // the list drops the highlight rather than leaving it on whichever item
+                // now occupies that index.
+                const toggledIndex =
+                  toggledValue === undefined
+                    ? -1
+                    : findItemIndex(registry, toggledValue, store.state.isItemEqualToValue);
+                nextIndex =
+                  toggledIndex !== -1
+                    ? toggledIndex
+                    : findSelectionIndex(
+                        registry,
+                        currentSelectedValue,
+                        store.state.isItemEqualToValue,
+                        isMultiple,
+                      );
+              }
+              store.set('activeIndex', nextIndex);
             } else if (autoHighlightMode === 'always') {
               store.set('activeIndex', 0);
             }

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -2556,8 +2556,10 @@ describe('<Combobox.Root />', () => {
       });
 
       it('anchors the highlight to the first selected item in rendered order regardless of value order', async () => {
+        // `cherry` is last in rendered order but first in the value array, so anchoring to the
+        // rendered order and anchoring to either end of the value array give different answers.
         const { user } = await render(
-          <MultiplePopupCombobox defaultValue={['cherry', 'banana']} />,
+          <MultiplePopupCombobox defaultValue={['banana', 'cherry']} />,
         );
 
         await user.click(screen.getByTestId('trigger'));
@@ -2570,11 +2572,14 @@ describe('<Combobox.Root />', () => {
         await waitFor(() => {
           expect(input).toHaveAttribute('aria-activedescendant', bananaItem.id);
         });
+        expect(screen.getByRole('option', { name: 'cherry' })).not.toHaveAttribute(
+          'data-highlighted',
+        );
       });
 
       it('anchors the highlight to the first selected item with individually rendered items', async () => {
         const { user } = await render(
-          <Combobox.Root multiple defaultValue={['cherry', 'banana']}>
+          <Combobox.Root multiple defaultValue={['banana', 'cherry']}>
             <Combobox.Input data-testid="input" />
             <Combobox.Portal>
               <Combobox.Positioner>
@@ -2602,6 +2607,191 @@ describe('<Combobox.Root />', () => {
         await waitFor(() => {
           expect(input).toHaveAttribute('aria-activedescendant', bananaItem.id);
         });
+        expect(screen.getByRole('option', { name: 'cherry' })).not.toHaveAttribute(
+          'data-highlighted',
+        );
+      });
+
+      it('anchors to the first selected item in rendered order across groups', async () => {
+        // `spinach` renders first but is not the last value, so anchoring to the rendered order
+        // and anchoring to the end of the value array give different answers.
+        const { user } = await render(
+          <Combobox.Root multiple defaultValue={['spinach', 'plum']}>
+            <Combobox.Input data-testid="input" />
+            <Combobox.Portal>
+              <Combobox.Positioner>
+                <Combobox.Popup>
+                  <Combobox.List>
+                    <Combobox.Group>
+                      <Combobox.GroupLabel>Vegetables</Combobox.GroupLabel>
+                      <Combobox.Item value="artichoke">artichoke</Combobox.Item>
+                      <Combobox.Item value="spinach">spinach</Combobox.Item>
+                    </Combobox.Group>
+                    <Combobox.Group>
+                      <Combobox.GroupLabel>Fruits</Combobox.GroupLabel>
+                      <Combobox.Item value="apple">apple</Combobox.Item>
+                      <Combobox.Item value="plum">plum</Combobox.Item>
+                    </Combobox.Group>
+                  </Combobox.List>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+        await user.click(input);
+
+        const spinachItem = await screen.findByRole('option', { name: 'spinach' });
+        await waitFor(() => {
+          expect(spinachItem).toHaveAttribute('data-highlighted');
+        });
+        await waitFor(() => {
+          expect(input).toHaveAttribute('aria-activedescendant', spinachItem.id);
+        });
+        expect(screen.getByRole('option', { name: 'plum' })).not.toHaveAttribute(
+          'data-highlighted',
+        );
+      });
+
+      it('keeps the highlight on an item a controlled value refused to select', async () => {
+        // A controlled consumer may decline the change without calling `cancel()`. The query
+        // still clears, and the highlight stays on the item that was pressed, matching what
+        // happens when the same item is pressed without a query active.
+        function App() {
+          const [value] = React.useState(['apple']);
+          return (
+            <Combobox.Root
+              items={['apple', 'banana', 'cherry']}
+              multiple
+              value={value}
+              onValueChange={() => {}}
+            >
+              <Combobox.Trigger data-testid="trigger">
+                <Combobox.Value />
+              </Combobox.Trigger>
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.Input data-testid="input" />
+                    <Combobox.List>
+                      {(item: string) => (
+                        <Combobox.Item key={item} value={item}>
+                          {item}
+                        </Combobox.Item>
+                      )}
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          );
+        }
+
+        const { user } = await render(<App />);
+
+        await user.click(screen.getByTestId('trigger'));
+        const input = await screen.findByTestId('input');
+
+        await user.type(input, 'banana');
+        await waitFor(() => {
+          expect(screen.queryByRole('option', { name: 'apple' })).toBe(null);
+        });
+
+        await user.click(screen.getByRole('option', { name: 'banana' }));
+        await waitFor(() => {
+          expect(input).toHaveValue('');
+        });
+
+        const bananaItem = await screen.findByRole('option', { name: 'banana' });
+        await waitFor(() => {
+          expect(bananaItem).toHaveAttribute('data-highlighted');
+        });
+        expect(bananaItem).toHaveAttribute('aria-selected', 'false');
+        expect(screen.getByRole('option', { name: 'apple' })).not.toHaveAttribute(
+          'data-highlighted',
+        );
+      });
+
+      it('anchors to the first selected item when opened with the keyboard', async () => {
+        const { user } = await render(
+          <MultiplePopupCombobox defaultValue={['banana', 'cherry']} />,
+        );
+
+        const trigger = screen.getByTestId('trigger');
+        await user.keyboard('{Tab}');
+        expect(trigger).toHaveFocus();
+        await user.keyboard('{ArrowDown}');
+
+        const bananaItem = await screen.findByRole('option', { name: 'banana' });
+        await waitFor(() => {
+          expect(bananaItem).toHaveAttribute('data-highlighted');
+        });
+        expect(screen.getByRole('option', { name: 'cherry' })).not.toHaveAttribute(
+          'data-highlighted',
+        );
+      });
+
+      it('continues arrow navigation from the anchor rather than the top of the list', async () => {
+        const { user } = await render(
+          <MultiplePopupCombobox defaultValue={['banana', 'cherry']} />,
+        );
+
+        await user.click(screen.getByTestId('trigger'));
+        const input = await screen.findByTestId('input');
+        // Focus reaches the input asynchronously. Keys sent before it lands are lost.
+        await waitFor(() => {
+          expect(input).toHaveFocus();
+        });
+        const bananaItem = await screen.findByRole('option', { name: 'banana' });
+        await waitFor(() => {
+          expect(bananaItem).toHaveAttribute('data-highlighted');
+        });
+
+        // The next item after the anchor, not `apple` at the top.
+        await user.keyboard('{ArrowDown}');
+        await waitFor(() => {
+          expect(screen.getByRole('option', { name: 'cherry' })).toHaveAttribute(
+            'data-highlighted',
+          );
+        });
+
+        await user.keyboard('{ArrowUp}');
+        await waitFor(() => {
+          expect(bananaItem).toHaveAttribute('data-highlighted');
+        });
+      });
+
+      it('keeps the toggled item highlighted when selecting with the keyboard while filtering', async () => {
+        const { user } = await render(<MultiplePopupCombobox />);
+
+        await user.click(screen.getByTestId('trigger'));
+        const input = await screen.findByTestId('input');
+
+        await user.type(input, 'cherry');
+        await waitFor(() => {
+          expect(screen.queryByRole('option', { name: 'apple' })).toBe(null);
+        });
+
+        await user.keyboard('{ArrowDown}');
+        await waitFor(() => {
+          expect(screen.getByRole('option', { name: 'cherry' })).toHaveAttribute(
+            'data-highlighted',
+          );
+        });
+
+        await user.keyboard('{Enter}');
+        await waitFor(() => {
+          expect(input).toHaveValue('');
+        });
+
+        const cherryItem = await screen.findByRole('option', { name: 'cherry' });
+        await waitFor(() => {
+          expect(cherryItem).toHaveAttribute('data-highlighted');
+        });
+        expect(screen.getByRole('option', { name: 'apple' })).not.toHaveAttribute(
+          'data-highlighted',
+        );
       });
 
       it('moves the anchor when the anchor item value changes', async () => {

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -1510,7 +1510,7 @@ describe('<Combobox.Root />', () => {
       );
 
       it.skipIf(isJSDOM)(
-        'highlights the last selected item on mount and keeps the highlight when toggling in a multiple inline list (items prop)',
+        'highlights the first selected item on mount and keeps the highlight when toggling in a multiple inline list (items prop)',
         async () => {
           const { user } = await render(
             <Combobox.Root
@@ -1535,12 +1535,12 @@ describe('<Combobox.Root />', () => {
           const date = await screen.findByRole('option', { name: 'date' });
           const apple = screen.getByRole('option', { name: 'apple' });
 
-          // Initial highlight follows the last selected value.
+          // Initial highlight follows the first selected value in rendered order.
           await waitFor(() => {
-            expect(date).toHaveAttribute('data-highlighted');
+            expect(apple).toHaveAttribute('data-highlighted');
           });
           await waitFor(() => {
-            expect(input).toHaveAttribute('aria-activedescendant', date.id);
+            expect(input).toHaveAttribute('aria-activedescendant', apple.id);
           });
 
           // Deselecting must not jump the highlight (and scroll) to the other selected item.
@@ -2524,7 +2524,7 @@ describe('<Combobox.Root />', () => {
         expect(handleValueChange.mock.calls[1][0]).toEqual(['a', 'b']);
       });
 
-      it('opens with an empty input and highlights the last selected item (input inside popup)', async () => {
+      it('opens with an empty input and highlights the first selected item (input inside popup)', async () => {
         const onItemHighlighted = vi.fn();
         const { user } = await render(
           <MultiplePopupCombobox onItemHighlighted={onItemHighlighted} />,
@@ -2539,23 +2539,72 @@ describe('<Combobox.Root />', () => {
         expect(appleItem).toHaveAttribute('aria-selected', 'true');
         expect(bananaItem).toHaveAttribute('aria-selected', 'true');
         await waitFor(() => {
+          expect(appleItem).toHaveAttribute('data-highlighted');
+        });
+        await waitFor(() => {
+          expect(input).toHaveAttribute('aria-activedescendant', appleItem.id);
+        });
+        await waitFor(() => {
+          expect(screen.getByTestId('active-index')).toHaveTextContent('0');
+        });
+        await waitFor(() => {
+          expect(onItemHighlighted).toHaveBeenCalledWith(
+            'apple',
+            expect.objectContaining({ reason: REASONS.none, index: 0 }),
+          );
+        });
+      });
+
+      it('anchors the highlight to the first selected item in rendered order regardless of value order', async () => {
+        const { user } = await render(
+          <MultiplePopupCombobox defaultValue={['banana', 'cherry']} />,
+        );
+
+        await user.click(screen.getByTestId('trigger'));
+        const input = await screen.findByTestId('input');
+        const bananaItem = screen.getByRole('option', { name: 'banana' });
+
+        await waitFor(() => {
           expect(bananaItem).toHaveAttribute('data-highlighted');
         });
         await waitFor(() => {
           expect(input).toHaveAttribute('aria-activedescendant', bananaItem.id);
         });
+      });
+
+      it('anchors the highlight to the first selected item with individually rendered items', async () => {
+        const { user } = await render(
+          <Combobox.Root multiple defaultValue={['banana', 'cherry']}>
+            <Combobox.Input data-testid="input" />
+            <Combobox.Portal>
+              <Combobox.Positioner>
+                <Combobox.Popup>
+                  <Combobox.List>
+                    {['apple', 'banana', 'cherry'].map((item) => (
+                      <Combobox.Item key={item} value={item}>
+                        {item}
+                      </Combobox.Item>
+                    ))}
+                  </Combobox.List>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>,
+        );
+
+        const input = screen.getByTestId('input');
+        await user.click(input);
+        const bananaItem = await screen.findByRole('option', { name: 'banana' });
+
         await waitFor(() => {
-          expect(screen.getByTestId('active-index')).toHaveTextContent('1');
+          expect(bananaItem).toHaveAttribute('data-highlighted');
         });
         await waitFor(() => {
-          expect(onItemHighlighted).toHaveBeenCalledWith(
-            'banana',
-            expect.objectContaining({ reason: REASONS.none, index: 1 }),
-          );
+          expect(input).toHaveAttribute('aria-activedescendant', bananaItem.id);
         });
       });
 
-      it('restores the highlight to the last selected item when clearing (input inside popup)', async () => {
+      it('restores the highlight to the first selected item when clearing (input inside popup)', async () => {
         const onItemHighlighted = vi.fn();
         const { user } = await render(
           <MultiplePopupCombobox onItemHighlighted={onItemHighlighted} />,
@@ -2564,28 +2613,28 @@ describe('<Combobox.Root />', () => {
         await user.click(screen.getByTestId('trigger'));
         const input = await screen.findByTestId('input');
 
-        await user.type(input, 'apple');
+        await user.type(input, 'banana');
         await waitFor(() => {
-          expect(screen.queryByRole('option', { name: 'banana' })).toBe(null);
+          expect(screen.queryByRole('option', { name: 'apple' })).toBe(null);
         });
 
         onItemHighlighted.mockClear();
         await user.clear(input);
 
-        const bananaItem = await screen.findByRole('option', { name: 'banana' });
+        const appleItem = await screen.findByRole('option', { name: 'apple' });
         await waitFor(() => {
-          expect(bananaItem).toHaveAttribute('data-highlighted');
+          expect(appleItem).toHaveAttribute('data-highlighted');
         });
         await waitFor(() => {
-          expect(input).toHaveAttribute('aria-activedescendant', bananaItem.id);
+          expect(input).toHaveAttribute('aria-activedescendant', appleItem.id);
         });
         await waitFor(() => {
-          expect(screen.getByTestId('active-index')).toHaveTextContent('1');
+          expect(screen.getByTestId('active-index')).toHaveTextContent('0');
         });
         await waitFor(() => {
           expect(onItemHighlighted).toHaveBeenCalledWith(
-            'banana',
-            expect.objectContaining({ reason: REASONS.none, index: 1 }),
+            'apple',
+            expect.objectContaining({ reason: REASONS.none, index: 0 }),
           );
         });
         expect(onItemHighlighted).toHaveBeenCalledTimes(1);
@@ -2633,7 +2682,7 @@ describe('<Combobox.Root />', () => {
         });
       });
 
-      it('keeps the toggled item highlighted when deselecting the last selected item', async () => {
+      it('keeps the toggled item highlighted when deselecting a selected item', async () => {
         const { user } = await render(<MultiplePopupCombobox />);
 
         await user.click(screen.getByTestId('trigger'));
@@ -2642,7 +2691,7 @@ describe('<Combobox.Root />', () => {
         const bananaItem = screen.getByRole('option', { name: 'banana' });
 
         await waitFor(() => {
-          expect(bananaItem).toHaveAttribute('data-highlighted');
+          expect(appleItem).toHaveAttribute('data-highlighted');
         });
         await user.click(bananaItem);
 
@@ -2680,7 +2729,7 @@ describe('<Combobox.Root />', () => {
         ).toBe(false);
       });
 
-      it('clears a closing query and restores the last selected item on reopen', async () => {
+      it('clears a closing query and restores the first selected item on reopen', async () => {
         const onItemHighlighted = vi.fn();
         const { user } = await render(
           <MultiplePopupCombobox onItemHighlighted={onItemHighlighted} />,
@@ -2702,27 +2751,27 @@ describe('<Combobox.Root />', () => {
         await user.click(screen.getByTestId('trigger'));
 
         const reopenedInput = await screen.findByTestId('input');
-        const bananaItem = await screen.findByRole('option', { name: 'banana' });
+        const appleItem = await screen.findByRole('option', { name: 'apple' });
         expect(reopenedInput).toHaveValue('');
         await waitFor(() => {
-          expect(bananaItem).toHaveAttribute('data-highlighted');
+          expect(appleItem).toHaveAttribute('data-highlighted');
         });
         await waitFor(() => {
-          expect(reopenedInput).toHaveAttribute('aria-activedescendant', bananaItem.id);
+          expect(reopenedInput).toHaveAttribute('aria-activedescendant', appleItem.id);
         });
         await waitFor(() => {
-          expect(screen.getByTestId('active-index')).toHaveTextContent('1');
+          expect(screen.getByTestId('active-index')).toHaveTextContent('0');
         });
         await waitFor(() => {
           expect(onItemHighlighted).toHaveBeenCalledWith(
-            'banana',
-            expect.objectContaining({ reason: REASONS.none, index: 1 }),
+            'apple',
+            expect.objectContaining({ reason: REASONS.none, index: 0 }),
           );
         });
       });
 
       it.skipIf(isJSDOM)(
-        'scrolls the last selected item into view when clearing (input inside popup)',
+        'scrolls the first selected item into view when clearing (input inside popup)',
         async ({ onTestFinished }) => {
           const scrollIntoView = vi.spyOn(HTMLElement.prototype, 'scrollIntoView');
           onTestFinished(() => scrollIntoView.mockRestore());
@@ -2741,12 +2790,12 @@ describe('<Combobox.Root />', () => {
           scrollIntoView.mockClear();
           await user.clear(input);
 
-          const selectedItem = await screen.findByRole('option', { name: 'item 80' });
+          const selectedItem = await screen.findByRole('option', { name: 'item 1' });
           await waitFor(() => {
             expect(selectedItem).toHaveAttribute('data-highlighted');
           });
           await waitFor(() => {
-            expect(screen.getByTestId('active-index')).toHaveTextContent('80');
+            expect(screen.getByTestId('active-index')).toHaveTextContent('1');
           });
           await waitFor(() => {
             expect(scrollIntoView.mock.contexts).toEqual([selectedItem]);
@@ -2781,15 +2830,15 @@ describe('<Combobox.Root />', () => {
 
         const input = screen.getByTestId('input');
         await user.click(input);
-        await user.type(input, 'apple');
-        await waitFor(() => expect(screen.queryByRole('option', { name: 'banana' })).toBe(null));
+        await user.type(input, 'banana');
+        await waitFor(() => expect(screen.queryByRole('option', { name: 'apple' })).toBe(null));
 
-        // Opening already highlights the last selected item in this layout, so clearing
+        // Opening already highlights the first selected item in this layout, so clearing
         // the query returns to the same anchor.
         await user.clear(input);
-        const banana = await screen.findByRole('option', { name: 'banana' });
-        await waitFor(() => expect(banana).toHaveAttribute('data-highlighted'));
-        expect(input).toHaveAttribute('aria-activedescendant', banana.id);
+        const apple = await screen.findByRole('option', { name: 'apple' });
+        await waitFor(() => expect(apple).toHaveAttribute('data-highlighted'));
+        expect(input).toHaveAttribute('aria-activedescendant', apple.id);
       });
 
       it('resets selectedIndex when clearing all selections while open', async () => {
@@ -2829,7 +2878,7 @@ describe('<Combobox.Root />', () => {
         await user.click(screen.getByTestId('input'));
 
         expect(await screen.findByRole('listbox')).not.toBe(null);
-        expect(screen.getByTestId('selected-index').textContent).toBe('1');
+        expect(screen.getByTestId('selected-index').textContent).toBe('0');
 
         await user.click(screen.getByTestId('clear'));
 
@@ -2929,7 +2978,7 @@ describe('<Combobox.Root />', () => {
         await user.click(input);
         expect(await screen.findByRole('listbox')).not.toBe(null);
         await waitFor(() => {
-          expect(screen.getByTestId('selected-index').textContent).toBe('1');
+          expect(screen.getByTestId('selected-index').textContent).toBe('0');
         });
 
         await user.keyboard('{Escape}');
@@ -8918,7 +8967,7 @@ describe('<Combobox.Root />', () => {
       await user.click(input);
       await waitFor(() => expect(screen.getByRole('listbox')).not.toBe(null));
 
-      await user.keyboard('{ArrowUp}');
+      await user.keyboard('{ArrowDown}');
 
       await waitFor(() => {
         expect(input).toHaveAttribute('aria-activedescendant');

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -2640,6 +2640,45 @@ describe('<Combobox.Root />', () => {
         });
       });
 
+      it('moves the anchor to the next selected item when the anchor item leaves the list', async () => {
+        function App(props: { hideApple?: boolean }) {
+          const visible = props.hideApple ? ['banana', 'cherry'] : ['apple', 'banana', 'cherry'];
+
+          return (
+            <Combobox.Root multiple defaultValue={['apple', 'cherry']}>
+              <Combobox.Input data-testid="input" />
+              <SelectedIndexProbe />
+              <Combobox.Portal keepMounted>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.List>
+                      {visible.map((item) => (
+                        <Combobox.Item key={item} value={item}>
+                          {item}
+                        </Combobox.Item>
+                      ))}
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          );
+        }
+
+        const { setProps } = await render(<App />);
+
+        await waitFor(() => {
+          expect(screen.getByTestId('selected-index').textContent).toBe('0');
+        });
+
+        await setProps({ hideApple: true });
+
+        // `banana` now occupies index 0 but is not selected, so `cherry` takes the anchor.
+        await waitFor(() => {
+          expect(screen.getByTestId('selected-index').textContent).toBe('1');
+        });
+      });
+
       it('restores the anchor rather than the toggled item when deselecting while filtering', async () => {
         const { user } = await render(<MultiplePopupCombobox />);
 

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -2557,7 +2557,7 @@ describe('<Combobox.Root />', () => {
 
       it('anchors the highlight to the first selected item in rendered order regardless of value order', async () => {
         const { user } = await render(
-          <MultiplePopupCombobox defaultValue={['banana', 'cherry']} />,
+          <MultiplePopupCombobox defaultValue={['cherry', 'banana']} />,
         );
 
         await user.click(screen.getByTestId('trigger'));
@@ -2574,7 +2574,7 @@ describe('<Combobox.Root />', () => {
 
       it('anchors the highlight to the first selected item with individually rendered items', async () => {
         const { user } = await render(
-          <Combobox.Root multiple defaultValue={['banana', 'cherry']}>
+          <Combobox.Root multiple defaultValue={['cherry', 'banana']}>
             <Combobox.Input data-testid="input" />
             <Combobox.Portal>
               <Combobox.Positioner>
@@ -2602,6 +2602,76 @@ describe('<Combobox.Root />', () => {
         await waitFor(() => {
           expect(input).toHaveAttribute('aria-activedescendant', bananaItem.id);
         });
+      });
+
+      it('moves the anchor to the next selected item when the anchor item leaves the list', async () => {
+        function App(props: { hideApple?: boolean }) {
+          const visible = props.hideApple ? ['banana', 'cherry'] : ['apple', 'banana', 'cherry'];
+
+          return (
+            <Combobox.Root multiple defaultValue={['apple', 'cherry']}>
+              <Combobox.Input data-testid="input" />
+              <SelectedIndexProbe />
+              <Combobox.Portal>
+                <Combobox.Positioner>
+                  <Combobox.Popup>
+                    <Combobox.List>
+                      {visible.map((item) => (
+                        <Combobox.Item key={item} value={item}>
+                          {item}
+                        </Combobox.Item>
+                      ))}
+                    </Combobox.List>
+                  </Combobox.Popup>
+                </Combobox.Positioner>
+              </Combobox.Portal>
+            </Combobox.Root>
+          );
+        }
+
+        const { user, setProps } = await render(<App />);
+
+        await user.click(screen.getByTestId('input'));
+        expect(await screen.findByRole('listbox')).not.toBe(null);
+        await waitFor(() => {
+          expect(screen.getByTestId('selected-index').textContent).toBe('0');
+        });
+
+        await setProps({ hideApple: true });
+        await waitFor(() => {
+          expect(screen.queryByRole('option', { name: 'apple' })).toBe(null);
+        });
+
+        // `banana` now occupies index 0 but is not selected, so `cherry` takes the anchor.
+        await waitFor(() => {
+          expect(screen.getByTestId('selected-index').textContent).toBe('1');
+        });
+      });
+
+      it('restores the anchor rather than the toggled item when deselecting while filtering', async () => {
+        const { user } = await render(<MultiplePopupCombobox />);
+
+        await user.click(screen.getByTestId('trigger'));
+        const input = await screen.findByTestId('input');
+
+        await user.type(input, 'banana');
+        await waitFor(() => {
+          expect(screen.queryByRole('option', { name: 'apple' })).toBe(null);
+        });
+
+        await user.click(screen.getByRole('option', { name: 'banana' }));
+        await waitFor(() => {
+          expect(input).toHaveValue('');
+        });
+
+        const appleItem = await screen.findByRole('option', { name: 'apple' });
+        await waitFor(() => {
+          expect(appleItem).toHaveAttribute('data-highlighted');
+        });
+        expect(screen.getByRole('option', { name: 'banana' })).not.toHaveAttribute(
+          'data-highlighted',
+        );
+        expect(screen.getByTestId('active-index')).toHaveTextContent('0');
       });
 
       it('restores the highlight to the first selected item when clearing (input inside popup)', async () => {
@@ -2777,7 +2847,7 @@ describe('<Combobox.Root />', () => {
           onTestFinished(() => scrollIntoView.mockRestore());
           const items = Array.from({ length: 100 }, (_, index) => `item ${index}`);
           const { user } = await render(
-            <MultiplePopupCombobox items={items} defaultValue={['item 1', 'item 80']} />,
+            <MultiplePopupCombobox items={items} defaultValue={['item 90', 'item 80']} />,
           );
 
           await user.click(screen.getByTestId('trigger'));
@@ -2790,12 +2860,12 @@ describe('<Combobox.Root />', () => {
           scrollIntoView.mockClear();
           await user.clear(input);
 
-          const selectedItem = await screen.findByRole('option', { name: 'item 1' });
+          const selectedItem = await screen.findByRole('option', { name: 'item 80' });
           await waitFor(() => {
             expect(selectedItem).toHaveAttribute('data-highlighted');
           });
           await waitFor(() => {
-            expect(screen.getByTestId('active-index')).toHaveTextContent('1');
+            expect(screen.getByTestId('active-index')).toHaveTextContent('80');
           });
           await waitFor(() => {
             expect(scrollIntoView.mock.contexts).toEqual([selectedItem]);

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -2556,22 +2556,25 @@ describe('<Combobox.Root />', () => {
       });
 
       it('anchors the highlight to the first selected item in rendered order regardless of value order', async () => {
-        // `cherry` is last in rendered order but first in the value array, so anchoring to the
-        // rendered order and anchoring to either end of the value array give different answers.
+        // `apple` renders first but sits in the middle of the value array, so neither end of
+        // that array points at it and only the rendered order does.
         const { user } = await render(
-          <MultiplePopupCombobox defaultValue={['banana', 'cherry']} />,
+          <MultiplePopupCombobox defaultValue={['banana', 'apple', 'cherry']} />,
         );
 
         await user.click(screen.getByTestId('trigger'));
         const input = await screen.findByTestId('input');
-        const bananaItem = screen.getByRole('option', { name: 'banana' });
+        const appleItem = screen.getByRole('option', { name: 'apple' });
 
         await waitFor(() => {
-          expect(bananaItem).toHaveAttribute('data-highlighted');
+          expect(appleItem).toHaveAttribute('data-highlighted');
         });
         await waitFor(() => {
-          expect(input).toHaveAttribute('aria-activedescendant', bananaItem.id);
+          expect(input).toHaveAttribute('aria-activedescendant', appleItem.id);
         });
+        expect(screen.getByRole('option', { name: 'banana' })).not.toHaveAttribute(
+          'data-highlighted',
+        );
         expect(screen.getByRole('option', { name: 'cherry' })).not.toHaveAttribute(
           'data-highlighted',
         );
@@ -2579,7 +2582,7 @@ describe('<Combobox.Root />', () => {
 
       it('anchors the highlight to the first selected item with individually rendered items', async () => {
         const { user } = await render(
-          <Combobox.Root multiple defaultValue={['banana', 'cherry']}>
+          <Combobox.Root multiple defaultValue={['banana', 'apple', 'cherry']}>
             <Combobox.Input data-testid="input" />
             <Combobox.Portal>
               <Combobox.Positioner>
@@ -2599,14 +2602,17 @@ describe('<Combobox.Root />', () => {
 
         const input = screen.getByTestId('input');
         await user.click(input);
-        const bananaItem = await screen.findByRole('option', { name: 'banana' });
+        const appleItem = await screen.findByRole('option', { name: 'apple' });
 
         await waitFor(() => {
-          expect(bananaItem).toHaveAttribute('data-highlighted');
+          expect(appleItem).toHaveAttribute('data-highlighted');
         });
         await waitFor(() => {
-          expect(input).toHaveAttribute('aria-activedescendant', bananaItem.id);
+          expect(input).toHaveAttribute('aria-activedescendant', appleItem.id);
         });
+        expect(screen.getByRole('option', { name: 'banana' })).not.toHaveAttribute(
+          'data-highlighted',
+        );
         expect(screen.getByRole('option', { name: 'cherry' })).not.toHaveAttribute(
           'data-highlighted',
         );

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -2604,23 +2604,21 @@ describe('<Combobox.Root />', () => {
         });
       });
 
-      it('moves the anchor to the next selected item when the anchor item leaves the list', async () => {
-        function App(props: { hideApple?: boolean }) {
-          const visible = props.hideApple ? ['banana', 'cherry'] : ['apple', 'banana', 'cherry'];
-
+      it('moves the anchor when the anchor item value changes', async () => {
+        function App(props: { replaceApple?: boolean }) {
           return (
             <Combobox.Root multiple defaultValue={['apple', 'cherry']}>
               <Combobox.Input data-testid="input" />
               <SelectedIndexProbe />
-              <Combobox.Portal>
+              <Combobox.Portal keepMounted>
                 <Combobox.Positioner>
                   <Combobox.Popup>
                     <Combobox.List>
-                      {visible.map((item) => (
-                        <Combobox.Item key={item} value={item}>
-                          {item}
-                        </Combobox.Item>
-                      ))}
+                      <Combobox.Item value={props.replaceApple ? 'date' : 'apple'}>
+                        {props.replaceApple ? 'date' : 'apple'}
+                      </Combobox.Item>
+                      <Combobox.Item value="banana">banana</Combobox.Item>
+                      <Combobox.Item value="cherry">cherry</Combobox.Item>
                     </Combobox.List>
                   </Combobox.Popup>
                 </Combobox.Positioner>
@@ -2629,22 +2627,16 @@ describe('<Combobox.Root />', () => {
           );
         }
 
-        const { user, setProps } = await render(<App />);
+        const { setProps } = await render(<App />);
 
-        await user.click(screen.getByTestId('input'));
-        expect(await screen.findByRole('listbox')).not.toBe(null);
         await waitFor(() => {
           expect(screen.getByTestId('selected-index').textContent).toBe('0');
         });
 
-        await setProps({ hideApple: true });
-        await waitFor(() => {
-          expect(screen.queryByRole('option', { name: 'apple' })).toBe(null);
-        });
+        await setProps({ replaceApple: true });
 
-        // `banana` now occupies index 0 but is not selected, so `cherry` takes the anchor.
         await waitFor(() => {
-          expect(screen.getByTestId('selected-index').textContent).toBe('1');
+          expect(screen.getByTestId('selected-index').textContent).toBe('2');
         });
       });
 

--- a/packages/react/src/internals/itemEquality.test.ts
+++ b/packages/react/src/internals/itemEquality.test.ts
@@ -1,0 +1,78 @@
+import { expect } from 'vitest';
+import { defaultItemEquality, findSelectionIndex, shouldClaimSelectedIndex } from './itemEquality';
+
+describe('findSelectionIndex', () => {
+  const items = ['a', 'b', 'c'];
+
+  it('anchors to the first selected item in rendered order, not value order', () => {
+    expect(findSelectionIndex(items, ['c', 'b'], defaultItemEquality, true)).toBe(1);
+    expect(findSelectionIndex(items, ['b', 'c'], defaultItemEquality, true)).toBe(1);
+  });
+
+  it('returns null when nothing in the value array is rendered', () => {
+    expect(findSelectionIndex(items, [], defaultItemEquality, true)).toBe(null);
+    expect(findSelectionIndex(items, ['d'], defaultItemEquality, true)).toBe(null);
+  });
+
+  it('treats an array as a single value outside multiple mode', () => {
+    const arrayValue = ['x', 'y'];
+    const comparer = (itemValue: unknown, selectedValue: unknown) =>
+      JSON.stringify(itemValue) === JSON.stringify(selectedValue);
+
+    expect(
+      findSelectionIndex<string | string[], string[]>(
+        ['a', arrayValue],
+        arrayValue,
+        comparer,
+        false,
+      ),
+    ).toBe(1);
+  });
+});
+
+describe('shouldClaimSelectedIndex', () => {
+  const registry = ['a', 'b', 'c'];
+
+  function claims(index: number, selectedValues: string[], currentIndex: number | null) {
+    return shouldClaimSelectedIndex(
+      index,
+      registry[index],
+      registry,
+      selectedValues,
+      defaultItemEquality,
+      currentIndex,
+    );
+  }
+
+  it('does not claim an unselected item', () => {
+    expect(claims(1, ['a', 'c'], null)).toBe(false);
+  });
+
+  it('claims when no item holds the index yet', () => {
+    expect(claims(2, ['c'], null)).toBe(true);
+  });
+
+  it('claims from a later holder', () => {
+    expect(claims(0, ['a', 'c'], 2)).toBe(true);
+  });
+
+  it('leaves the index with an earlier selected holder', () => {
+    expect(claims(2, ['a', 'c'], 0)).toBe(false);
+  });
+
+  it('takes over from an earlier holder that is no longer selected', () => {
+    // `a` held the index but has been deselected, so `b` takes it and `c` then defers.
+    expect(claims(1, ['b', 'c'], 0)).toBe(true);
+    expect(claims(2, ['b', 'c'], 1)).toBe(false);
+  });
+
+  it('takes over when the earlier holder has left the registry', () => {
+    const sparseRegistry: string[] = [];
+    sparseRegistry[1] = 'b';
+    sparseRegistry[2] = 'c';
+
+    expect(shouldClaimSelectedIndex(2, 'c', sparseRegistry, ['c'], defaultItemEquality, 0)).toBe(
+      true,
+    );
+  });
+});

--- a/packages/react/src/internals/itemEquality.test.ts
+++ b/packages/react/src/internals/itemEquality.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'vitest';
-import { defaultItemEquality, findSelectionIndex, shouldClaimSelectedIndex } from './itemEquality';
+import { defaultItemEquality, findSelectionIndex, resolveSelectedIndex } from './itemEquality';
 
 describe('findSelectionIndex', () => {
   const items = ['a', 'b', 'c'];
@@ -30,11 +30,11 @@ describe('findSelectionIndex', () => {
   });
 });
 
-describe('shouldClaimSelectedIndex', () => {
+describe('resolveSelectedIndex', () => {
   const registry = ['a', 'b', 'c'];
 
-  function claims(index: number, selectedValues: string[], currentIndex: number | null) {
-    return shouldClaimSelectedIndex(
+  function resolve(index: number, selectedValues: string[], currentIndex: number | null) {
+    return resolveSelectedIndex(
       index,
       registry[index],
       registry,
@@ -45,25 +45,25 @@ describe('shouldClaimSelectedIndex', () => {
   }
 
   it('does not claim an unselected item', () => {
-    expect(claims(1, ['a', 'c'], null)).toBe(false);
+    expect(resolve(1, ['a', 'c'], null)).toBe(null);
   });
 
   it('claims when no item holds the index yet', () => {
-    expect(claims(2, ['c'], null)).toBe(true);
+    expect(resolve(2, ['c'], null)).toBe(2);
   });
 
   it('claims from a later holder', () => {
-    expect(claims(0, ['a', 'c'], 2)).toBe(true);
+    expect(resolve(0, ['a', 'c'], 2)).toBe(0);
   });
 
   it('leaves the index with an earlier selected holder', () => {
-    expect(claims(2, ['a', 'c'], 0)).toBe(false);
+    expect(resolve(2, ['a', 'c'], 0)).toBe(0);
   });
 
   it('takes over from an earlier holder that is no longer selected', () => {
     // `a` held the index but has been deselected, so `b` takes it and `c` then defers.
-    expect(claims(1, ['b', 'c'], 0)).toBe(true);
-    expect(claims(2, ['b', 'c'], 1)).toBe(false);
+    expect(resolve(0, ['b', 'c'], 0)).toBe(1);
+    expect(resolve(2, ['b', 'c'], 1)).toBe(1);
   });
 
   it('takes over when the earlier holder has left the registry', () => {
@@ -71,8 +71,6 @@ describe('shouldClaimSelectedIndex', () => {
     sparseRegistry[1] = 'b';
     sparseRegistry[2] = 'c';
 
-    expect(shouldClaimSelectedIndex(2, 'c', sparseRegistry, ['c'], defaultItemEquality, 0)).toBe(
-      true,
-    );
+    expect(resolveSelectedIndex(2, 'c', sparseRegistry, ['c'], defaultItemEquality, 0)).toBe(2);
   });
 });

--- a/packages/react/src/internals/itemEquality.ts
+++ b/packages/react/src/internals/itemEquality.ts
@@ -96,16 +96,15 @@ export function shouldClaimSelectedIndex<Item, Value>(
   comparer: ItemEqualityComparer<Item, Value>,
   currentIndex: number | null,
 ): boolean {
-  if (!selectedValueIncludes(selectedValues, itemValue, comparer)) {
+  // A later item only takes over once the current anchor stops being selected.
+  if (
+    currentIndex != null &&
+    index > currentIndex &&
+    selectedValueIncludes(selectedValues, registry[currentIndex], comparer)
+  ) {
     return false;
   }
-  if (currentIndex == null || index <= currentIndex) {
-    return true;
-  }
-  const currentValue = registry[currentIndex];
-  return (
-    currentValue === undefined || !selectedValueIncludes(selectedValues, currentValue, comparer)
-  );
+  return selectedValueIncludes(selectedValues, itemValue, comparer);
 }
 
 export function removeItem<Item, Value>(

--- a/packages/react/src/internals/itemEquality.ts
+++ b/packages/react/src/internals/itemEquality.ts
@@ -38,7 +38,7 @@ export function selectedValueIncludes<Item, Value>(
   itemValue: Value,
   comparer: ItemEqualityComparer<Value, Item>,
 ): boolean {
-  if (!selectedValues || selectedValues.length === 0) {
+  if (!selectedValues) {
     return false;
   }
   return selectedValues.some((selectedValue) => {
@@ -54,7 +54,7 @@ export function findItemIndex<Item, Value>(
   selectedValue: Value,
   comparer: ItemEqualityComparer<Item, Value>,
 ): number {
-  if (!itemValues || itemValues.length === 0) {
+  if (!itemValues) {
     return -1;
   }
   return itemValues.findIndex((itemValue) => {
@@ -66,24 +66,22 @@ export function findItemIndex<Item, Value>(
 }
 
 export function findSelectionIndex<Item, Value>(
-  itemValues: readonly Item[] | undefined | null,
+  itemValues: readonly Item[],
   selectedValue: Value | readonly Value[] | null | undefined,
   comparer: ItemEqualityComparer<Item, Value>,
   multiple: boolean,
 ): number | null {
   // Only treat the value as a list in multiple mode: an array can itself be a valid
   // single-select value.
-  if (multiple && Array.isArray(selectedValue)) {
-    // Anchor to the first selected item in rendered order so the index does not depend
-    // on the order in which the values were added to the array.
-    const index =
-      itemValues?.findIndex(
-        (itemValue) =>
-          itemValue !== undefined && selectedValueIncludes(selectedValue, itemValue, comparer),
-      ) ?? -1;
-    return index === -1 ? null : index;
-  }
-  const index = findItemIndex(itemValues, selectedValue as Value, comparer);
+  const index =
+    multiple && Array.isArray(selectedValue)
+      ? // Anchor to the first selected item in rendered order so the index does not depend
+        // on the order in which the values were added to the array.
+        // A hole (`undefined`) never matches: `selectedValueIncludes` rejects it.
+        itemValues.findIndex((itemValue) =>
+          selectedValueIncludes(selectedValue, itemValue, comparer),
+        )
+      : findItemIndex(itemValues, selectedValue as Value, comparer);
   return index === -1 ? null : index;
 }
 
@@ -96,21 +94,18 @@ export function resolveSelectedIndex<Item, Value>(
   comparer: ItemEqualityComparer<Item, Value>,
   currentIndex: number | null,
 ): number | null {
-  if (index === currentIndex) {
-    return selectedValueIncludes(selectedValues, itemValue, comparer)
-      ? index
-      : findSelectionIndex(registry, selectedValues, comparer, true);
+  if (selectedValueIncludes(selectedValues, itemValue, comparer)) {
+    // A later item only takes over once the current anchor stops being selected.
+    return currentIndex != null &&
+      index > currentIndex &&
+      selectedValueIncludes(selectedValues, registry[currentIndex], comparer)
+      ? currentIndex
+      : index;
   }
-
-  // A later item only takes over once the current anchor stops being selected.
-  if (
-    currentIndex != null &&
-    index > currentIndex &&
-    selectedValueIncludes(selectedValues, registry[currentIndex], comparer)
-  ) {
-    return currentIndex;
-  }
-  return selectedValueIncludes(selectedValues, itemValue, comparer) ? index : currentIndex;
+  // The holder re-elects the anchor once it stops being selected.
+  return index === currentIndex
+    ? findSelectionIndex(registry, selectedValues, comparer, true)
+    : currentIndex;
 }
 
 export function removeItem<Item, Value>(

--- a/packages/react/src/internals/itemEquality.ts
+++ b/packages/react/src/internals/itemEquality.ts
@@ -87,24 +87,30 @@ export function findSelectionIndex<Item, Value>(
   return index === -1 ? null : index;
 }
 
-/** Whether an item should become the first selected index in rendered order. */
-export function shouldClaimSelectedIndex<Item, Value>(
+/** Resolves the first selected index as items register or change. */
+export function resolveSelectedIndex<Item, Value>(
   index: number,
   itemValue: Item,
   registry: readonly Item[],
   selectedValues: readonly Value[],
   comparer: ItemEqualityComparer<Item, Value>,
   currentIndex: number | null,
-): boolean {
+): number | null {
+  if (index === currentIndex) {
+    return selectedValueIncludes(selectedValues, itemValue, comparer)
+      ? index
+      : findSelectionIndex(registry, selectedValues, comparer, true);
+  }
+
   // A later item only takes over once the current anchor stops being selected.
   if (
     currentIndex != null &&
     index > currentIndex &&
     selectedValueIncludes(selectedValues, registry[currentIndex], comparer)
   ) {
-    return false;
+    return currentIndex;
   }
-  return selectedValueIncludes(selectedValues, itemValue, comparer);
+  return selectedValueIncludes(selectedValues, itemValue, comparer) ? index : currentIndex;
 }
 
 export function removeItem<Item, Value>(

--- a/packages/react/src/internals/itemEquality.ts
+++ b/packages/react/src/internals/itemEquality.ts
@@ -71,13 +71,41 @@ export function findSelectionIndex<Item, Value>(
   comparer: ItemEqualityComparer<Item, Value>,
   multiple: boolean,
 ): number | null {
-  // Only unwrap in multiple mode: an array can itself be a valid single-select value.
-  const lastValue =
-    multiple && Array.isArray(selectedValue)
-      ? selectedValue[selectedValue.length - 1]
-      : selectedValue;
-  const index = findItemIndex(itemValues, lastValue as Value, comparer);
+  // Only treat the value as a list in multiple mode: an array can itself be a valid
+  // single-select value.
+  if (multiple && Array.isArray(selectedValue)) {
+    // Anchor to the first selected item in rendered order so the index does not depend
+    // on the order in which the values were added to the array.
+    const index =
+      itemValues?.findIndex(
+        (itemValue) =>
+          itemValue !== undefined && selectedValueIncludes(selectedValue, itemValue, comparer),
+      ) ?? -1;
+    return index === -1 ? null : index;
+  }
+  const index = findItemIndex(itemValues, selectedValue as Value, comparer);
   return index === -1 ? null : index;
+}
+
+/** Whether an item should become the first selected index in rendered order. */
+export function shouldClaimSelectedIndex<Item, Value>(
+  index: number,
+  itemValue: Item,
+  registry: readonly Item[],
+  selectedValues: readonly Value[],
+  comparer: ItemEqualityComparer<Item, Value>,
+  currentIndex: number | null,
+): boolean {
+  if (!selectedValueIncludes(selectedValues, itemValue, comparer)) {
+    return false;
+  }
+  if (currentIndex == null || index <= currentIndex) {
+    return true;
+  }
+  const currentValue = registry[currentIndex];
+  return (
+    currentValue === undefined || !selectedValueIncludes(selectedValues, currentValue, comparer)
+  );
 }
 
 export function removeItem<Item, Value>(

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -75,11 +75,12 @@ export const SelectItem = React.memo(
     useIsoLayoutEffect(() => {
       const selectedValue = store.state.value;
 
+      const currentIndex = store.state.selectedIndex;
+      let nextIndex = currentIndex;
       let claims: boolean;
       if (multiple && Array.isArray(selectedValue)) {
         // The claiming item also owns the text ref that aligns the popup.
-        const currentIndex = store.state.selectedIndex;
-        const nextIndex = resolveSelectedIndex(
+        nextIndex = resolveSelectedIndex(
           index,
           itemValue,
           store.context.valuesRef.current,
@@ -87,28 +88,24 @@ export const SelectItem = React.memo(
           isItemEqualToValue,
           currentIndex,
         );
-        if (nextIndex !== currentIndex) {
-          store.set('selectedIndex', nextIndex);
-          if (index === currentIndex) {
-            store.context.selectedItemTextRef.current = null;
-          }
-        }
         claims = nextIndex === index;
+        if (index === currentIndex && !claims) {
+          store.context.selectedItemTextRef.current = null;
+        }
       } else {
         claims =
           selectedValue !== undefined &&
           compareItemEquality(itemValue, selectedValue, isItemEqualToValue);
         if (claims) {
-          store.set('selectedIndex', index);
+          nextIndex = index;
         }
       }
+      store.set('selectedIndex', nextIndex);
 
-      if (claims) {
-        // Make sure SelectPopup can measure the selected item on first open.
-        // SelectItemText can still update this ref later when focus moves.
-        if (textRef.current) {
-          store.context.selectedItemTextRef.current = textRef.current;
-        }
+      // Make sure SelectPopup can measure the selected item on first open.
+      // SelectItemText can still update this ref later when focus moves.
+      if (claims && textRef.current) {
+        store.context.selectedItemTextRef.current = textRef.current;
       }
     }, [index, multiple, isItemEqualToValue, store, itemValue]);
 

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -77,9 +77,7 @@ export const SelectItem = React.memo(
 
       let claims: boolean;
       if (multiple && Array.isArray(selectedValue)) {
-        // The first selected item in rendered order owns the index (and the text ref that
-        // aligns the popup), so the anchor does not depend on the order in which the
-        // values were added to the array.
+        // The claiming item also owns the text ref that aligns the popup.
         claims = shouldClaimSelectedIndex(
           index,
           itemValue,

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -17,7 +17,7 @@ import { REASONS } from '../../internals/reasons';
 import {
   compareItemEquality,
   removeItem,
-  shouldClaimSelectedIndex,
+  resolveSelectedIndex,
 } from '../../internals/itemEquality';
 import { isVirtualClick } from '../../floating-ui-react/utils/event';
 
@@ -78,22 +78,32 @@ export const SelectItem = React.memo(
       let claims: boolean;
       if (multiple && Array.isArray(selectedValue)) {
         // The claiming item also owns the text ref that aligns the popup.
-        claims = shouldClaimSelectedIndex(
+        const currentIndex = store.state.selectedIndex;
+        const nextIndex = resolveSelectedIndex(
           index,
           itemValue,
           store.context.valuesRef.current,
           selectedValue,
           isItemEqualToValue,
-          store.state.selectedIndex,
+          currentIndex,
         );
+        if (nextIndex !== currentIndex) {
+          store.set('selectedIndex', nextIndex);
+          if (index === currentIndex) {
+            store.context.selectedItemTextRef.current = null;
+          }
+        }
+        claims = nextIndex === index;
       } else {
         claims =
           selectedValue !== undefined &&
           compareItemEquality(itemValue, selectedValue, isItemEqualToValue);
+        if (claims) {
+          store.set('selectedIndex', index);
+        }
       }
 
       if (claims) {
-        store.set('selectedIndex', index);
         // Make sure SelectPopup can measure the selected item on first open.
         // SelectItemText can still update this ref later when focus moves.
         if (textRef.current) {

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -14,7 +14,11 @@ import { SelectItemContext } from './SelectItemContext';
 import { useButton } from '../../internals/use-button';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
-import { compareItemEquality, removeItem } from '../../internals/itemEquality';
+import {
+  compareItemEquality,
+  removeItem,
+  shouldClaimSelectedIndex,
+} from '../../internals/itemEquality';
 import { isVirtualClick } from '../../floating-ui-react/utils/event';
 
 /**
@@ -71,18 +75,26 @@ export const SelectItem = React.memo(
     useIsoLayoutEffect(() => {
       const selectedValue = store.state.value;
 
-      let selectedCandidate = selectedValue;
+      let claims: boolean;
       if (multiple && Array.isArray(selectedValue)) {
-        // Compare against the last selected item, or `undefined` when nothing is selected — never
-        // the raw array, which a custom `isItemEqualToValue` isn't expected to receive.
-        selectedCandidate =
-          selectedValue.length > 0 ? selectedValue[selectedValue.length - 1] : undefined;
+        // The first selected item in rendered order owns the index (and the text ref that
+        // aligns the popup), so the anchor does not depend on the order in which the
+        // values were added to the array.
+        claims = shouldClaimSelectedIndex(
+          index,
+          itemValue,
+          store.context.valuesRef.current,
+          selectedValue,
+          isItemEqualToValue,
+          store.state.selectedIndex,
+        );
+      } else {
+        claims =
+          selectedValue !== undefined &&
+          compareItemEquality(itemValue, selectedValue, isItemEqualToValue);
       }
 
-      if (
-        selectedCandidate !== undefined &&
-        compareItemEquality(itemValue, selectedCandidate, isItemEqualToValue)
-      ) {
+      if (claims) {
         store.set('selectedIndex', index);
         // Make sure SelectPopup can measure the selected item on first open.
         // SelectItemText can still update this ref later when focus moves.

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -5718,8 +5718,10 @@ describe('<Select.Root />', () => {
     });
 
     it('highlights the first selected item in rendered order regardless of value order', async () => {
+      // `c` is last in rendered order but first in the value array, so anchoring to the rendered
+      // order and anchoring to either end of the value array give different answers.
       const { user } = await render(
-        <Select.Root multiple defaultValue={['c', 'b']}>
+        <Select.Root multiple defaultValue={['b', 'c']}>
           <Select.Trigger data-testid="trigger">
             <Select.Value />
           </Select.Trigger>
@@ -5789,6 +5791,336 @@ describe('<Select.Root />', () => {
       });
       expect(screen.getByRole('option', { name: 'x' })).not.toHaveAttribute('data-highlighted');
     });
+
+    it('moves the anchor to the next selected item when the anchor item leaves the list', async () => {
+      function App(props: { trimmed?: boolean }) {
+        return (
+          <Select.Root multiple defaultValue={['a', 'b', 'c']}>
+            <Select.Trigger data-testid="trigger">
+              <Select.Value />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner>
+                <Select.Popup>
+                  {!props.trimmed && <Select.Item value="a">a</Select.Item>}
+                  <Select.Item value="b">b</Select.Item>
+                  <Select.Item value="c">c</Select.Item>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+        );
+      }
+
+      const { user, setProps } = await render(<App />);
+
+      // The items have to register under the full list before one of them can leave it.
+      await user.click(screen.getByTestId('trigger'));
+      await screen.findByRole('option', { name: 'a' });
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).toBe(null);
+      });
+
+      await setProps({ trimmed: true });
+
+      await user.click(screen.getByTestId('trigger'));
+
+      const optionB = await screen.findByRole('option', { name: 'b' });
+      await waitFor(() => {
+        expect(optionB).toHaveAttribute('data-highlighted');
+      });
+      expect(screen.getByRole('option', { name: 'c' })).not.toHaveAttribute('data-highlighted');
+    });
+
+    it('re-anchors backwards when a new isItemEqualToValue identity re-runs every item', async () => {
+      // An inline comparer gives every render a new identity, so all item effects re-run. The
+      // anchor moving to an earlier item must survive the old anchor's own effect.
+      interface Option {
+        id: number;
+      }
+      const options: Option[] = [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }];
+
+      function App(props: { value: Option[] }) {
+        return (
+          <Select.Root
+            multiple
+            value={props.value}
+            isItemEqualToValue={(a: Option, b: Option) => a.id === b.id}
+          >
+            <Select.Trigger data-testid="trigger">
+              <Select.Value>{() => 'value'}</Select.Value>
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner>
+                <Select.Popup>
+                  {options.map((option) => (
+                    <Select.Item key={option.id} value={option}>
+                      <Select.ItemText>{`opt-${option.id}`}</Select.ItemText>
+                    </Select.Item>
+                  ))}
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+        );
+      }
+
+      const { user, setProps } = await render(<App value={[{ id: 2 }, { id: 3 }]} />);
+
+      await user.click(screen.getByTestId('trigger'));
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'opt-2' })).toHaveAttribute('data-highlighted');
+      });
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).toBe(null);
+      });
+
+      await setProps({ value: [{ id: 0 }, { id: 1 }] });
+
+      await user.click(screen.getByTestId('trigger'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'opt-0' })).toHaveAttribute('data-highlighted');
+      });
+      expect(screen.getByRole('option', { name: 'opt-1' })).not.toHaveAttribute('data-highlighted');
+    });
+
+    it.skipIf(isJSDOM)(
+      'aligns the first selected item with the trigger when alignItemWithTrigger is active',
+      async () => {
+        // The list has to be long enough, and the popup unconstrained enough, for aligned
+        // positioning to stay active. Otherwise the popup falls back to a side and the
+        // measurement below would be meaningless, so `data-side` is asserted first.
+        const options = Array.from({ length: 40 }, (_, index) => `opt-${index}`);
+
+        const { user } = await render(
+          <div style={{ paddingTop: 120, paddingLeft: 32 }}>
+            <Select.Root multiple defaultValue={['opt-10', 'opt-30']}>
+              <Select.Trigger data-testid="trigger" style={{ width: 160, height: 36 }}>
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Positioner>
+                  <Select.Popup data-testid="popup" style={{ maxHeight: 'none', minHeight: 100 }}>
+                    {options.map((option) => (
+                      <Select.Item key={option} value={option}>
+                        <Select.ItemText>{option}</Select.ItemText>
+                      </Select.Item>
+                    ))}
+                  </Select.Popup>
+                </Select.Positioner>
+              </Select.Portal>
+            </Select.Root>
+          </div>,
+        );
+
+        const trigger = screen.getByTestId('trigger');
+        await user.click(trigger);
+
+        const anchorItem = await screen.findByRole('option', { name: 'opt-10' });
+        await waitFor(() => {
+          expect(anchorItem).toHaveAttribute('data-highlighted');
+        });
+        await waitFor(() => {
+          expect(screen.getByTestId('popup')).toHaveAttribute('data-side', 'none');
+        });
+
+        const verticalCenter = (element: Element) => {
+          const rect = element.getBoundingClientRect();
+          return rect.top + rect.height / 2;
+        };
+
+        await waitFor(() => {
+          expect(
+            Math.abs(verticalCenter(anchorItem) - verticalCenter(trigger)),
+          ).toBeLessThanOrEqual(1);
+        });
+      },
+    );
+
+    it('anchors to the first selected item when opened with the keyboard', async () => {
+      const { user } = await render(
+        <Select.Root multiple defaultValue={['b', 'c']}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      await user.keyboard('{Tab}');
+      expect(screen.getByTestId('trigger')).toHaveFocus();
+      await user.keyboard('{ArrowDown}');
+
+      const optionB = await screen.findByRole('option', { name: 'b' });
+      await waitFor(() => {
+        expect(optionB).toHaveAttribute('data-highlighted');
+      });
+      expect(screen.getByRole('option', { name: 'c' })).not.toHaveAttribute('data-highlighted');
+    });
+
+    it('continues arrow navigation from the anchor rather than the top of the list', async () => {
+      const { user } = await render(
+        <Select.Root multiple defaultValue={['b', 'c']}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+                <Select.Item value="d">d</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      await user.click(screen.getByTestId('trigger'));
+      const optionB = await screen.findByRole('option', { name: 'b' });
+      await waitFor(() => {
+        expect(optionB).toHaveAttribute('data-highlighted');
+      });
+      // Focus reaches the anchor asynchronously. Keys sent before it lands are lost.
+      await waitFor(() => {
+        expect(optionB).toHaveFocus();
+      });
+
+      // The next item after the anchor, not `a` at the top.
+      await user.keyboard('{ArrowDown}');
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'c' })).toHaveAttribute('data-highlighted');
+      });
+
+      await user.keyboard('{ArrowUp}');
+      await waitFor(() => {
+        expect(optionB).toHaveAttribute('data-highlighted');
+      });
+    });
+
+    it('keeps the highlight on an item deselected with the keyboard', async () => {
+      const { user } = await render(
+        <Select.Root multiple defaultValue={['b', 'c']}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      await user.click(screen.getByTestId('trigger'));
+      const optionB = await screen.findByRole('option', { name: 'b' });
+      await waitFor(() => {
+        expect(optionB).toHaveAttribute('data-highlighted');
+      });
+      // Focus reaches the anchor asynchronously. Keys sent before it lands are lost.
+      await waitFor(() => {
+        expect(optionB).toHaveFocus();
+      });
+
+      await user.keyboard('{Enter}');
+      await waitFor(() => {
+        expect(optionB).toHaveAttribute('aria-selected', 'false');
+      });
+      expect(optionB).toHaveAttribute('data-highlighted');
+    });
+
+    it('anchors to the first selected item in rendered order across groups', async () => {
+      // `spinach` renders first but is not the last value, so anchoring to the rendered order
+      // and anchoring to the end of the value array give different answers.
+      const { user } = await render(
+        <Select.Root multiple defaultValue={['spinach', 'plum']}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Group>
+                  <Select.GroupLabel>Vegetables</Select.GroupLabel>
+                  <Select.Item value="artichoke">artichoke</Select.Item>
+                  <Select.Item value="spinach">spinach</Select.Item>
+                </Select.Group>
+                <Select.Group>
+                  <Select.GroupLabel>Fruits</Select.GroupLabel>
+                  <Select.Item value="apple">apple</Select.Item>
+                  <Select.Item value="plum">plum</Select.Item>
+                </Select.Group>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      await user.click(screen.getByTestId('trigger'));
+
+      const spinachItem = await screen.findByRole('option', { name: 'spinach' });
+      await waitFor(() => {
+        expect(spinachItem).toHaveAttribute('data-highlighted');
+      });
+      expect(screen.getByRole('option', { name: 'plum' })).not.toHaveAttribute('data-highlighted');
+    });
+
+    it.skipIf(isJSDOM)(
+      'scrolls the first selected item into view on open',
+      async ({ onTestFinished }) => {
+        const scrollIntoView = vi.spyOn(HTMLElement.prototype, 'scrollIntoView');
+        onTestFinished(() => scrollIntoView.mockRestore());
+        const options = Array.from({ length: 100 }, (_, index) => `item ${index}`);
+
+        const { user } = await render(
+          <Select.Root multiple defaultValue={['item 80', 'item 90']}>
+            <Select.Trigger data-testid="trigger">
+              <Select.Value />
+            </Select.Trigger>
+            <Select.Portal>
+              {/* Aligned positioning translates the popup instead of scrolling the list, so the
+                  scroll path only runs with it turned off. */}
+              <Select.Positioner alignItemWithTrigger={false}>
+                <Select.Popup style={{ maxHeight: 200, overflowY: 'auto' }}>
+                  {options.map((option) => (
+                    <Select.Item key={option} value={option}>
+                      <Select.ItemText>{option}</Select.ItemText>
+                    </Select.Item>
+                  ))}
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>,
+        );
+
+        scrollIntoView.mockClear();
+        await user.click(screen.getByTestId('trigger'));
+
+        const selectedItem = await screen.findByRole('option', { name: 'item 80' });
+        await waitFor(() => {
+          expect(selectedItem).toHaveAttribute('data-highlighted');
+        });
+        await waitFor(() => {
+          expect(scrollIntoView.mock.contexts).toContain(selectedItem);
+        });
+      },
+    );
 
     it('should handle defaultValue as array in multiple mode', async () => {
       await render(

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -5717,6 +5717,33 @@ describe('<Select.Root />', () => {
       });
     });
 
+    it('highlights the first selected item in rendered order regardless of value order', async () => {
+      const { user } = await render(
+        <Select.Root multiple defaultValue={['b', 'c']}>
+          <Select.Trigger data-testid="trigger">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item value="a">a</Select.Item>
+                <Select.Item value="b">b</Select.Item>
+                <Select.Item value="c">c</Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>,
+      );
+
+      await user.click(screen.getByTestId('trigger'));
+
+      const optionB = await screen.findByRole('option', { name: 'b' });
+      await waitFor(() => {
+        expect(optionB).toHaveAttribute('data-highlighted');
+      });
+      expect(screen.getByRole('option', { name: 'c' })).not.toHaveAttribute('data-highlighted');
+    });
+
     it('should handle defaultValue as array in multiple mode', async () => {
       await render(
         <Select.Root multiple defaultValue={['a', 'c']}>

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -5719,7 +5719,7 @@ describe('<Select.Root />', () => {
 
     it('highlights the first selected item in rendered order regardless of value order', async () => {
       const { user } = await render(
-        <Select.Root multiple defaultValue={['b', 'c']}>
+        <Select.Root multiple defaultValue={['c', 'b']}>
           <Select.Trigger data-testid="trigger">
             <Select.Value />
           </Select.Trigger>

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -5718,10 +5718,10 @@ describe('<Select.Root />', () => {
     });
 
     it('highlights the first selected item in rendered order regardless of value order', async () => {
-      // `c` is last in rendered order but first in the value array, so anchoring to the rendered
-      // order and anchoring to either end of the value array give different answers.
+      // `a` renders first but sits in the middle of the value array, so neither end of that
+      // array points at it and only the rendered order does.
       const { user } = await render(
-        <Select.Root multiple defaultValue={['b', 'c']}>
+        <Select.Root multiple defaultValue={['b', 'a', 'c']}>
           <Select.Trigger data-testid="trigger">
             <Select.Value />
           </Select.Trigger>
@@ -5739,10 +5739,11 @@ describe('<Select.Root />', () => {
 
       await user.click(screen.getByTestId('trigger'));
 
-      const optionB = await screen.findByRole('option', { name: 'b' });
+      const optionA = await screen.findByRole('option', { name: 'a' });
       await waitFor(() => {
-        expect(optionB).toHaveAttribute('data-highlighted');
+        expect(optionA).toHaveAttribute('data-highlighted');
       });
+      expect(screen.getByRole('option', { name: 'b' })).not.toHaveAttribute('data-highlighted');
       expect(screen.getByRole('option', { name: 'c' })).not.toHaveAttribute('data-highlighted');
     });
 

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -5768,10 +5768,20 @@ describe('<Select.Root />', () => {
 
       const { user, setProps } = await render(<App />);
 
-      // The list stays mounted while closed, so the swap happens in place.
+      // The list only mounts on the first open, and stays mounted once closed. Opening
+      // first is what makes the swap below happen in place, on items that already
+      // registered their values and elected an anchor.
+      const trigger = screen.getByTestId('trigger');
+      await user.click(trigger);
+      await screen.findByRole('option', { name: 'a' });
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('listbox')).toBe(null);
+      });
+
       await setProps({ replaceA: true });
 
-      await user.click(screen.getByTestId('trigger'));
+      await user.click(trigger);
 
       const optionC = await screen.findByRole('option', { name: 'c' });
       await waitFor(() => {

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -5744,6 +5744,42 @@ describe('<Select.Root />', () => {
       expect(screen.getByRole('option', { name: 'c' })).not.toHaveAttribute('data-highlighted');
     });
 
+    it('re-elects the anchor when the anchor item value changes in place', async () => {
+      function App(props: { replaceA?: boolean }) {
+        return (
+          <Select.Root multiple defaultValue={['a', 'c']}>
+            <Select.Trigger data-testid="trigger">
+              <Select.Value />
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner>
+                <Select.Popup>
+                  <Select.Item value={props.replaceA ? 'x' : 'a'}>
+                    {props.replaceA ? 'x' : 'a'}
+                  </Select.Item>
+                  <Select.Item value="b">b</Select.Item>
+                  <Select.Item value="c">c</Select.Item>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+        );
+      }
+
+      const { user, setProps } = await render(<App />);
+
+      // The list stays mounted while closed, so the swap happens in place.
+      await setProps({ replaceA: true });
+
+      await user.click(screen.getByTestId('trigger'));
+
+      const optionC = await screen.findByRole('option', { name: 'c' });
+      await waitFor(() => {
+        expect(optionC).toHaveAttribute('data-highlighted');
+      });
+      expect(screen.getByRole('option', { name: 'x' })).not.toHaveAttribute('data-highlighted');
+    });
+
     it('should handle defaultValue as array in multiple mode', async () => {
       await render(
         <Select.Root multiple defaultValue={['a', 'c']}>

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -241,8 +241,6 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
 
   useIsoLayoutEffect(
     function syncSelectedIndex() {
-      // In multiple mode this resolves to the first selected item in rendered order, so
-      // the anchor does not depend on the order of the value array.
       const nextIndex = findSelectionIndex(valuesRef.current, value, isItemEqualToValue, multiple);
 
       if (nextIndex === null) {

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -40,7 +40,7 @@ import { useFormContext } from '../../internals/form-context/FormContext';
 import { type Group, stringifyAsLabel, stringifyAsValue } from '../../internals/resolveValueLabel';
 import {
   defaultItemEquality,
-  findItemIndex,
+  findSelectionIndex,
   isSelectedValueDirty,
 } from '../../internals/itemEquality';
 import { useValueChanged } from '../../internals/useValueChanged';
@@ -241,19 +241,9 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
 
   useIsoLayoutEffect(
     function syncSelectedIndex() {
-      let target: unknown = value;
-      let empty = false;
-
-      if (multiple) {
-        const currentValue = Array.isArray(value) ? value : [];
-        empty = currentValue.length === 0;
-        target = currentValue[currentValue.length - 1];
-      }
-
-      const index = empty
-        ? -1
-        : findItemIndex(valuesRef.current, target as Value, isItemEqualToValue);
-      const nextIndex = index === -1 ? null : index;
+      // In multiple mode this resolves to the first selected item in rendered order, so
+      // the anchor does not depend on the order of the value array.
+      const nextIndex = findSelectionIndex(valuesRef.current, value, isItemEqualToValue, multiple);
 
       if (nextIndex === null) {
         selectedItemTextRef.current = null;


### PR DESCRIPTION
Closes #3077
Closes #5549

Multiple-selection popups continue to open from a selected item. When more than one item is selected, the anchor is the first selected item in rendered order rather than the most recently added value. This follows the single-selection rule and keeps the opening position stable when values are toggled or supplied in a different order.

## Changes

- Use the same rendered-order anchor in Combobox and Select, including individually rendered items and `items` collections.
- Preserve the just-selected highlight when a filtered multiple Combobox clears its query.
- Cover opening, query clearing, scrolling, controlled updates, and reordered value arrays.

---

APG guidance for multi-select listboxes:
 
<img width="976" height="440" alt="Screenshot 2026-09-01 at 2 12 57 pm" src="https://github.com/user-attachments/assets/2f0b0aaa-0078-4b96-8756-12aefccc9e2c" />
