### PR TITLE
[number field] Keep native selection behavior when focusing the input

### DIFF
--- a/packages/react/src/number-field/increment/NumberFieldIncrement.test.tsx
+++ b/packages/react/src/number-field/increment/NumberFieldIncrement.test.tsx
@@ -731,6 +731,24 @@ describe('<NumberField.Increment />', () => {
     expect(onValueCommitted).not.toHaveBeenCalled();
   });
 
+  it('places the caret at the end of the input when a mouse press focuses it', async () => {
+    await render(
+      <NumberField.Root defaultValue={100}>
+        <NumberField.Increment />
+        <NumberField.Input />
+      </NumberField.Root>,
+    );
+
+    const button = screen.getByRole('button');
+    const input = screen.getByRole<HTMLInputElement>('textbox');
+
+    fireEvent.pointerDown(button, { pointerType: 'mouse', button: 0 });
+
+    expect(document.activeElement).toBe(input);
+    expect(input.selectionStart).toBe(input.value.length);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+
   it('treats pen pointer as touch-like', async () => {
     await render(
       <NumberField.Root defaultValue={0}>

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -1520,6 +1520,25 @@ describe('<NumberField.Input />', () => {
     });
   });
 
+  describe('focus selection', () => {
+    it('keeps the selection the browser set when focus moves into the input', async () => {
+      await render(
+        <NumberField.Root defaultValue={100}>
+          <NumberField.Input />
+        </NumberField.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('textbox');
+
+      // Tabbing into an input natively selects the whole value before the focus event fires.
+      input.setSelectionRange(0, input.value.length);
+      await act(async () => input.focus());
+
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe(input.value.length);
+    });
+  });
+
   describe('consumer-prevented defaults', () => {
     it('does not mark the field focused when the focus default is prevented', async () => {
       await render(

--- a/packages/react/src/number-field/input/NumberFieldInput.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.tsx
@@ -82,7 +82,6 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
     useFieldRootContext();
   const { labelId } = useLabelableContext();
 
-  const hasTouchedInputRef = React.useRef(false);
   const blockRevalidationRef = React.useRef(false);
   const pendingCaretRef = React.useRef<number | null>(null);
 
@@ -133,18 +132,6 @@ export const NumberFieldInput = React.forwardRef(function NumberFieldInput(
       }
 
       setFocused(true);
-
-      if (hasTouchedInputRef.current) {
-        return;
-      }
-
-      hasTouchedInputRef.current = true;
-
-      // Browsers set selection at the start of the input field by default. We want to set it at
-      // the end for the first focus.
-      const target = event.currentTarget;
-      const length = target.value.length;
-      target.setSelectionRange(length, length);
     },
     onBlur(event) {
       if (event.defaultPrevented || disabled) {

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -338,6 +338,20 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
     [minWithDefault],
   );
 
+  // Programmatic focus leaves the caret at the start (Chrome/Firefox) or selects the whole value
+  // (Safari). Place the caret at the end instead. The selection must be set after `focus()`
+  // returns, not in the focus handler: WebKit applies its own selection after dispatching the
+  // focus event. Keyboard and pointer focus keep the browser's native selection behavior.
+  const focusInput = useStableCallback(() => {
+    const input = inputRef.current;
+    if (!input) {
+      return;
+    }
+    input.focus();
+    const length = input.value.length;
+    input.setSelectionRange(length, length);
+  });
+
   // React attaches `onWheel` as a passive listener, so calling `preventDefault` there is ignored.
   // Attach a native (non-passive) `wheel` listener to the input instead to prevent page scrolling.
   React.useEffect(
@@ -419,6 +433,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
   const contextValue: NumberFieldRootContext = React.useMemo(
     () => ({
       inputRef,
+      focusInput,
       minWithDefault,
       maxWithDefault,
       id,
@@ -444,6 +459,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
     }),
     [
       inputRef,
+      focusInput,
       minWithDefault,
       maxWithDefault,
       id,
@@ -478,7 +494,7 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
       <input
         {...validation.getValidationProps(disabled, {
           onFocus() {
-            inputRef.current?.focus();
+            focusInput();
           },
           onChange(event: React.ChangeEvent<HTMLInputElement>) {
             // Workaround for https://github.com/react/react/issues/9023

--- a/packages/react/src/number-field/root/NumberFieldRootContext.ts
+++ b/packages/react/src/number-field/root/NumberFieldRootContext.ts
@@ -13,6 +13,7 @@ export interface NumberFieldRootContext {
   getStepAmount: (event?: EventWithOptionalKeyState) => number;
   incrementValue: (amount: number, params: IncrementValueParameters) => boolean;
   inputRef: React.RefObject<HTMLInputElement | null>;
+  focusInput: () => void;
   allowInputSyncRef: React.RefObject<boolean | null>;
   formatOptionsRef: React.RefObject<Intl.NumberFormatOptions | undefined>;
   valueRef: React.RefObject<number | null>;

--- a/packages/react/src/number-field/root/useNumberFieldStepperButton.ts
+++ b/packages/react/src/number-field/root/useNumberFieldStepperButton.ts
@@ -47,6 +47,7 @@ export function useNumberFieldStepperButton(
     id,
     incrementValue,
     inputRef,
+    focusInput,
     maxWithDefault,
     minWithDefault,
     setValue,
@@ -162,7 +163,7 @@ export function useNumberFieldStepperButton(
 
       if (!isTouchLikePointerType(event.pointerType)) {
         // Focus the input so the user can continue with keyboard interactions.
-        inputRef.current?.focus();
+        focusInput();
       }
 
       pointerHandlers.onPointerDown(event);

--- a/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.tsx
+++ b/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.tsx
@@ -48,6 +48,7 @@ export const NumberFieldScrubArea = React.forwardRef(function NumberFieldScrubAr
     state,
     setIsScrubbing: setRootScrubbing,
     inputRef,
+    focusInput,
     incrementValue,
     allowInputSyncRef,
     getStepAmount,
@@ -308,7 +309,7 @@ export const NumberFieldScrubArea = React.forwardRef(function NumberFieldScrubAr
 
       if (event.pointerType === 'mouse') {
         event.preventDefault();
-        inputRef.current?.focus();
+        focusInput();
       }
 
       isScrubbingRef.current = true;


### PR DESCRIPTION
Fixes #5576

Tabbing into the input natively selects the whole value, but a first-focus `setSelectionRange` override collapsed that selection to the end, so the first tab-in behaved differently from every later one. In Firefox the same override also moved the caret to the end on the first click, ignoring the click position.

## Changes

- Removed the first-focus selection override from the input. Keyboard and pointer focus now keep the browser's native selection.
- Moved the caret-at-end placement into a shared `focusInput()` helper used by the programmatic focus paths (stepper buttons, scrub area, hidden input focus redirect), where it is still needed: programmatic focus places the caret at the start in Chrome/Firefox and selects the whole value in WebKit. The helper sets the selection after `focus()` returns because WebKit applies its own selection after dispatching the focus event, which overrides any range set inside a focus handler.
