### PR TITLE
[combobox] Fix stale composition text when selecting an item with the pointer

### DIFF
--- a/packages/react/src/combobox/input/ComboboxInput.iOS.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.iOS.test.tsx
@@ -1,0 +1,86 @@
+import { expect, vi } from 'vitest';
+import * as React from 'react';
+import { Combobox } from '@base-ui/react/combobox';
+import { createRenderer } from '#test-utils';
+import { fireEvent, screen } from '@mui/internal-test-utils';
+
+vi.mock('@base-ui/utils/platform', async () => {
+  const actual =
+    await vi.importActual<typeof import('@base-ui/utils/platform')>('@base-ui/utils/platform');
+
+  return {
+    ...actual,
+    platform: {
+      ...actual.platform,
+      os: { ...actual.platform.os, ios: true, apple: true },
+    },
+  };
+});
+
+describe('<Combobox.Input /> on iOS', () => {
+  const { render } = createRenderer();
+
+  // Replacing the value while the native IME is composing leaves the field unable to accept
+  // input until it is blurred and refocused, so the stale preview has to survive the press.
+  // https://bugs.webkit.org/show_bug.cgi?id=255857
+  it('keeps the composition preview when an item is selected with the pointer', async () => {
+    const { user } = await render(
+      <Combobox.Root items={['창세기', '출애굽기']}>
+        <Combobox.Input />
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.List>
+                {(item: string) => (
+                  <Combobox.Item key={item} value={item}>
+                    {item}
+                  </Combobox.Item>
+                )}
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: '창' } });
+
+    await user.click(screen.getByRole('option', { name: '창세기' }));
+
+    expect(input).toHaveValue('창');
+  });
+
+  it('applies the selected value once the composition ends', async () => {
+    const { user } = await render(
+      <Combobox.Root items={['창세기', '출애굽기']}>
+        <Combobox.Input />
+        <Combobox.Portal>
+          <Combobox.Positioner>
+            <Combobox.Popup>
+              <Combobox.List>
+                {(item: string) => (
+                  <Combobox.Item key={item} value={item}>
+                    {item}
+                  </Combobox.Item>
+                )}
+              </Combobox.List>
+            </Combobox.Popup>
+          </Combobox.Positioner>
+        </Combobox.Portal>
+      </Combobox.Root>,
+    );
+
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: '창' } });
+
+    await user.click(screen.getByRole('option', { name: '창세기' }));
+    fireEvent.compositionEnd(input, { target: { value: '창세기' } });
+
+    expect(input).toHaveValue('창세기');
+  });
+});

--- a/packages/react/src/combobox/input/ComboboxInput.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.test.tsx
@@ -1,8 +1,10 @@
 import { expect, vi } from 'vitest';
+import type { CDPSession } from '@vitest/browser-playwright';
 import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
-import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { platform } from '@base-ui/utils/platform';
 import { Field } from '@base-ui/react/field';
 import { REASONS } from '../../internals/reasons';
 
@@ -898,6 +900,161 @@ describe('<Combobox.Input />', () => {
       expect(screen.getByRole('listbox')).not.toBe(null);
       expect(input).not.toHaveAttribute('aria-activedescendant');
     });
