### PR TITLE
[docs] Bump docs-infra to canary.41

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -70,7 +70,6 @@ const rootPackage = loadPackageJson();
 
 /** @type {import('@mui/internal-docs-infra/pipeline/loadPrecomputedTypes').LoaderOptions} */
 const typesGenerationOptions = {
-  socketDir: '.next/docs-infra',
   updateParentIndex: {
     baseDir,
     onlyUpdateIndexes: true,

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
     "@base-ui/utils": "workspace:*",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
-    "@mui/internal-docs-infra": "https://pkg.pr.new/@mui/internal-docs-infra@64e31953",
+    "@mui/internal-docs-infra": "https://pkg.pr.new/@mui/internal-docs-infra@6d3da753",
     "@next/mdx": "^16.3.1",
     "@react-spring/web": "^10.1.2",
     "@stefanprobst/rehype-extract-toc": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
     "@base-ui/utils": "workspace:*",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
-    "@mui/internal-docs-infra": "0.12.1-canary.26",
+    "@mui/internal-docs-infra": "https://pkg.pr.new/@mui/internal-docs-infra@64e31953",
     "@next/mdx": "^16.3.1",
     "@react-spring/web": "^10.1.2",
     "@stefanprobst/rehype-extract-toc": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
     "@base-ui/utils": "workspace:*",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
-    "@mui/internal-docs-infra": "https://pkg.pr.new/@mui/internal-docs-infra@6d3da753",
+    "@mui/internal-docs-infra": "0.12.1-canary.41",
     "@next/mdx": "^16.3.1",
     "@react-spring/web": "^10.1.2",
     "@stefanprobst/rehype-extract-toc": "^3.0.0",

--- a/docs/src/app/(docs)/react/components/autocomplete/types.md
+++ b/docs/src/app/(docs)/react/components/autocomplete/types.md
@@ -934,7 +934,7 @@ Matches items against a query using `Intl.Collator` for robust string matching.
 
 | Parameter | Type                        | Default | Description |
 | :-------- | :-------------------------- | :------ | :---------- |
-| options?  | `AutocompleteFilterOptions` | -       | -           |
+| options?  | `AutocompleteFilterOptions` | `{}`    | -           |
 
 **Return Value:**
 

--- a/docs/src/app/(docs)/react/components/combobox/types.md
+++ b/docs/src/app/(docs)/react/components/combobox/types.md
@@ -1059,10 +1059,10 @@ by their data.
 
 **Parameters:**
 
-| Parameter | Type                                                                                                                                                                                                                                                                                                                                                               | Default | Description                                                                 |
-| :-------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------ | :-------------------------------------------------------------------------- |
-| data      | ``Item[] & unknown \| 'Base UI: items passed to createItems() cannot have an `items` array property because it marks a group. Rename the field or cast the data.' \| ({ items: Item[] })[] & unknown \| 'Base UI: items passed to createItems() cannot have an `items` array property because it marks a group. Rename the field or cast the data.' \| undefined`` | -       | The flat or grouped source items, or `undefined` while they are loading.    |
-| options   | `CreateComboboxItemsOptions<Item, ComboboxPrimitiveValue>`                                                                                                                                                                                                                                                                                                         | -       | Functions that derive each source item's selection value and display label. |
+| Parameter | Type                                                                                                                                                                                                                                                                                                                                                                   | Default | Description                                                                 |
+| :-------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------ | :-------------------------------------------------------------------------- |
+| data      | ``Item[] & (unknown \| 'Base UI: items passed to createItems() cannot have an `items` array property because it marks a group. Rename the field or cast the data.') \| ({ items: Item[] })[] & (unknown \| 'Base UI: items passed to createItems() cannot have an `items` array property because it marks a group. Rename the field or cast the data.') \| undefined`` | -       | The flat or grouped source items, or `undefined` while they are loading.    |
+| options   | `CreateComboboxItemsOptions<Item, ComboboxPrimitiveValue>`                                                                                                                                                                                                                                                                                                             | -       | Functions that derive each source item's selection value and display label. |
 
 **Return Value:**
 
@@ -1144,7 +1144,7 @@ Matches items against a query using `Intl.Collator` for robust string matching.
 
 | Parameter | Type                    | Default | Description |
 | :-------- | :---------------------- | :------ | :---------- |
-| options?  | `ComboboxFilterOptions` | -       | -           |
+| options?  | `ComboboxFilterOptions` | `{}`    | -           |
 
 **Return Value:**
 

--- a/docs/src/app/(docs)/react/components/drawer/types.md
+++ b/docs/src/app/(docs)/react/components/drawer/types.md
@@ -343,6 +343,12 @@ Renders a `<div>` element.
 | style     | `React.CSSProperties \| ((state: Drawer.Content.State) => React.CSSProperties \| undefined)` | -       | Style applied to the element, or a function that&#xA;returns a style object based on the component's state.                                                                                   |
 | render    | `ReactElement \| ((props: HTMLProps, state: Drawer.Content.State) => ReactElement)`          | -       | Allows you to replace the component's HTML element&#xA;with a different tag, or compose it with another component. Accepts a `ReactElement` or a function that returns the element to render. |
 
+**Content Data Attributes:**
+
+| Attribute           | Type | Description |
+| :------------------ | :--- | :---------- |
+| data-drawer-content | -    | -           |
+
 ### Content.Props
 
 Re-export of [Content](#content) props.

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -767,6 +767,7 @@ A panel that slides in from the edge of the screen.
     - CSS Variables: --drawer-frontmost-height, --drawer-height, --drawer-snap-point-offset, --drawer-swipe-movement-x, --drawer-swipe-movement-y, --drawer-swipe-strength, --nested-drawers
   - Drawer - Content
     - Props: className, render, style
+    - Data Attributes: data-drawer-content
   - Drawer - Title
     - Props: className, render, style
   - Drawer - Description

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.18)(react@19.2.8)
       '@mui/internal-docs-infra':
-        specifier: https://pkg.pr.new/@mui/internal-docs-infra@64e31953
-        version: https://pkg.pr.new/@mui/internal-docs-infra@64e31953(@types/react@19.2.18)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)
+        specifier: https://pkg.pr.new/@mui/internal-docs-infra@6d3da753
+        version: https://pkg.pr.new/@mui/internal-docs-infra@6d3da753(@types/react@19.2.18)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)
       '@next/mdx':
         specifier: ^16.3.1
         version: 16.3.1(@mdx-js/loader@3.1.1(supports-color@10.2.2)(webpack@5.109.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)(uglify-js@3.19.3)))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))
