### PR TITLE
[ci] Bump the Claude review workflow pin

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   claude-review:
-    uses: mui/mui-public/.github/workflows/claude-review.yml@0534c1cc1a7f0f170d927199ec407192a656e81f # master
+    uses: mui/mui-public/.github/workflows/claude-review.yml@573def85d39688f971a01b3653d108374cd8e9ac # master
     permissions:
       contents: read # read the repo (checkout + git diff)
       id-token: write # mint the GitHub OIDC token exchanged for a Claude token via WIF


### PR DESCRIPTION
Picks up mui/mui-public#1815, which authenticates the PR head fetch and collapses it into a single call. Reviews here are unaffected today, since base-ui is public and the anonymous fetch worked; this keeps the pin current with the other callers.