+
+    it('replaces in-progress composition text when an item is selected with the pointer', async () => {
+      const { user } = await render(
+        <Combobox.Root items={['창세기', '출애굽기']}>
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      fireEvent.compositionStart(input);
+      fireEvent.change(input, { target: { value: '창' } });
+      expect(input).toHaveValue('창');
+
+      await user.click(screen.getByRole('option', { name: '창세기' }));
+
+      expect(input).toHaveValue('창세기');
+    });
+
+    it('replaces composition text when the pressed item matches the current input value', async () => {
+      const { user } = await render(
+        <Combobox.Root items={['창세기', '출애굽기']} defaultValue="창세기" filter={null}>
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      fireEvent.compositionStart(input);
+      fireEvent.change(input, { target: { value: '창세기창' } });
+      expect(input).toHaveValue('창세기창');
+
+      await user.click(screen.getByRole('option', { name: '창세기' }));
+
+      expect(input).toHaveValue('창세기');
+    });
+
+    it.skipIf(isJSDOM || !platform.engine.blink)(
+      'replaces a real IME composition when an item is selected with the mouse',
+      async () => {
+        const { cdp } = await import('vitest/browser');
+        const session = cdp() as CDPSession;
+
+        await render(
+          <Combobox.Root items={['창세기', '출애굽기']}>
+            <Combobox.Input />
+            <Combobox.Portal>
+              <Combobox.Positioner>
+                <Combobox.Popup>
+                  <Combobox.List>
+                    {(item: string) => (
+                      <Combobox.Item key={item} value={item}>
+                        {item}
+                      </Combobox.Item>
+                    )}
+                  </Combobox.List>
+                </Combobox.Popup>
+              </Combobox.Positioner>
+            </Combobox.Portal>
+          </Combobox.Root>,
+        );
+
+        const input = screen.getByRole('combobox');
+        await act(async () => input.focus());
+
+        // Drive a genuine in-progress composition (Korean 2-Set: ㅊ ㅏ ㅇ → 창).
+        await act(async () => {
+          await session.send('Input.imeSetComposition', {
+            text: 'ㅊ',
+            selectionStart: 1,
+            selectionEnd: 1,
+          });
+          await session.send('Input.imeSetComposition', {
+            text: '차',
+            selectionStart: 1,
+            selectionEnd: 1,
+          });
+          await session.send('Input.imeSetComposition', {
+            text: '창',
+            selectionStart: 1,
+            selectionEnd: 1,
+          });
+        });
+
+        expect(input).toHaveValue('창');
+
+        const option = await screen.findByRole('option', { name: '창세기' });
+        const frame = window.frameElement as HTMLIFrameElement | null;
+        const frameRect = frame?.getBoundingClientRect();
+        const optionRect = option.getBoundingClientRect();
+        const optionCenter = {
+          x:
+            (frameRect?.left ?? 0) +
+            (frame?.clientLeft ?? 0) +
+            optionRect.left +
+            optionRect.width / 2,
+          y:
+            (frameRect?.top ?? 0) +
+            (frame?.clientTop ?? 0) +
+            optionRect.top +
+            optionRect.height / 2,
+        };
+
+        await act(async () => {
+          await session.send('Input.dispatchMouseEvent', {
+            type: 'mouseMoved',
+            ...optionCenter,
+          });
+          await session.send('Input.dispatchMouseEvent', {
+            type: 'mousePressed',
+            ...optionCenter,
+            button: 'left',
+            buttons: 1,
+            clickCount: 1,
+          });
+          await session.send('Input.dispatchMouseEvent', {
+            type: 'mouseReleased',
+            ...optionCenter,
+            button: 'left',
+            buttons: 0,
+            clickCount: 1,
+          });
+        });
+
+        await waitFor(() => {
+          expect(input).toHaveValue('창세기');
+        });
+      },
+    );
 
     it('removes the last rendered chip when pressing Backspace in an empty input', async () => {
       const handleValueChange = vi.fn();

--- a/packages/react/src/combobox/input/ComboboxInput.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.test.tsx
@@ -963,6 +963,74 @@ describe('<Combobox.Input />', () => {
       expect(input).toHaveValue('창세기');
     });
 
+    it('clears the composition preview when a multiselect item press clears the input', async () => {
+      const { user } = await render(
+        <Combobox.Root items={['창세기', '출애굽기']} multiple defaultOpen>
+          <Combobox.Trigger>open</Combobox.Trigger>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.Input data-testid="input" />
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = await screen.findByTestId('input');
+      fireEvent.compositionStart(input);
+      fireEvent.change(input, { target: { value: '창' } });
+      expect(input).toHaveValue('창');
+
+      // The press clears an input value that is already empty, so nothing but the preview changes.
+      await user.click(screen.getByRole('option', { name: '창세기' }));
+
+      expect(input).toHaveValue('');
+    });
+
+    it('does not re-report the written value as typed input when the composition then ends', async () => {
+      const onInputValueChange = vi.fn();
+      const { user } = await render(
+        <Combobox.Root items={['창세기', '출애굽기']} onInputValueChange={onInputValueChange}>
+          <Combobox.Input />
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      fireEvent.compositionStart(input);
+      fireEvent.change(input, { target: { value: '창' } });
+
+      await user.click(screen.getByRole('option', { name: '창세기' }));
+      onInputValueChange.mockClear();
+
+      // WebKit and Gecko end the composition as soon as the value is replaced.
+      fireEvent.compositionEnd(input);
+
+      expect(onInputValueChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue('창세기');
+    });
+
     it.skipIf(isJSDOM || !platform.engine.blink)(
       'replaces a real IME composition when an item is selected with the mouse',
       async () => {

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -256,7 +256,15 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
           setComposingValue(event.currentTarget.value);
         },
         onCompositionEnd(event) {
+          const wasComposing = isComposingRef.current;
           endComposing();
+          // An accepted external write (e.g. an item press) already ended the composition and
+          // owns the value. WebKit and Gecko then fire `compositionend` for that write, which
+          // must not re-report the written value as typed input. Android never tracks
+          // compositions, so its commit always writes.
+          if (!wasComposing && !platform.os.android) {
+            return;
+          }
           store.context.setInputValue(
             event.currentTarget.value,
             createChangeEventDetails(REASONS.inputChange, event.nativeEvent),

--- a/packages/react/src/combobox/input/ComboboxInput.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.tsx
@@ -99,6 +99,13 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
   const lastActiveIndexRef = React.useRef<number | null>(null);
   const shouldRestoreActiveIndexRef = React.useRef(false);
 
+  const endComposing = useStableCallback(() => {
+    isComposingRef.current = false;
+    setComposingValue(null);
+  });
+
+  React.useImperativeHandle(store.context.endComposingRef, () => endComposing);
+
   const inputOwnsFormValue = selectionMode === 'none' && !hasPositionerParent;
 
   const setInputElement = useStableCallback((element: HTMLInputElement | null) => {
@@ -249,11 +256,9 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
           setComposingValue(event.currentTarget.value);
         },
         onCompositionEnd(event) {
-          isComposingRef.current = false;
-          const next = event.currentTarget.value;
-          setComposingValue(null);
+          endComposing();
           store.context.setInputValue(
-            next,
+            event.currentTarget.value,
             createChangeEventDetails(REASONS.inputChange, event.nativeEvent),
           );
         },

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -270,6 +270,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
    * `mouseup` on an item belongs to a drag-select gesture that started elsewhere.
    */
   const pointerDownItemRef = React.useRef<Element | null>(null);
+  const endComposingRef = React.useRef<(() => void) | null>(null);
 
   const disabled = fieldDisabled || disabledProp;
   const name = fieldName ?? nameProp;
@@ -532,6 +533,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
         valuesRef,
         pointerDownItemRef,
         selectionEventRef,
+        endComposingRef,
       },
       selectors,
     );
@@ -648,6 +650,11 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
       if (eventDetails.isCanceled) {
         return;
       }
+
+      // An accepted write must be displayed even while the input renders an in-progress
+      // IME composition, e.g. when a pointer item press fills the input mid-composition.
+      // https://github.com/mui/base-ui/issues/5574
+      endComposingRef.current?.();
 
       // A canceled selection clear must not suppress close-completion cleanup.
       hadInputClearRef.current = eventDetails.reason === REASONS.inputClear;

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -1,5 +1,6 @@
 'use client';
 import * as React from 'react';
+import { platform } from '@base-ui/utils/platform';
 import { useControlled } from '@base-ui/utils/useControlled';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useOnFirstRender } from '@base-ui/utils/useOnFirstRender';
@@ -654,7 +655,12 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
       // An accepted write must be displayed even while the input renders an in-progress
       // IME composition, e.g. when a pointer item press fills the input mid-composition.
       // https://github.com/mui/base-ui/issues/5574
-      endComposingRef.current?.();
+      // iOS is excluded: replacing the value there leaves the native IME composing, and the
+      // field stops accepting input until it is blurred and refocused, so the stale preview
+      // is the lesser evil. https://bugs.webkit.org/show_bug.cgi?id=255857
+      if (!platform.os.ios) {
+        endComposingRef.current?.();
+      }
 
       // A canceled selection clear must not suppress close-completion cleanup.
       hadInputClearRef.current = eventDetails.reason === REASONS.inputClear;

--- a/packages/react/src/combobox/store.ts
+++ b/packages/react/src/combobox/store.ts
@@ -94,6 +94,9 @@ export type ComboboxStoreContext = {
   /** Native event that triggered the in-flight selection. */
   readonly selectionEventRef: React.RefObject<MouseEvent | PointerEvent | KeyboardEvent | null>;
 
+  /** Clears the input's in-progress composition preview. */
+  readonly endComposingRef: React.RefObject<(() => void) | null>;
+
   // Commands. Seeded with `NOOP` when the store is constructed and assigned during the root's
   // first render, so they are not `readonly`.
 


### PR DESCRIPTION
Fixes #5574

Selecting an item with the mouse during an active IME composition committed the value but left the in-progress composition text in the input. The item press keeps focus in the input, so `compositionend` never fires, and the input kept rendering its local `composingValue` over the filled store value. Deleting the leftover text then cleared the selection in single mode, turning a display glitch into data loss.

## Changes

- `Combobox.Input` registers an `endComposing` callback in the store, and the root's `setInputValue` invokes it after the `isCanceled` check. Any accepted external write (item-press fill, multiple-mode query clear, close cleanup) now dismisses the composition preview, while a canceled `onInputValueChange` preserves it. A value diff was not enough: re-selecting the item whose label already equals the input value, and the multiple-mode `'' → ''` clear, change nothing.
- Added jsdom regression tests plus a Chromium test that drives a genuine composition through CDP `Input.imeSetComposition`, since the bug only reproduces with a real composition.