@@ -2161,8 +2161,8 @@ packages:
       typescript:
         optional: true
 
-  '@mui/internal-docs-infra@https://pkg.pr.new/@mui/internal-docs-infra@64e31953':
-    resolution: {integrity: sha512-nmZl8bIBT1ieBz1ErLQDeBkLSK21k/tpSbYllcABR4nF0W6b/qEVuJpa7AydLJOuSNES8UR8dOAPj/tT6yUlnQ==, tarball: https://pkg.pr.new/@mui/internal-docs-infra@64e31953}
+  '@mui/internal-docs-infra@https://pkg.pr.new/@mui/internal-docs-infra@6d3da753':
+    resolution: {integrity: sha512-E6slM7gfZC6aMDuc9WM2CQbzZ4qfuZZ8w26FL4mgwGRG+yUOTHZEMlAqbcf5A5bAtxVI1Gk4jgTuJjQ7CBOgIg==, tarball: https://pkg.pr.new/@mui/internal-docs-infra@6d3da753}
     version: 0.12.0
     engines: {node: '>=22.18.0'}
     hasBin: true
@@ -11602,7 +11602,7 @@ snapshots:
       - supports-color
       - vitest
 
-  '@mui/internal-docs-infra@https://pkg.pr.new/@mui/internal-docs-infra@64e31953(@types/react@19.2.18)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)':
+  '@mui/internal-docs-infra@https://pkg.pr.new/@mui/internal-docs-infra@6d3da753(@types/react@19.2.18)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@csstools/postcss-light-dark-function': 3.0.3(postcss@8.5.26)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.18)(react@19.2.8)
       '@mui/internal-docs-infra':
-        specifier: https://pkg.pr.new/@mui/internal-docs-infra@6d3da753
-        version: https://pkg.pr.new/@mui/internal-docs-infra@6d3da753(@types/react@19.2.18)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)
+        specifier: 0.12.1-canary.41
+        version: 0.12.1-canary.41(@types/react@19.2.18)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)
       '@next/mdx':
         specifier: ^16.3.1
         version: 16.3.1(@mdx-js/loader@3.1.1(supports-color@10.2.2)(webpack@5.109.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)(uglify-js@3.19.3)))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))
@@ -2150,9 +2150,8 @@ packages:
       typescript:
         optional: true
 
-  '@mui/internal-docs-infra@https://pkg.pr.new/@mui/internal-docs-infra@6d3da753':
-    resolution: {integrity: sha512-E6slM7gfZC6aMDuc9WM2CQbzZ4qfuZZ8w26FL4mgwGRG+yUOTHZEMlAqbcf5A5bAtxVI1Gk4jgTuJjQ7CBOgIg==, tarball: https://pkg.pr.new/@mui/internal-docs-infra@6d3da753}
-    version: 0.12.0
+  '@mui/internal-docs-infra@0.12.1-canary.41':
+    resolution: {integrity: sha512-fSX56iRjhQTeNlZ/MXmUuMWw0hQCyiahfc38/x/md21GE7iki6T/qXmUR+xjbix1nKtNxCmCTPRMz6fCdTRnAQ==}
     engines: {node: '>=22.18.0'}
     hasBin: true
     peerDependencies:
@@ -2161,7 +2160,6 @@ packages:
       prettier: ^3.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-      typescript: ^6.0.2
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4111,6 +4109,10 @@ packages:
   '@typescript/native-preview@7.0.0-dev.20260707.2':
     resolution: {integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==}
     engines: {node: '>=16.20.0'}
+    hasBin: true
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
     hasBin: true
 
   '@ungap/structured-clone@1.3.0':
@@ -11582,7 +11584,7 @@ snapshots:
       - supports-color
       - vitest
 
-  '@mui/internal-docs-infra@https://pkg.pr.new/@mui/internal-docs-infra@6d3da753(@types/react@19.2.18)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)':
+  '@mui/internal-docs-infra@0.12.1-canary.41(@types/react@19.2.18)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@csstools/postcss-light-dark-function': 3.0.3(postcss@8.5.26)
@@ -11621,7 +11623,7 @@ snapshots:
       remark-stringify: 11.0.0
       remark-typography: 0.8.2
       sucrase: 3.35.1
-      typescript: 6.0.3
+      typescript: '@typescript/typescript6@6.0.2'
       typescript-api-extractor: 1.0.0-beta.6
       uint8-to-base64: 0.2.1
       unified: 11.0.5
@@ -13662,6 +13664,10 @@ snapshots:
       '@typescript/native-preview-linux-x64': 7.0.0-dev.20260707.2
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@ungap/structured-clone@1.3.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1272,23 +1272,12 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/color-helpers@6.1.0':
-    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
-    engines: {node: '>=20.19.0'}
-
   '@csstools/color-helpers@6.1.1':
     resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
     engines: {node: '>=20.19.0'}
 
   '@csstools/css-calc@3.3.0':
     resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
-    engines: {node: '>=20.19.0'}
-    peerDependencies:
-      '@csstools/css-parser-algorithms': ^4.0.0
-      '@csstools/css-tokenizer': ^4.0.0
-
-  '@csstools/css-color-parser@4.1.10':
-    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -9831,7 +9820,7 @@ snapshots:
   '@asamuzakjp/css-color@4.1.2':
     dependencies:
       '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
       lru-cache: 11.3.0
@@ -10693,19 +10682,10 @@ snapshots:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/color-helpers@6.1.0': {}
-
   '@csstools/color-helpers@6.1.1': {}
 
   '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-tokenizer': 4.0.0
-
-  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
-    dependencies:
-      '@csstools/color-helpers': 6.1.0
-      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.18)(react@19.2.8)
       '@mui/internal-docs-infra':
-        specifier: 0.12.1-canary.26
-        version: 0.12.1-canary.26(@types/react@19.2.18)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)
+        specifier: https://pkg.pr.new/@mui/internal-docs-infra@64e31953
+        version: https://pkg.pr.new/@mui/internal-docs-infra@64e31953(@types/react@19.2.18)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)
       '@next/mdx':
         specifier: ^16.3.1
         version: 16.3.1(@mdx-js/loader@3.1.1(supports-color@10.2.2)(webpack@5.109.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)(uglify-js@3.19.3)))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))
@@ -1276,6 +1276,10 @@ packages:
     resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
     engines: {node: '>=20.19.0'}
 
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
   '@csstools/css-calc@3.3.0':
     resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
     engines: {node: '>=20.19.0'}
@@ -1285,6 +1289,13 @@ packages:
 
   '@csstools/css-color-parser@4.1.10':
     resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.0':
+    resolution: {integrity: sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -1315,20 +1326,20 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/postcss-light-dark-function@3.0.2':
-    resolution: {integrity: sha512-Fu6si5QhRrT5lP7nmXxfowR8zNkYrqoolsWOZxPZBZpVTdoEKazN6v+K53vPcy1EM4Mlj6tSaEjMu4gAwC8yqw==}
+  '@csstools/postcss-light-dark-function@3.0.3':
+    resolution: {integrity: sha512-5P5Y3q0cRNSYh662IJCuzNY/25WKzMGPMpL5f7PQcoNEH6OD9J1lAAK0DakLiopwnJ3dD1Qe2vkC8Yl2GUrZOQ==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       postcss: ^8.5.26
 
-  '@csstools/postcss-progressive-custom-properties@5.1.1':
-    resolution: {integrity: sha512-b9+lusgVDTHXRBgYKE9s0RKUyEn6Q/knmMDmYmSrkZjtpb0Nd71pBtgVMf9tSpOIb0K8hyzeyy6JyKFqg5rBJw==}
+  '@csstools/postcss-progressive-custom-properties@5.1.2':
+    resolution: {integrity: sha512-aGHhh/haanBUxYTqr+mXC52iCNuG/p68CSqz3aoQyqSAgwyxNQGofFYwWo7sd8iQUS8BDoQ/khkPb4ymGyt3aw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       postcss: ^8.5.26
 
-  '@csstools/postcss-relative-color-syntax@4.0.7':
-    resolution: {integrity: sha512-YzfSjBQxLkIBfLTZJVjMRGy57Od7vWdZ1yleCBQR4S+lg0lVaONbDukkF6x8Amiv7m5HUv97ZIxl3wh3kFcHGg==}
+  '@csstools/postcss-relative-color-syntax@4.0.8':
+    resolution: {integrity: sha512-PUk4ZqNMTVcKRlAD1XXVVzUPJjUtZQKvxPM1O2Z5UC7OCdzqM+FfKDx8rhuOk9lwGvOtFpia8S9rC6p7oGIpfw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       postcss: ^8.5.26
@@ -2150,8 +2161,9 @@ packages:
       typescript:
         optional: true
 
-  '@mui/internal-docs-infra@0.12.1-canary.26':
-    resolution: {integrity: sha512-7olHhvR5tDbyRx+y3yVG0lmAApFk7h+JdkmyZDph3x+Bf6YwwbSE1ZTtkU64PLCgBKoP7AukbxP8YkDiz/rHOg==}
+  '@mui/internal-docs-infra@https://pkg.pr.new/@mui/internal-docs-infra@64e31953':
+    resolution: {integrity: sha512-nmZl8bIBT1ieBz1ErLQDeBkLSK21k/tpSbYllcABR4nF0W6b/qEVuJpa7AydLJOuSNES8UR8dOAPj/tT6yUlnQ==, tarball: https://pkg.pr.new/@mui/internal-docs-infra@64e31953}
+    version: 0.12.0
     engines: {node: '>=22.18.0'}
     hasBin: true
     peerDependencies:
@@ -4366,6 +4378,7 @@ packages:
   '@xmldom/xmldom@0.9.11':
     resolution: {integrity: sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -4560,6 +4573,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  arrayiffy-if-string@5.2.1:
+    resolution: {integrity: sha512-Sy/PXEYEMa8m/BsCUOrJu7+2elSV9pvyIM9dkGBPbrJg8SuETuMFhTzc/hgiKsO64SgfXELs0AciDwqKxU0ifg==}
+    engines: {node: '>=18.20.8'}
 
   arrify@1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
@@ -4824,6 +4841,10 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chalk@6.0.0:
+    resolution: {integrity: sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==}
+    engines: {node: '>=22'}
+
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
@@ -4940,6 +4961,10 @@ packages:
   cmd-shim@7.0.0:
     resolution: {integrity: sha512-rtpaCbr164TPPh+zFdkWpCyZuKkjpAzODfaZCf/SVJZzJN+4bHQb/LP3Jzq5/+84um3XXY8r548XiWKSborwVw==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  codsen-utils@1.9.0:
+    resolution: {integrity: sha512-TqGe8+q7S6tqBg3Pl4iaj8O12N1TwbzLvrVD1Jm/S+Uh83psw7hLkPXKL5EUlR6XRjX/FotC16ZVnl5ZfNvX3w==}
+    engines: {node: '>=18.20.8'}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -5443,6 +5468,9 @@ packages:
 
   es-toolkit@1.50.0:
     resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
+
+  es-toolkit@1.51.0:
+    resolution: {integrity: sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -8171,6 +8199,22 @@ packages:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
     engines: {node: '>= 0.6'}
 
+  ranges-apply@7.2.2:
+    resolution: {integrity: sha512-cdaEXm/ZqU2d6z/EKUkIgg+z2iK7y2PdERE3+48OcP/rZ3Byx5HbEgfIqkPY3qbT3fPhgiN0gBSAB/eaWKMNiw==}
+    engines: {node: '>=18.20.8'}
+
+  ranges-merge@9.2.2:
+    resolution: {integrity: sha512-usBK6ybMlLiJlxiQDMY6cqxyTAD/BncgfYMcL8Fdcn7l2+BAM6F8bOY+KNREvk6+Z3VkZk5ge6GJyjHz1yxwoA==}
+    engines: {node: '>=18.20.8'}
+
+  ranges-push@7.2.1:
+    resolution: {integrity: sha512-Jd8xsZFe8ghxBVm/jhXVyWOIqkrX/dO0DCaLpDjXzMFIaMo2z/4k8930BarxlGmwQlMZ7BjvaDE0kxss5GuOKQ==}
+    engines: {node: '>=18.20.8'}
+
+  ranges-sort@6.2.1:
+    resolution: {integrity: sha512-4/4b6nvWUnrvqTp4iRgnnWr26+apIGRHRsCyce67r1NV/NrgxQE5Ghnbnj9OKvXcIh8zPoZ5OYFeqC4ok2zB9A==}
+    engines: {node: '>=18.20.8'}
+
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -8414,6 +8458,10 @@ packages:
   remark-typography@0.7.3:
     resolution: {integrity: sha512-4PwzZTgKQclWZGWAjaB65H1neHKIUmAOuR1noLfPvD8DcrXKVCs/vDt9yhFJHYTrDXhWqYUBUmbrz0V77Do2kg==}
     engines: {node: '>=14.18.0'}
+
+  remark-typography@0.8.2:
+    resolution: {integrity: sha512-carMjpFO6z+sDJwEAhe4w8LJIQUoaiDCN89DCHnylkG97Nfo2pGJdAEE2ypwGBlX7PqAFzHxc6aOx7K9dglmaA==}
+    engines: {node: '>=18.20.8'}
 
   remove-accents@0.5.0:
     resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
@@ -8754,9 +8802,33 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  string-apostrophes@4.2.2:
+    resolution: {integrity: sha512-r5iUlTwieeGIpMlXiC2AdLFFKfX/8jj2DiOSy5KnAGzipk0IalrZFSjaboCZyqJ7Lm5isRqL25qi6atHxaK1fw==}
+    engines: {node: '>=18.20.8'}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
+
+  string-collapse-leading-whitespace@7.2.0:
+    resolution: {integrity: sha512-c6r2y/R1auNBF2Ce2H6n/5LBaYlZYWGLB09E2D7tgUQI7ORIUi9IjoxTtVOwMTPzhu4dd0aFTxiR9VKTPfeFWQ==}
+    engines: {node: '>=18.20.8'}
+
+  string-dashes@1.4.2:
+    resolution: {integrity: sha512-P/lio0hEqzWHAj6UOeqB+BNw9GJA8UomPvB3BpOdzcAIUSKMUYkUyVc4zdTgeW3x4QfD4Cpw/80QfNBIsEy60g==}
+    engines: {node: '>=18.20.8'}
+
+  string-left-right@6.2.1:
+    resolution: {integrity: sha512-GF7njCVMRj/qFfELOSO0zltyEbSYQ5/a+nIZQzWka+/PaLS8vaKzpBCSScv37DZMqfNp7WCW7cySKyknIpwLgA==}
+    engines: {node: '>=18.20.8'}
+
+  string-match-left-right@9.2.2:
+    resolution: {integrity: sha512-S3pS00EgBRtmktD+nsd3h2zZTn+1Ub0cz5107iTGOI3csFWRXTZ0xA3nwPYOumFt/DxGJEhL7whJ9g7rcZIQvQ==}
+    engines: {node: '>=18.20.8'}
+
+  string-remove-widows@4.2.2:
+    resolution: {integrity: sha512-siVW2O/dTYioUatS+pTyFfGctaBOk4X9adjUBsm0TAswf+/ELlXkRt9u0dwy9l1mi6zugFyY96aJpxbcoos9lg==}
+    engines: {node: '>=18.20.8'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -9122,11 +9194,9 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript-api-extractor@1.0.0-beta.4:
-    resolution: {integrity: sha512-tVSlm5uZ3/cIWe1Rjg0ehVa7VdbwFECHm6HHc9d+dyWmcDiuHGQXOKRYADFatc9tqgIPodZ4tvJJbCyYG807JQ==}
+  typescript-api-extractor@1.0.0-beta.6:
+    resolution: {integrity: sha512-l+JzdLi1e56mc4ARk8CdHdEsjzmqBNsyX67d+KwU2BprhXutdjNnhmaEeY0SSWh/RfuvSxNajLncILCL8vDozQ==}
     engines: {node: '>=22'}
-    peerDependencies:
-      typescript: ^5.8 || ^6.0
 
   typescript-eslint@8.67.0:
     resolution: {integrity: sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==}
@@ -10625,6 +10695,8 @@ snapshots:
 
   '@csstools/color-helpers@6.1.0': {}
 
+  '@csstools/color-helpers@6.1.1': {}
+
   '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
@@ -10633,6 +10705,13 @@ snapshots:
   '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
       '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
@@ -10652,25 +10731,25 @@ snapshots:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/postcss-light-dark-function@3.0.2(postcss@8.5.26)':
+  '@csstools/postcss-light-dark-function@3.0.3(postcss@8.5.26)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.1.1(postcss@8.5.26)
+      '@csstools/postcss-progressive-custom-properties': 5.1.2(postcss@8.5.26)
       '@csstools/utilities': 3.0.0(postcss@8.5.26)
       postcss: 8.5.26
 
-  '@csstools/postcss-progressive-custom-properties@5.1.1(postcss@8.5.26)':
+  '@csstools/postcss-progressive-custom-properties@5.1.2(postcss@8.5.26)':
     dependencies:
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-relative-color-syntax@4.0.7(postcss@8.5.26)':
+  '@csstools/postcss-relative-color-syntax@4.0.8(postcss@8.5.26)':
     dependencies:
-      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
-      '@csstools/postcss-progressive-custom-properties': 5.1.1(postcss@8.5.26)
+      '@csstools/postcss-progressive-custom-properties': 5.1.2(postcss@8.5.26)
       '@csstools/utilities': 3.0.0(postcss@8.5.26)
       postcss: 8.5.26
 
@@ -11523,11 +11602,11 @@ snapshots:
       - supports-color
       - vitest
 
-  '@mui/internal-docs-infra@0.12.1-canary.26(@types/react@19.2.18)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)':
+  '@mui/internal-docs-infra@https://pkg.pr.new/@mui/internal-docs-infra@64e31953(@types/react@19.2.18)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.1)(@types/node@22.20.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(prettier@3.9.6)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@babel/runtime': 7.29.7
-      '@csstools/postcss-light-dark-function': 3.0.2(postcss@8.5.26)
-      '@csstools/postcss-relative-color-syntax': 4.0.7(postcss@8.5.26)
+      '@csstools/postcss-light-dark-function': 3.0.3(postcss@8.5.26)
+      '@csstools/postcss-relative-color-syntax': 4.0.8(postcss@8.5.26)
       '@csstools/postcss-stepped-value-functions': 5.0.4(postcss@8.5.26)
       '@orama/orama': 3.1.18
       '@orama/plugin-qps': 3.1.18
@@ -11535,9 +11614,9 @@ snapshots:
       '@orama/stopwords': 3.1.18
       '@wooorm/starry-night': 3.10.0
       autoprefixer: 10.5.4(postcss@8.5.26)
-      chalk: 5.6.2
+      chalk: 6.0.0
       clipboard-copy: 4.0.1
-      es-toolkit: 1.50.0
+      es-toolkit: 1.51.0
       fflate: 0.8.3
       hast-util-to-jsx-runtime: 2.3.6(supports-color@10.2.2)
       hast-util-to-text: 4.0.2
@@ -11560,10 +11639,10 @@ snapshots:
       remark-mdx: 3.1.1(supports-color@10.2.2)
       remark-parse: 11.0.0(supports-color@10.2.2)
       remark-stringify: 11.0.0
-      remark-typography: 0.7.3
+      remark-typography: 0.8.2
       sucrase: 3.35.1
       typescript: 6.0.3
-      typescript-api-extractor: 1.0.0-beta.4(typescript@6.0.3)
+      typescript-api-extractor: 1.0.0-beta.6
       uint8-to-base64: 0.2.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
@@ -14098,6 +14177,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  arrayiffy-if-string@5.2.1: {}
+
   arrify@1.0.1: {}
 
   assertion-error@2.0.1: {}
@@ -14380,6 +14461,8 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  chalk@6.0.0: {}
+
   char-regex@1.0.2: {}
 
   character-entities-html4@2.1.0: {}
@@ -14490,6 +14573,8 @@ snapshots:
   cmd-shim@6.0.3: {}
 
   cmd-shim@7.0.0: {}
+
+  codsen-utils@1.9.0: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -15059,6 +15144,8 @@ snapshots:
       is-symbol: 1.1.1
 
   es-toolkit@1.50.0: {}
+
+  es-toolkit@1.51.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -18706,6 +18793,26 @@ snapshots:
 
   range-parser@1.2.0: {}
 
+  ranges-apply@7.2.2:
+    dependencies:
+      codsen-utils: 1.9.0
+      ranges-merge: 9.2.2
+
+  ranges-merge@9.2.2:
+    dependencies:
+      codsen-utils: 1.9.0
+      ranges-sort: 6.2.1
+
+  ranges-push@7.2.1:
+    dependencies:
+      codsen-utils: 1.9.0
+      ranges-sort: 6.2.1
+      string-collapse-leading-whitespace: 7.2.0
+
+  ranges-sort@6.2.1:
+    dependencies:
+      codsen-utils: 1.9.0
+
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -19147,6 +19254,16 @@ snapshots:
 
   remark-typography@0.7.3: {}
 
+  remark-typography@0.8.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      codsen-utils: 1.9.0
+      string-apostrophes: 4.2.2
+      string-dashes: 1.4.2
+      string-remove-widows: 4.2.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+
   remove-accents@0.5.0: {}
 
   require-directory@2.1.1: {}
@@ -19552,7 +19669,37 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  string-apostrophes@4.2.2:
+    dependencies:
+      codsen-utils: 1.9.0
+      ranges-apply: 7.2.2
+
   string-argv@0.3.2: {}
+
+  string-collapse-leading-whitespace@7.2.0: {}
+
+  string-dashes@1.4.2:
+    dependencies:
+      codsen-utils: 1.9.0
+      ranges-apply: 7.2.2
+      string-left-right: 6.2.1
+
+  string-left-right@6.2.1:
+    dependencies:
+      codsen-utils: 1.9.0
+
+  string-match-left-right@9.2.2:
+    dependencies:
+      arrayiffy-if-string: 5.2.1
+      codsen-utils: 1.9.0
+
+  string-remove-widows@4.2.2:
+    dependencies:
+      codsen-utils: 1.9.0
+      ranges-apply: 7.2.2
+      ranges-push: 7.2.1
+      string-left-right: 6.2.1
+      string-match-left-right: 9.2.2
 
   string-width@4.2.3:
     dependencies:
@@ -19978,7 +20125,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-api-extractor@1.0.0-beta.4(typescript@6.0.3):
+  typescript-api-extractor@1.0.0-beta.6:
     dependencies:
       es-toolkit: 1.50.0
       typescript: 6.0.3


### PR DESCRIPTION
Bumps docs-infra to `0.12.1-canary.41`, which includes mui/mui-public#1817 — fixes `keyof` props documenting as `unknown`.

The reference changes are the point of the PR — `combobox` also picks up a grouping fix on `data`, where `Item[] & RejectGroupShapedItems<Item>` was rendering without parentheses around the union.