### PR TITLE
[select] Split the store into state and context

### DIFF
--- a/docs/src/error-codes.json
+++ b/docs/src/error-codes.json
@@ -97,5 +97,6 @@
   "97": "Base UI: SharedCalendarRootContext is missing. Calendar parts must be placed within <Calendar.Root /> and Range Calendar parts must be placed within <RangeCalendar.Root />.",
   "98": "Base UI: OTPFieldRootContext is missing. OTPField parts must be placed within <OTPField.Root>.",
   "99": "Base UI: %sHandle.open() was called with the trigger id \"%s\", but no matching trigger is registered with this handle. An anchored popup cannot open without a trigger to anchor to. Pass the id of a mounted %s.Trigger that has this handle set on its \"handle\" prop.",
-  "100": "Base UI: the `items` prop received an object that is not a collection, so its items cannot be read. Pass an array of items, an array of groups with items, or the result of `createItems()`. See https://base-ui.com/react/components/combobox#createitems"
+  "100": "Base UI: the `items` prop received an object that is not a collection, so its items cannot be read. Pass an array of items, an array of groups with items, or the result of `createItems()`. See https://base-ui.com/react/components/combobox#createitems",
+  "101": "Base UI: SelectRootPropsContext is missing. Select parts must be placed within <Select.Root>."
 }

--- a/packages/react/src/select/arrow/SelectArrow.tsx
+++ b/packages/react/src/select/arrow/SelectArrow.tsx
@@ -1,13 +1,11 @@
 'use client';
 import * as React from 'react';
-import { useStore } from '@base-ui/utils/store';
 import { useSelectPositionerContext } from '../positioner/SelectPositionerContext';
 import { useSelectRootContext } from '../root/SelectRootContext';
 import type { BaseUIComponentProps } from '../../internals/types';
 import type { Align, Side } from '../../internals/useAnchorPositioning';
 import { popupTransitionStateMapping } from '../../utils/popupStateMapping';
 import { useRenderElement } from '../../internals/useRenderElement';
-import { selectors } from '../store';
 
 /**
  * Displays an element positioned against the select popup anchor.
@@ -21,11 +19,11 @@ export const SelectArrow = React.forwardRef(function SelectArrow(
 ) {
   const { render, className, style, ...elementProps } = componentProps;
 
-  const { store } = useSelectRootContext();
+  const store = useSelectRootContext();
   const { side, align, arrowRef, arrowStyles, arrowUncentered, alignItemWithTriggerActive } =
     useSelectPositionerContext();
 
-  const open = useStore(store, selectors.open);
+  const open = store.useState('open');
 
   const state: SelectArrowState = {
     open,

--- a/packages/react/src/select/backdrop/SelectBackdrop.tsx
+++ b/packages/react/src/select/backdrop/SelectBackdrop.tsx
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import { useStore } from '@base-ui/utils/store';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useSelectRootContext } from '../root/SelectRootContext';
 import { popupStateMapping } from '../../utils/popupStateMapping';
@@ -8,7 +7,6 @@ import type { StateAttributesMapping } from '../../internals/getStateAttributesP
 import type { TransitionStatus } from '../../internals/useTransitionStatus';
 import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
 import { useRenderElement } from '../../internals/useRenderElement';
-import { selectors } from '../store';
 
 const stateAttributesMapping: StateAttributesMapping<SelectBackdropState> = {
   ...popupStateMapping,
@@ -27,11 +25,11 @@ export const SelectBackdrop = React.forwardRef(function SelectBackdrop(
 ) {
   const { render, className, style, ...elementProps } = componentProps;
 
-  const { store } = useSelectRootContext();
+  const store = useSelectRootContext();
 
-  const open = useStore(store, selectors.open);
-  const mounted = useStore(store, selectors.mounted);
-  const transitionStatus = useStore(store, selectors.transitionStatus);
+  const open = store.useState('open');
+  const mounted = store.useState('mounted');
+  const transitionStatus = store.useState('transitionStatus');
 
   const state: SelectBackdropState = {
     open,

--- a/packages/react/src/select/icon/SelectIcon.tsx
+++ b/packages/react/src/select/icon/SelectIcon.tsx
@@ -1,11 +1,9 @@
 'use client';
 import * as React from 'react';
-import { useStore } from '@base-ui/utils/store';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useSelectRootContext } from '../root/SelectRootContext';
 import { triggerOpenStateMapping } from '../../utils/popupStateMapping';
-import { selectors } from '../store';
 
 /**
  * An icon that indicates that the trigger button opens a select popup.
@@ -19,8 +17,8 @@ export const SelectIcon = React.forwardRef(function SelectIcon(
 ) {
   const { render, className, style, ...elementProps } = componentProps;
 
-  const { store } = useSelectRootContext();
-  const open = useStore(store, selectors.open);
+  const store = useSelectRootContext();
+  const open = store.useState('open');
 
   const state: SelectIconState = {
     open,

--- a/packages/react/src/select/item-text/SelectItemText.tsx
+++ b/packages/react/src/select/item-text/SelectItemText.tsx
@@ -17,7 +17,7 @@ export const SelectItemText = React.memo(
     forwardedRef: React.ForwardedRef<HTMLDivElement>,
   ) {
     const { index, textRef, selectedByFocus } = useSelectItemContext();
-    const { firstItemTextRef, selectedItemTextRef } = useSelectRootContext();
+    const store = useSelectRootContext();
 
     const { render, className, style, ...elementProps } = componentProps;
 
@@ -28,13 +28,13 @@ export const SelectItemText = React.memo(
         }
 
         if (index === 0) {
-          firstItemTextRef.current = node;
+          store.context.firstItemTextRef.current = node;
         }
         if (selectedByFocus) {
-          selectedItemTextRef.current = node;
+          store.context.selectedItemTextRef.current = node;
         }
       },
-      [firstItemTextRef, selectedItemTextRef, index, selectedByFocus],
+      [store, index, selectedByFocus],
     );
 
     const element = useRenderElement('div', componentProps, {

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -1,8 +1,7 @@
 'use client';
 import * as React from 'react';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { useStore } from '@base-ui/utils/store';
-import { useSelectRootContext } from '../root/SelectRootContext';
+import { useSelectRootContext, useSelectRootPropsContext } from '../root/SelectRootContext';
 import { useCompositeListItem } from '../../internals/composite/list/useCompositeListItem';
 import type {
   BaseUIComponentProps,
@@ -12,7 +11,6 @@ import type {
 } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { SelectItemContext } from './SelectItemContext';
-import { selectors } from '../store';
 import { useButton } from '../../internals/use-button';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
@@ -48,39 +46,27 @@ export const SelectItem = React.memo(
       textRef,
     });
 
-    const {
-      store,
-      itemProps,
-      setOpen,
-      setValue,
-      selectionRef,
-      typingRef,
-      valuesRef,
-      multiple,
-      selectedItemTextRef,
-      disabled: selectDisabled,
-      readOnly,
-    } = useSelectRootContext();
-
+    const store = useSelectRootContext();
+    const { itemProps, multiple, disabled: selectDisabled, readOnly } = useSelectRootPropsContext();
     const disabled = selectDisabled || disabledProp;
-    const highlighted = useStore(store, selectors.isActive, listItem.index);
-    const open = useStore(store, selectors.open);
-    const selected = useStore(store, selectors.isSelected, itemValue);
-    const selectedByFocus = useStore(store, selectors.isSelectedByFocus, listItem.index);
-    const isItemEqualToValue = useStore(store, selectors.isItemEqualToValue);
+    const highlighted = store.useState('isActive', listItem.index);
+    const open = store.useState('open');
+    const selected = store.useState('isSelected', itemValue);
+    const selectedByFocus = store.useState('isSelectedByFocus', listItem.index);
+    const isItemEqualToValue = store.useState('isItemEqualToValue');
 
     const index = listItem.index;
 
     const itemRef = React.useRef<HTMLDivElement | null>(null);
 
     useIsoLayoutEffect(() => {
-      const values = valuesRef.current;
+      const values = store.context.valuesRef.current;
       values[index] = itemValue;
 
       return () => {
         delete values[index];
       };
-    }, [index, itemValue, valuesRef]);
+    }, [index, itemValue, store]);
 
     useIsoLayoutEffect(() => {
       const selectedValue = store.state.value;
@@ -101,10 +87,10 @@ export const SelectItem = React.memo(
         // Make sure SelectPopup can measure the selected item on first open.
         // SelectItemText can still update this ref later when focus moves.
         if (textRef.current) {
-          selectedItemTextRef.current = textRef.current;
+          store.context.selectedItemTextRef.current = textRef.current;
         }
       }
-    }, [index, multiple, isItemEqualToValue, store, itemValue, selectedItemTextRef]);
+    }, [index, multiple, isItemEqualToValue, store, itemValue]);
 
     const pointerTypeRef = React.useRef<'mouse' | 'touch' | 'pen'>('mouse');
     const allowMouseSelectionRef = React.useRef(false);
@@ -135,15 +121,15 @@ export const SelectItem = React.memo(
         const nextValue = selected
           ? removeItem(currentValue, itemValue, isItemEqualToValue)
           : [...currentValue, itemValue];
-        setValue(nextValue, createChangeEventDetails(REASONS.itemPress, event));
+        store.context.setValue(nextValue, createChangeEventDetails(REASONS.itemPress, event));
       } else {
-        setValue(itemValue, createChangeEventDetails(REASONS.itemPress, event));
-        setOpen(false, createChangeEventDetails(REASONS.itemPress, event));
+        store.context.setValue(itemValue, createChangeEventDetails(REASONS.itemPress, event));
+        store.context.setOpen(false, createChangeEventDetails(REASONS.itemPress, event));
       }
     }
 
     function resetDragMovement() {
-      selectionRef.current.dragY = 0;
+      store.context.selectionRef.current.dragY = 0;
     }
 
     const defaultProps: HTMLProps = {
@@ -153,7 +139,7 @@ export const SelectItem = React.memo(
       onKeyDown(event: BaseUIEvent<React.KeyboardEvent>) {
         store.set('activeIndex', index);
 
-        if (event.key === ' ' && typingRef.current) {
+        if (event.key === ' ' && store.context.typingRef.current) {
           // `useButton` skips Space activation for `role="option"` items when the keydown
           // is `defaultPrevented`, keeping typeahead spaces from committing a selection.
           event.preventDefault();
@@ -188,7 +174,7 @@ export const SelectItem = React.memo(
       },
       onPointerMove(event) {
         if (event.pointerType === 'mouse' && event.buttons === 1) {
-          const selection = selectionRef.current;
+          const selection = store.context.selectionRef.current;
           selection.dragY += event.movementY;
 
           if (selection.dragY ** 2 >= 64) {
@@ -213,8 +199,10 @@ export const SelectItem = React.memo(
           return;
         }
 
-        const disallowSelectedMouseUp = !selectionRef.current.allowSelectedMouseUp && selected;
-        const disallowUnselectedMouseUp = !selectionRef.current.allowUnselectedMouseUp && !selected;
+        const disallowSelectedMouseUp =
+          !store.context.selectionRef.current.allowSelectedMouseUp && selected;
+        const disallowUnselectedMouseUp =
+          !store.context.selectionRef.current.allowUnselectedMouseUp && !selected;
 
         if (disallowSelectedMouseUp || disallowUnselectedMouseUp) {
           return;

--- a/packages/react/src/select/label/SelectLabel.tsx
+++ b/packages/react/src/select/label/SelectLabel.tsx
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import { useStore } from '@base-ui/utils/store';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
 import type { FieldRoot } from '../../field/root/FieldRoot';
@@ -9,7 +8,6 @@ import { fieldValidityMapping } from '../../internals/field-constants/constants'
 import { useLabel } from '../../internals/labelable-provider/useLabel';
 import { getDefaultLabelId } from '../../utils/resolveAriaLabelledBy';
 import { useSelectRootContext } from '../root/SelectRootContext';
-import { selectors } from '../store';
 
 /**
  * An accessible label that is automatically associated with the select trigger.
@@ -27,10 +25,10 @@ export const SelectLabel = React.forwardRef(function SelectLabel(
   delete elementPropsWithoutId.id;
 
   const fieldRootContext = useFieldRootContext();
-  const { store } = useSelectRootContext();
+  const store = useSelectRootContext();
 
-  const triggerElement = useStore(store, selectors.triggerElement);
-  const rootId = useStore(store, selectors.id);
+  const triggerElement = store.useState('triggerElement');
+  const rootId = store.useState('id');
   const defaultLabelId = getDefaultLabelId(rootId);
 
   const labelProps = useLabel({

--- a/packages/react/src/select/list/SelectList.tsx
+++ b/packages/react/src/select/list/SelectList.tsx
@@ -1,13 +1,11 @@
 'use client';
 import * as React from 'react';
-import { useStore } from '@base-ui/utils/store';
 import type { BaseUIComponentProps, HTMLProps } from '../../internals/types';
-import { useSelectRootContext } from '../root/SelectRootContext';
+import { useSelectRootContext, useSelectRootPropsContext } from '../root/SelectRootContext';
 import { useSelectPositionerContext } from '../positioner/SelectPositionerContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { styleDisableScrollbar } from '../../utils/styles';
 import { LIST_FUNCTIONAL_STYLES } from '../popup/utils';
-import { selectors } from '../store';
 
 /**
  * A container for the select items.
@@ -21,12 +19,13 @@ export const SelectList = React.forwardRef(function SelectList(
 ) {
   const { render, className, style, ...elementProps } = componentProps;
 
-  const { store, scrollHandlerRef, multiple, readOnly } = useSelectRootContext();
+  const store = useSelectRootContext();
+  const { multiple, readOnly } = useSelectRootPropsContext();
   const { alignItemWithTriggerActive } = useSelectPositionerContext();
 
-  const hasScrollArrows = useStore(store, selectors.hasScrollArrows);
-  const openMethod = useStore(store, selectors.openMethod);
-  const id = useStore(store, selectors.id);
+  const hasScrollArrows = store.useState('hasScrollArrows');
+  const openMethod = store.useState('openMethod');
+  const id = store.useState('id');
 
   const defaultProps: HTMLProps = {
     id: `${id}-list`,
@@ -34,7 +33,7 @@ export const SelectList = React.forwardRef(function SelectList(
     'aria-multiselectable': multiple || undefined,
     'aria-readonly': readOnly || undefined,
     onScroll(event) {
-      scrollHandlerRef.current?.(event.currentTarget);
+      store.context.scrollHandlerRef.current?.(event.currentTarget);
     },
     ...(alignItemWithTriggerActive && {
       style: LIST_FUNCTIONAL_STYLES,

--- a/packages/react/src/select/popup/SelectPopup.tsx
+++ b/packages/react/src/select/popup/SelectPopup.tsx
@@ -6,14 +6,17 @@ import { platform } from '@base-ui/utils/platform';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { ownerDocument, ownerWindow } from '@base-ui/utils/owner';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { useStore } from '@base-ui/utils/store';
 import { useAnimationFrame } from '@base-ui/utils/useAnimationFrame';
 import type { InteractionType } from '@base-ui/utils/useEnhancedClickHandler';
 import { clamp } from '@base-ui/utils/clamp';
 import { FloatingFocusManager, platform as floatingPlatform } from '../../floating-ui-react';
 import type { ClientRectObject } from '../../floating-ui-react';
 import type { BaseUIComponentProps, HTMLProps } from '../../internals/types';
-import { useSelectRootContext } from '../root/SelectRootContext';
+import {
+  useSelectFloatingContext,
+  useSelectRootContext,
+  useSelectRootPropsContext,
+} from '../root/SelectRootContext';
 import { popupStateMapping } from '../../utils/popupStateMapping';
 import type { Side, Align } from '../../internals/useAnchorPositioning';
 import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
@@ -23,7 +26,6 @@ import { styleDisableScrollbar } from '../../utils/styles';
 import { transitionStatusMapping } from '../../internals/stateAttributesMapping';
 import { useOpenChangeComplete } from '../../internals/useOpenChangeComplete';
 import { useRenderElement } from '../../internals/useRenderElement';
-import { selectors } from '../store';
 import { clearStyles, LIST_FUNCTIONAL_STYLES } from './utils';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
@@ -51,22 +53,9 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
 ) {
   const { render, className, style, finalFocus, ...elementProps } = componentProps;
 
-  const {
-    store,
-    popupRef,
-    onOpenChangeComplete,
-    setOpen,
-    valueRef,
-    firstItemTextRef,
-    selectedItemTextRef,
-    multiple,
-    readOnly,
-    handleScrollArrowVisibility,
-    scrollHandlerRef,
-    listRef,
-    highlightItemOnHover,
-    floatingContext: floatingRootContext,
-  } = useSelectRootContext();
+  const store = useSelectRootContext();
+  const { multiple, readOnly, highlightItemOnHover } = useSelectRootPropsContext();
+  const floatingRootContext = useSelectFloatingContext();
   const {
     side,
     align,
@@ -79,16 +68,15 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
 
   const { nonce, disableStyleElements } = useCSPContext();
 
-  const id = useStore(store, selectors.id);
-  const open = useStore(store, selectors.open);
-  const openMethod = useStore(store, selectors.openMethod);
-  const mounted = useStore(store, selectors.mounted);
-  const popupProps = useStore(store, selectors.popupProps);
-  const transitionStatus = useStore(store, selectors.transitionStatus);
-  const triggerElement = useStore(store, selectors.triggerElement);
-  const positionerElement = useStore(store, selectors.positionerElement);
-  const listElement = useStore(store, selectors.listElement);
-
+  const id = store.useState('id');
+  const open = store.useState('open');
+  const openMethod = store.useState('openMethod');
+  const mounted = store.useState('mounted');
+  const popupProps = store.useState('popupProps');
+  const transitionStatus = store.useState('transitionStatus');
+  const triggerElement = store.useState('triggerElement');
+  const positionerElement = store.useState('positionerElement');
+  const listElement = store.useState('listElement');
   const reachedMaxHeightRef = React.useRef(false);
   const initialPlacedRef = React.useRef(false);
   const originalPositionerStylesRef = React.useRef<React.CSSProperties>({});
@@ -96,7 +84,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
   const scrollArrowFrame = useAnimationFrame();
 
   const handleScroll = useStableCallback((scroller: HTMLDivElement) => {
-    if (!positionerElement || !popupRef.current || !initialPlacedRef.current) {
+    if (!positionerElement || !store.context.popupRef.current || !initialPlacedRef.current) {
       return;
     }
 
@@ -108,7 +96,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
       !alignItemWithTriggerActive ||
       (!isTopPositioned && !isBottomPositioned)
     ) {
-      handleScrollArrowVisibility(scroller);
+      store.context.handleScrollArrowVisibility(scroller);
       return;
     }
 
@@ -123,7 +111,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     const positionerStyles = win.getComputedStyle(positionerElement);
     const marginTop = parseFloat(positionerStyles.marginTop);
     const marginBottom = parseFloat(positionerStyles.marginBottom);
-    const maxPopupHeight = getMaxPopupHeight(win.getComputedStyle(popupRef.current));
+    const maxPopupHeight = getMaxPopupHeight(win.getComputedStyle(store.context.popupRef.current));
     const maxAvailableHeight = Math.min(
       doc.documentElement.clientHeight - marginTop - marginBottom,
       maxPopupHeight,
@@ -152,7 +140,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
       if (maxAvailableHeight - (currentHeight + heightDelta) <= SCROLL_EDGE_TOLERANCE_PX) {
         reachedMaxHeightRef.current = true;
       }
-      handleScrollArrowVisibility(scroller);
+      store.context.handleScrollArrowVisibility(scroller);
       return;
     }
 
@@ -183,17 +171,17 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
       reachedMaxHeightRef.current = true;
     }
 
-    handleScrollArrowVisibility(scroller);
+    store.context.handleScrollArrowVisibility(scroller);
   });
 
-  React.useImperativeHandle(scrollHandlerRef, () => handleScroll, [handleScroll]);
+  React.useImperativeHandle(store.context.scrollHandlerRef, () => handleScroll, [handleScroll]);
 
   useOpenChangeComplete({
     open,
-    ref: popupRef,
+    ref: store.context.popupRef,
     onComplete() {
       if (open) {
-        onOpenChangeComplete?.(true);
+        store.context.onOpenChangeComplete(true);
       }
     },
   });
@@ -208,7 +196,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
   useIsoLayoutEffect(() => {
     if (
       !positionerElement ||
-      !popupRef.current ||
+      !store.context.popupRef.current ||
       Object.keys(originalPositionerStylesRef.current).length
     ) {
       return;
@@ -225,7 +213,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
       marginTop: positionerElement.style.marginTop,
       marginBottom: positionerElement.style.marginBottom,
     };
-  }, [popupRef, positionerElement]);
+  }, [store, positionerElement]);
 
   useIsoLayoutEffect(() => {
     if (open || alignItemWithTriggerActive) {
@@ -235,10 +223,10 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     initialPlacedRef.current = false;
     reachedMaxHeightRef.current = false;
     clearStyles(positionerElement, originalPositionerStylesRef.current);
-  }, [open, alignItemWithTriggerActive, positionerElement, popupRef]);
+  }, [open, alignItemWithTriggerActive, positionerElement]);
 
   useIsoLayoutEffect(() => {
-    const popupElement = popupRef.current;
+    const popupElement = store.context.popupRef.current;
 
     // Wait for Floating UI's first positioning pass before reading DOM geometry.
     // We replace the final coordinates for aligned selects, but still need middleware
@@ -260,7 +248,9 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     if (!alignItemWithTriggerActive) {
       // The wrapper supplies the scroller: the list owns scrolling once it has mounted, and
       // this effect re-runs (cancelling the stale frame) when that happens.
-      scrollArrowFrame.request(() => handleScrollArrowVisibility(listElement || popupElement));
+      scrollArrowFrame.request(() =>
+        store.context.handleScrollArrowVisibility(listElement || popupElement),
+      );
       return;
     }
 
@@ -269,17 +259,17 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     const restoreTransformStyles = unsetTransformStyles(popupElement);
 
     try {
-      let textElement = selectedItemTextRef.current;
+      let textElement = store.context.selectedItemTextRef.current;
 
       if (!textElement?.isConnected) {
-        const hasSelectedValue = selectors.hasSelectedValue(store.state);
+        const hasSelectedValue = store.select('hasSelectedValue');
         textElement =
-          !hasSelectedValue && firstItemTextRef.current?.isConnected
-            ? firstItemTextRef.current
+          !hasSelectedValue && store.context.firstItemTextRef.current?.isConnected
+            ? store.context.firstItemTextRef.current
             : null;
       }
 
-      const valueElement = valueRef.current;
+      const valueElement = store.context.valueRef.current;
 
       const win = ownerWindow(positionerElement);
       const positionerStyles = win.getComputedStyle(positionerElement);
@@ -402,13 +392,13 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
         reachedMaxHeightRef.current = true;
       }
 
-      handleScrollArrowVisibility(scroller);
+      store.context.handleScrollArrowVisibility(scroller);
 
       if (
         highlightItemOnHover &&
         store.state.selectedIndex === null &&
         store.state.activeIndex === null &&
-        listRef.current[0] != null
+        store.context.listRef.current[0] != null
       ) {
         store.set('activeIndex', 0);
       }
@@ -420,16 +410,10 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     open,
     positionerElement,
     triggerElement,
-    valueRef,
-    firstItemTextRef,
-    selectedItemTextRef,
-    popupRef,
-    handleScrollArrowVisibility,
     alignItemWithTriggerActive,
     setControlledAlignItemWithTrigger,
     scrollArrowFrame,
     listElement,
-    listRef,
     highlightItemOnHover,
     direction,
     isPositioned,
@@ -443,11 +427,11 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
     const win = ownerWindow(positionerElement);
 
     function handleResize(event: UIEvent) {
-      setOpen(false, createChangeEventDetails(REASONS.windowResize, event));
+      store.context.setOpen(false, createChangeEventDetails(REASONS.windowResize, event));
     }
 
     return addEventListener(win, 'resize', handleResize);
-  }, [setOpen, alignItemWithTriggerActive, positionerElement, open]);
+  }, [store, alignItemWithTriggerActive, positionerElement, open]);
 
   const defaultProps: HTMLProps = {
     ...(listElement
@@ -479,7 +463,7 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
   };
 
   const element = useRenderElement('div', componentProps, {
-    ref: [forwardedRef, popupRef],
+    ref: [forwardedRef, store.context.popupRef],
     state,
     stateAttributesMapping,
     props: [

--- a/packages/react/src/select/portal/SelectPortal.tsx
+++ b/packages/react/src/select/portal/SelectPortal.tsx
@@ -1,10 +1,8 @@
 'use client';
 import * as React from 'react';
-import { useStore } from '@base-ui/utils/store';
 import { FloatingPortal } from '../../floating-ui-react';
 import { type BaseUIComponentProps } from '../../internals/types';
 import { useSelectRootContext } from '../root/SelectRootContext';
-import { selectors } from '../store';
 
 /**
  * A portal element that moves the popup to a different part of the DOM.
@@ -17,9 +15,9 @@ export const SelectPortal = React.forwardRef(function SelectPortal(
   portalProps: SelectPortal.Props,
   forwardedRef: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const { store } = useSelectRootContext();
-  const mounted = useStore(store, selectors.mounted);
-  const forceMount = useStore(store, selectors.forceMount);
+  const store = useSelectRootContext();
+  const mounted = store.useState('mounted');
+  const forceMount = store.useState('forceMount');
 
   const shouldRender = mounted || forceMount;
   if (!shouldRender) {

--- a/packages/react/src/select/positioner/SelectPositioner.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.tsx
@@ -3,8 +3,7 @@ import * as React from 'react';
 import { inertValue } from '@base-ui/utils/inertValue';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { useStore } from '@base-ui/utils/store';
-import { useSelectRootContext } from '../root/SelectRootContext';
+import { useSelectFloatingContext, useSelectRootContext } from '../root/SelectRootContext';
 import { CompositeList } from '../../internals/composite/list/CompositeList';
 import type { BaseUIComponentProps } from '../../internals/types';
 import {
@@ -17,7 +16,6 @@ import { SelectPositionerContext } from './SelectPositionerContext';
 import { InternalBackdrop } from '../../utils/InternalBackdrop';
 import { DROPDOWN_COLLISION_AVOIDANCE } from '../../internals/constants';
 import { clearStyles } from '../popup/utils';
-import { selectors } from '../store';
 import { createChangeEventDetails } from '../../internals/createBaseUIEventDetails';
 import { REASONS } from '../../internals/reasons';
 import { findItemIndex } from '../../internals/itemEquality';
@@ -58,28 +56,18 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
     ...elementProps
   } = componentProps;
 
-  const {
-    store,
-    listRef,
-    labelsRef,
-    alignItemWithTriggerActiveRef,
-    selectedItemTextRef,
-    valuesRef,
-    initialValueRef,
-    popupRef,
-    setValue,
-    floatingContext: floatingRootContext,
-  } = useSelectRootContext();
+  const store = useSelectRootContext();
+  const floatingRootContext = useSelectFloatingContext();
 
-  const open = useStore(store, selectors.open);
-  const mounted = useStore(store, selectors.mounted);
-  const modal = useStore(store, selectors.modal);
-  const value = useStore(store, selectors.value);
-  const openMethod = useStore(store, selectors.openMethod);
-  const positionerElement = useStore(store, selectors.positionerElement);
-  const triggerElement = useStore(store, selectors.triggerElement);
-  const isItemEqualToValue = useStore(store, selectors.isItemEqualToValue);
-  const transitionStatus = useStore(store, selectors.transitionStatus);
+  const open = store.useState('open');
+  const mounted = store.useState('mounted');
+  const modal = store.useState('modal');
+  const value = store.useState('value');
+  const openMethod = store.useState('openMethod');
+  const positionerElement = store.useState('positionerElement');
+  const triggerElement = store.useState('triggerElement');
+  const isItemEqualToValue = store.useState('isItemEqualToValue');
+  const transitionStatus = store.useState('transitionStatus');
 
   const scrollUpArrowRef = React.useRef<HTMLDivElement | null>(null);
   const scrollDownArrowRef = React.useRef<HTMLDivElement | null>(null);
@@ -93,7 +81,10 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
     setControlledAlignItemWithTrigger(alignItemWithTrigger);
   }
 
-  React.useImperativeHandle(alignItemWithTriggerActiveRef, () => alignItemWithTriggerActive);
+  React.useImperativeHandle(
+    store.context.alignItemWithTriggerActiveRef,
+    () => alignItemWithTriggerActive,
+  );
 
   useAnchoredPopupScrollLock(
     (alignItemWithTriggerActive || modal) && open,
@@ -149,7 +140,7 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
 
   const onMapChange = useStableCallback(
     (map: Map<Element, { index?: number | null | undefined } | null>) => {
-      if (valuesRef.current.length === 0) {
+      if (store.context.valuesRef.current.length === 0) {
         return;
       }
 
@@ -159,18 +150,26 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
       const eventDetails = createChangeEventDetails(REASONS.none);
 
       if (prevSize !== 0 && !store.state.multiple && value !== null) {
-        const selectedValueIndex = findItemIndex(valuesRef.current, value, isItemEqualToValue);
+        const selectedValueIndex = findItemIndex(
+          store.context.valuesRef.current,
+          value,
+          isItemEqualToValue,
+        );
         if (selectedValueIndex === -1) {
-          const initialSelectedValue = initialValueRef.current;
+          const initialSelectedValue = store.context.initialValueRef.current;
           const hasInitial =
             initialSelectedValue != null &&
-            findItemIndex(valuesRef.current, initialSelectedValue, isItemEqualToValue) !== -1;
+            findItemIndex(
+              store.context.valuesRef.current,
+              initialSelectedValue,
+              isItemEqualToValue,
+            ) !== -1;
           const nextValue = hasInitial ? initialSelectedValue : null;
-          setValue(nextValue, eventDetails);
+          store.context.setValue(nextValue, eventDetails);
 
           if (nextValue === null) {
             store.set('selectedIndex', null);
-            selectedItemTextRef.current = null;
+            store.context.selectedItemTextRef.current = null;
           }
         }
       }
@@ -178,14 +177,18 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
       if (prevSize !== 0 && store.state.multiple && Array.isArray(value)) {
         const nextValue = value.filter(
           (selectedItemValue) =>
-            findItemIndex(valuesRef.current, selectedItemValue, isItemEqualToValue) !== -1,
+            findItemIndex(
+              store.context.valuesRef.current,
+              selectedItemValue,
+              isItemEqualToValue,
+            ) !== -1,
         );
         if (nextValue.length !== value.length) {
-          setValue(nextValue, eventDetails);
+          store.context.setValue(nextValue, eventDetails);
 
           if (nextValue.length === 0) {
             store.set('selectedIndex', null);
-            selectedItemTextRef.current = null;
+            store.context.selectedItemTextRef.current = null;
           }
         }
       }
@@ -198,7 +201,7 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
 
         const stylesToClear: React.CSSProperties = { height: '' };
         clearStyles(positionerElement, stylesToClear);
-        clearStyles(popupRef.current, stylesToClear);
+        clearStyles(store.context.popupRef.current, stylesToClear);
       }
     },
   );
@@ -216,7 +219,11 @@ export const SelectPositioner = React.forwardRef(function SelectPositioner(
   );
 
   return (
-    <CompositeList elementsRef={listRef} labelsRef={labelsRef} onMapChange={onMapChange}>
+    <CompositeList
+      elementsRef={store.context.listRef}
+      labelsRef={store.context.labelsRef}
+      onMapChange={onMapChange}
+    >
       <SelectPositionerContext.Provider value={contextValue}>
         {mounted && modal && <InternalBackdrop inert={inertValue(!open)} cutout={triggerElement} />}
         {element}

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -10,7 +10,7 @@ import { useControlled } from '@base-ui/utils/useControlled';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
-import { useStore, ReactStore } from '@base-ui/utils/store';
+import { ReactStore } from '@base-ui/utils/store';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from '@base-ui/utils/empty';
 import {
   useClick,
@@ -19,12 +19,17 @@ import {
   useListNavigation,
   useTypeahead,
 } from '../../floating-ui-react';
-import { SelectRootContext } from './SelectRootContext';
+import {
+  SelectFloatingContext,
+  SelectRootContext,
+  SelectRootPropsContext,
+  type SelectRootPropsContextValue,
+} from './SelectRootContext';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
 import { useRegisterFieldControl } from '../../internals/field-register-control/useRegisterFieldControl';
 import { useLabelableId } from '../../internals/labelable-provider/useLabelableId';
 import { useTransitionStatus } from '../../internals/useTransitionStatus';
-import { selectors, type State as StoreState } from '../store';
+import { selectors, type SelectStoreContext, type State as StoreState } from '../store';
 import {
   type BaseUIChangeEventDetails,
   createChangeEventDetails,
@@ -43,6 +48,7 @@ import { useOpenInteractionType } from '../../utils/useOpenInteractionType';
 import { getMaxScrollOffset, normalizeScrollOffset } from '../../utils/scrollEdges';
 import { FOCUSABLE_POPUP_PROPS } from '../../utils/popups';
 import { mergeProps } from '../../merge-props';
+import { NOOP } from '../../internals/noop';
 
 /**
  * Groups all parts of the select.
@@ -128,45 +134,68 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
     dragY: 0,
   });
   const alignItemWithTriggerActiveRef = React.useRef(false);
+  const initialValueRef = React.useRef(value);
 
   const { mounted, setMounted, transitionStatus } = useTransitionStatus(open);
   const { openMethod, triggerProps: interactionTypeProps } = useOpenInteractionType(open);
 
   const store = useRefWithInit(
     () =>
-      new ReactStore<StoreState>({
-        id: generatedId,
-        labelId: undefined,
-        modal,
-        multiple,
-        itemToStringLabel,
-        itemToStringValue,
-        isItemEqualToValue,
-        value,
-        open,
-        mounted,
-        transitionStatus,
-        items,
-        forceMount: false,
-        openMethod: null,
-        activeIndex: null,
-        selectedIndex: null,
-        popupProps: {},
-        triggerProps: {},
-        triggerElement: null,
-        positionerElement: null,
-        listElement: null,
-        popupSide: null,
-        scrollUpArrowVisible: false,
-        scrollDownArrowVisible: false,
-        hasScrollArrows: false,
-      }),
+      new ReactStore<StoreState, SelectStoreContext, typeof selectors>(
+        {
+          id: generatedId,
+          labelId: undefined,
+          modal,
+          multiple,
+          itemToStringLabel,
+          itemToStringValue,
+          isItemEqualToValue,
+          value,
+          open,
+          mounted,
+          transitionStatus,
+          items,
+          forceMount: false,
+          openMethod: null,
+          activeIndex: null,
+          selectedIndex: null,
+          popupProps: EMPTY_OBJECT,
+          triggerProps: EMPTY_OBJECT,
+          triggerElement: null,
+          positionerElement: null,
+          listElement: null,
+          popupSide: null,
+          scrollUpArrowVisible: false,
+          scrollDownArrowVisible: false,
+          hasScrollArrows: false,
+        },
+        {
+          setValue: NOOP,
+          setOpen: NOOP,
+          handleScrollArrowVisibility: NOOP,
+          onOpenChangeComplete: NOOP,
+          listRef,
+          popupRef,
+          scrollHandlerRef,
+          scrollArrowsMountedCountRef,
+          valueRef,
+          valuesRef,
+          labelsRef,
+          typingRef,
+          selectionRef,
+          firstItemTextRef,
+          selectedItemTextRef,
+          alignItemWithTriggerActiveRef,
+          initialValueRef,
+        },
+        selectors,
+      ),
   ).current;
 
-  const activeIndex = useStore(store, selectors.activeIndex);
-  const selectedIndex = useStore(store, selectors.selectedIndex);
-  const triggerElement = useStore(store, selectors.triggerElement);
-  const positionerElement = useStore(store, selectors.positionerElement);
+  const activeIndex = store.useState('activeIndex');
+  const selectedIndex = store.useState('selectedIndex');
+  const triggerElement = store.useState('triggerElement');
+  const positionerElement = store.useState('positionerElement');
 
   const previousOpenMethod = usePreviousValue(openMethod);
   const renderedOpenMethod = openMethod ?? previousOpenMethod;
@@ -200,7 +229,6 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
     nameProp,
   );
 
-  const initialValueRef = React.useRef(value);
   // Mirror the `hasSelectedValue` store selector so the Field's filled state agrees with the
   // trigger/value placeholder semantics (a value serializing to `''` counts as empty).
   const hasSelectedValue = multiple
@@ -411,6 +439,13 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
   const itemProps =
     (listNavigation.item as React.HTMLProps<HTMLElement> | undefined) ?? EMPTY_OBJECT;
 
+  store.useContextCallback('setValue', setValue);
+  store.useContextCallback('setOpen', setOpen);
+  store.useContextCallback('handleScrollArrowVisibility', handleScrollArrowVisibility);
+  store.useContextCallback('onOpenChangeComplete', onOpenChangeComplete);
+
+  // The prop bags must be in the store before the parts render. `useSyncedValues` writes in a
+  // layout effect, after all descendants have rendered.
   useOnFirstRender(() => {
     store.update({
       popupProps,
@@ -435,50 +470,16 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
     openMethod: renderedOpenMethod,
   });
 
-  const contextValue: SelectRootContext = React.useMemo(
+  const rootPropsContextValue: SelectRootPropsContextValue = React.useMemo(
     () => ({
-      store,
-      floatingContext,
-      required,
       disabled,
       readOnly,
+      required,
       multiple,
       highlightItemOnHover,
-      setValue,
-      setOpen,
-      listRef,
-      popupRef,
-      scrollHandlerRef,
-      handleScrollArrowVisibility,
-      scrollArrowsMountedCountRef,
       itemProps,
-      valueRef,
-      valuesRef,
-      labelsRef,
-      typingRef,
-      selectionRef,
-      firstItemTextRef,
-      selectedItemTextRef,
-      validation,
-      onOpenChangeComplete,
-      alignItemWithTriggerActiveRef,
-      initialValueRef,
     }),
-    [
-      store,
-      floatingContext,
-      required,
-      disabled,
-      readOnly,
-      multiple,
-      highlightItemOnHover,
-      setValue,
-      setOpen,
-      itemProps,
-      validation,
-      onOpenChangeComplete,
-      handleScrollArrowVisibility,
-    ],
+    [disabled, readOnly, required, multiple, highlightItemOnHover, itemProps],
   );
 
   const ref = useMergedRefs(inputRef, validation.inputRef);
@@ -506,8 +507,12 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
   }, [multiple, value, form, name, itemToStringValue, disabled]);
 
   return (
-    <SelectRootContext.Provider value={contextValue}>
-      {children}
+    <SelectRootContext.Provider value={store}>
+      <SelectRootPropsContext.Provider value={rootPropsContextValue}>
+        <SelectFloatingContext.Provider value={floatingContext}>
+          {children}
+        </SelectFloatingContext.Provider>
+      </SelectRootPropsContext.Provider>
       <input
         {...validation.getValidationProps(disabled, {
           onFocus() {
@@ -534,7 +539,8 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
               }
 
               // Preserve the original serialized matching, then fall back to rendered text,
-              // which browsers can autofill for primitive values like `value="US">United States`.
+              // which browsers can autofill for primitive values like
+              // `value="US">United States`.
               const nextValueLower = nextValue.toLowerCase();
               let matchingIndex = valuesRef.current.findIndex(
                 (candidate) =>

--- a/packages/react/src/select/root/SelectRootContext.ts
+++ b/packages/react/src/select/root/SelectRootContext.ts
@@ -2,50 +2,54 @@
 import * as React from 'react';
 import { type FloatingRootContext } from '../../floating-ui-react';
 import type { SelectStore } from '../store';
-import type { UseFieldValidationReturnValue } from '../../field/root/useFieldValidation';
 import type { HTMLProps } from '../../internals/types';
-import type { SelectRoot } from './SelectRoot';
 
-export interface SelectRootContext {
-  store: SelectStore;
-  floatingContext: FloatingRootContext;
+/**
+ * Root values consumed during render. Keep these outside `useSyncedValues` so descendant ref
+ * callbacks see the current props during the same commit.
+ */
+export interface SelectRootPropsContextValue {
   disabled: boolean;
   readOnly: boolean;
   required: boolean;
   multiple: boolean;
   highlightItemOnHover: boolean;
-  setValue: (nextValue: any, eventDetails: SelectRoot.ChangeEventDetails) => void;
-  setOpen: (open: boolean, eventDetails: SelectRoot.ChangeEventDetails) => void;
-  listRef: React.RefObject<Array<HTMLElement | null>>;
-  popupRef: React.RefObject<HTMLDivElement | null>;
-  scrollHandlerRef: React.RefObject<((el: HTMLDivElement) => void) | null>;
-  handleScrollArrowVisibility: (scroller: HTMLElement) => void;
-  scrollArrowsMountedCountRef: React.RefObject<number>;
   itemProps: HTMLProps;
-  valueRef: React.RefObject<HTMLSpanElement | null>;
-  valuesRef: React.RefObject<Array<any>>;
-  labelsRef: React.RefObject<Array<string | null>>;
-  typingRef: React.RefObject<boolean>;
-  selectionRef: React.RefObject<{
-    allowUnselectedMouseUp: boolean;
-    allowSelectedMouseUp: boolean;
-    dragY: number;
-  }>;
-  firstItemTextRef: React.RefObject<HTMLElement | null>;
-  selectedItemTextRef: React.RefObject<HTMLElement | null>;
-  validation: UseFieldValidationReturnValue;
-  onOpenChangeComplete?: ((open: boolean) => void) | undefined;
-  alignItemWithTriggerActiveRef: React.RefObject<boolean>;
-  initialValueRef: React.RefObject<any>;
 }
 
-export const SelectRootContext = React.createContext<SelectRootContext | null>(null);
+export const SelectRootContext = React.createContext<SelectStore | undefined>(undefined);
+export const SelectRootPropsContext = React.createContext<SelectRootPropsContextValue | undefined>(
+  undefined,
+);
+export const SelectFloatingContext = React.createContext<FloatingRootContext | undefined>(
+  undefined,
+);
 
 export function useSelectRootContext() {
-  const context = React.useContext(SelectRootContext);
-  if (context === null) {
+  const store = React.useContext(SelectRootContext);
+  if (store === undefined) {
     throw new Error(
       'Base UI: SelectRootContext is missing. Select parts must be placed within <Select.Root>.',
+    );
+  }
+  return store;
+}
+
+export function useSelectRootPropsContext() {
+  const context = React.useContext(SelectRootPropsContext);
+  if (context === undefined) {
+    throw new Error(
+      'Base UI: SelectRootPropsContext is missing. Select parts must be placed within <Select.Root>.',
+    );
+  }
+  return context;
+}
+
+export function useSelectFloatingContext() {
+  const context = React.useContext(SelectFloatingContext);
+  if (context === undefined) {
+    throw new Error(
+      'Base UI: SelectFloatingContext is missing. Select parts must be placed within <Select.Root>.',
     );
   }
   return context;

--- a/packages/react/src/select/scroll-arrow/SelectScrollArrow.tsx
+++ b/packages/react/src/select/scroll-arrow/SelectScrollArrow.tsx
@@ -1,7 +1,6 @@
 'use client';
 import * as React from 'react';
 import { useTimeout } from '@base-ui/utils/useTimeout';
-import { useStore } from '@base-ui/utils/store';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useSelectRootContext } from '../root/SelectRootContext';
@@ -16,7 +15,6 @@ import {
   normalizeScrollOffset,
   SCROLL_EDGE_TOLERANCE_PX,
 } from '../../utils/scrollEdges';
-import { selectors } from '../store';
 
 /**
  * @internal
@@ -29,14 +27,13 @@ export const SelectScrollArrow = React.forwardRef(function SelectScrollArrow(
 
   const isUp = direction === 'up';
 
-  const { store, popupRef, listRef, handleScrollArrowVisibility, scrollArrowsMountedCountRef } =
-    useSelectRootContext();
+  const store = useSelectRootContext();
   const { side, scrollDownArrowRef, scrollUpArrowRef } = useSelectPositionerContext();
 
-  const visibleSelector = isUp ? selectors.scrollUpArrowVisible : selectors.scrollDownArrowVisible;
+  const visibleSelector = isUp ? 'scrollUpArrowVisible' : 'scrollDownArrowVisible';
 
-  const stateVisible = useStore(store, visibleSelector);
-  const openMethod = useStore(store, selectors.openMethod);
+  const stateVisible = store.useState(visibleSelector);
+  const openMethod = store.useState('openMethod');
 
   // Scroll arrows are disabled for touch modality as they are a hover-only element.
   const visible = stateVisible && openMethod !== 'touch';
@@ -48,16 +45,19 @@ export const SelectScrollArrow = React.forwardRef(function SelectScrollArrow(
   const { mounted, transitionStatus, setMounted } = useTransitionStatus(visible);
 
   useIsoLayoutEffect(() => {
-    scrollArrowsMountedCountRef.current += 1;
+    store.context.scrollArrowsMountedCountRef.current += 1;
     store.set('hasScrollArrows', true);
 
     return () => {
-      scrollArrowsMountedCountRef.current = Math.max(0, scrollArrowsMountedCountRef.current - 1);
-      if (scrollArrowsMountedCountRef.current === 0) {
+      store.context.scrollArrowsMountedCountRef.current = Math.max(
+        0,
+        store.context.scrollArrowsMountedCountRef.current - 1,
+      );
+      if (store.context.scrollArrowsMountedCountRef.current === 0) {
         store.set('hasScrollArrows', false);
       }
     };
-  }, [store, scrollArrowsMountedCountRef]);
+  }, [store]);
 
   useOpenChangeComplete({
     open: visible,
@@ -90,18 +90,18 @@ export const SelectScrollArrow = React.forwardRef(function SelectScrollArrow(
       store.set('activeIndex', null);
 
       function scrollNextItem() {
-        const scroller = store.state.listElement ?? popupRef.current;
+        const scroller = store.state.listElement ?? store.context.popupRef.current;
         if (!scroller) {
           return;
         }
 
         store.set('activeIndex', null);
-        handleScrollArrowVisibility(scroller);
+        store.context.handleScrollArrowVisibility(scroller);
 
         const maxScrollTop = getMaxScrollOffset(scroller.scrollHeight, scroller.clientHeight);
         const scrollTop = normalizeScrollOffset(scroller.scrollTop, maxScrollTop);
         const isScrolledToEdge = scrollTop === (isUp ? 0 : maxScrollTop);
-        const items = listRef.current;
+        const items = store.context.listRef.current;
 
         if (scrollTop !== scroller.scrollTop) {
           scroller.scrollTop = scrollTop;

--- a/packages/react/src/select/store.test.tsx
+++ b/packages/react/src/select/store.test.tsx
@@ -1,0 +1,141 @@
+import { expect, vi } from 'vitest';
+import * as React from 'react';
+import { screen } from '@mui/internal-test-utils';
+import { createRenderer } from '#test-utils';
+import { Select } from '@base-ui/react/select';
+import { useSelectRootContext } from './root/SelectRootContext';
+import type { SelectStore } from './store';
+import { createChangeEventDetails } from '../internals/createBaseUIEventDetails';
+import { REASONS } from '../internals/reasons';
+
+describe('select store synchronization', () => {
+  beforeEach(() => {
+    globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
+  });
+
+  const { render } = createRenderer();
+
+  function StoreProbe({ storeRef }: { storeRef: { current: SelectStore | null } }) {
+    storeRef.current = useSelectRootContext();
+    return null;
+  }
+
+  function SynchronizationFixture({
+    id,
+    modal,
+    storeRef,
+  }: {
+    id: string;
+    modal: boolean;
+    storeRef: { current: SelectStore | null };
+  }) {
+    return (
+      <Select.Root id={id} modal={modal}>
+        <StoreProbe storeRef={storeRef} />
+        <Select.Trigger />
+      </Select.Root>
+    );
+  }
+
+  it('publishes synchronized values in a single store transaction', async () => {
+    const storeRef: { current: SelectStore | null } = { current: null };
+    const { setProps } = await render(
+      <SynchronizationFixture id="first" modal storeRef={storeRef} />,
+    );
+
+    const store = storeRef.current!;
+    const snapshots: Array<{ id: string | undefined; modal: boolean }> = [];
+    const unsubscribe = store.subscribe((state) => {
+      snapshots.push({ id: state.id, modal: state.modal });
+    });
+
+    try {
+      await setProps({ id: 'second', modal: false });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(snapshots.some((snapshot) => snapshot.id === 'second' && snapshot.modal)).toBe(false);
+    expect(snapshots.some((snapshot) => snapshot.id === 'first' && !snapshot.modal)).toBe(false);
+    expect(snapshots).toContainEqual({ id: 'second', modal: false });
+  });
+
+  it('provides setOpen to a descendant ref callback on the first commit', async () => {
+    const handleOpenChange = vi.fn();
+    let invoked = false;
+
+    function CommandProbe() {
+      const store = useSelectRootContext();
+
+      return (
+        <div
+          ref={(element) => {
+            if (element && !invoked) {
+              invoked = true;
+              store.context.setOpen(true, createChangeEventDetails(REASONS.none));
+            }
+          }}
+        />
+      );
+    }
+
+    await render(
+      <Select.Root onOpenChange={handleOpenChange}>
+        <CommandProbe />
+        <Select.Trigger />
+        <Select.Portal>
+          <Select.Positioner>
+            <Select.Popup>
+              <Select.Item value="alpha">alpha</Select.Item>
+            </Select.Popup>
+          </Select.Positioner>
+        </Select.Portal>
+      </Select.Root>,
+    );
+
+    expect(invoked).toBe(true);
+    expect(handleOpenChange).toHaveBeenCalled();
+    expect(handleOpenChange.mock.calls[0][0]).toBe(true);
+  });
+
+  it('makes an updated disabled prop available to item ref callbacks', async () => {
+    const handleValueChange = vi.fn();
+    let clickOnUpdate = false;
+    let clicked = false;
+
+    function Fixture({ disabled }: { disabled: boolean }) {
+      return (
+        <Select.Root defaultOpen disabled={disabled} onValueChange={handleValueChange}>
+          <Select.Trigger />
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup>
+                <Select.Item
+                  data-testid="item"
+                  value="alpha"
+                  ref={(element) => {
+                    if (element && clickOnUpdate && !clicked) {
+                      clicked = true;
+                      element.click();
+                    }
+                  }}
+                >
+                  alpha
+                </Select.Item>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>
+      );
+    }
+
+    const { setProps, user } = await render(<Fixture disabled={false} />);
+    await user.hover(screen.getByTestId('item'));
+
+    clickOnUpdate = true;
+    await setProps({ disabled: true });
+
+    expect(clicked).toBe(true);
+    expect(handleValueChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/select/store.ts
+++ b/packages/react/src/select/store.ts
@@ -5,6 +5,7 @@ import type { HTMLProps } from '../internals/types';
 import type { Side } from '../internals/useAnchorPositioning';
 import { compareItemEquality } from '../internals/itemEquality';
 import { type Group, hasNullItemLabel, stringifyAsValue } from '../internals/resolveValueLabel';
+import type { SelectRoot } from './root/SelectRoot';
 
 export type State = {
   id: string | undefined;
@@ -45,7 +46,36 @@ export type State = {
   hasScrollArrows: boolean;
 };
 
-export type SelectStore = ReactStore<State>;
+/**
+ * Non-reactive values shared with the select parts. Nothing here is observable through
+ * `selectors`, so writing to a ref never notifies subscribers.
+ */
+export type SelectStoreContext = {
+  readonly listRef: React.RefObject<Array<HTMLElement | null>>;
+  readonly popupRef: React.RefObject<HTMLDivElement | null>;
+  readonly scrollHandlerRef: React.RefObject<((element: HTMLDivElement) => void) | null>;
+  readonly scrollArrowsMountedCountRef: React.RefObject<number>;
+  readonly valueRef: React.RefObject<HTMLSpanElement | null>;
+  readonly valuesRef: React.RefObject<Array<any>>;
+  readonly labelsRef: React.RefObject<Array<string | null>>;
+  readonly typingRef: React.RefObject<boolean>;
+  readonly selectionRef: React.RefObject<{
+    allowUnselectedMouseUp: boolean;
+    allowSelectedMouseUp: boolean;
+    dragY: number;
+  }>;
+  readonly firstItemTextRef: React.RefObject<HTMLElement | null>;
+  readonly selectedItemTextRef: React.RefObject<HTMLElement | null>;
+  readonly alignItemWithTriggerActiveRef: React.RefObject<boolean>;
+  readonly initialValueRef: React.RefObject<any>;
+
+  // Commands. Seeded with `NOOP` when the store is constructed and assigned during the root's
+  // first render, so they are not `readonly`.
+  setValue: (nextValue: any, eventDetails: SelectRoot.ChangeEventDetails) => void;
+  setOpen: (open: boolean, eventDetails: SelectRoot.ChangeEventDetails) => void;
+  handleScrollArrowVisibility: (scroller: HTMLElement) => void;
+  onOpenChangeComplete: (open: boolean) => void;
+};
 
 export const selectors = {
   id: (state: State) => state.id,
@@ -116,3 +146,5 @@ export const selectors = {
 
   hasScrollArrows: (state: State) => state.hasScrollArrows,
 };
+
+export type SelectStore = ReactStore<State, SelectStoreContext, typeof selectors>;

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -3,8 +3,7 @@ import * as React from 'react';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { useTimeout } from '@base-ui/utils/useTimeout';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
-import { useStore } from '@base-ui/utils/store';
-import { useSelectRootContext } from '../root/SelectRootContext';
+import { useSelectRootContext, useSelectRootPropsContext } from '../root/SelectRootContext';
 import { BaseUIComponentProps, HTMLProps, NativeButtonProps } from '../../internals/types';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
 import { useLabelableContext } from '../../internals/labelable-provider/LabelableContext';
@@ -12,7 +11,6 @@ import { pressableTriggerOpenStateMapping } from '../../utils/popupStateMapping'
 import { fieldValidityMapping } from '../../internals/field-constants/constants';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { StateAttributesMapping } from '../../internals/getStateAttributesProps';
-import { selectors } from '../store';
 import { isMouseWithinBounds } from '../../utils/getPseudoElementBounds';
 import { contains, getFloatingFocusElement } from '../../floating-ui-react/utils';
 import { mergeProps } from '../../merge-props';
@@ -57,33 +55,25 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
     setTouched,
     setFocused,
     validationMode,
+    validation,
     state: fieldState,
     disabled: fieldDisabled,
   } = useFieldRootContext();
   const { labelId: fieldLabelId } = useLabelableContext();
-  const {
-    store,
-    setOpen,
-    selectionRef,
-    validation,
-    readOnly,
-    required,
-    alignItemWithTriggerActiveRef,
-    disabled: selectDisabled,
-  } = useSelectRootContext();
-
+  const store = useSelectRootContext();
+  const { readOnly, required, disabled: selectDisabled } = useSelectRootPropsContext();
   const disabled = fieldDisabled || selectDisabled || disabledProp;
 
-  const open = useStore(store, selectors.open);
-  const mounted = useStore(store, selectors.mounted);
-  const value = useStore(store, selectors.value);
-  const triggerProps = useStore(store, selectors.triggerProps);
-  const positionerElement = useStore(store, selectors.positionerElement);
-  const listElement = useStore(store, selectors.listElement);
-  const popupSideValue = useStore(store, selectors.popupSide);
-  const rootId = useStore(store, selectors.id);
-  const selectLabelId = useStore(store, selectors.labelId);
-  const hasSelectedValue = useStore(store, selectors.hasSelectedValue);
+  const open = store.useState('open');
+  const mounted = store.useState('mounted');
+  const value = store.useState('value');
+  const triggerProps = store.useState('triggerProps');
+  const positionerElement = store.useState('positionerElement');
+  const listElement = store.useState('listElement');
+  const popupSideValue = store.useState('popupSide');
+  const rootId = store.useState('id');
+  const selectLabelId = store.useState('labelId');
+  const hasSelectedValue = store.useState('hasSelectedValue');
   const popupSide = mounted && positionerElement ? popupSideValue : null;
 
   const id = idProp ?? rootId;
@@ -113,8 +103,8 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
       // commit an accidental selection. SelectItem can still opt into unselected mouseup sooner
       // after a real drag over the item.
       selectedDelayTimeout.start(SELECTED_DELAY, () => {
-        selectionRef.current.allowUnselectedMouseUp = true;
-        selectionRef.current.allowSelectedMouseUp = true;
+        store.context.selectionRef.current.allowUnselectedMouseUp = true;
+        store.context.selectionRef.current.allowSelectedMouseUp = true;
       });
 
       return () => {
@@ -122,7 +112,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
       };
     }
 
-    selectionRef.current = {
+    store.context.selectionRef.current = {
       allowSelectedMouseUp: false,
       allowUnselectedMouseUp: false,
       dragY: 0,
@@ -131,7 +121,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
     timeoutMouseDown.clear();
 
     return undefined;
-  }, [open, selectionRef, timeoutMouseDown, selectedDelayTimeout]);
+  }, [open, store, timeoutMouseDown, selectedDelayTimeout]);
 
   const mergedProps: HTMLProps = mergeProps<'button'>(
     triggerProps,
@@ -151,8 +141,8 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
         setFocused(true);
 
         // The popup element shouldn't obscure the focused trigger.
-        if (open && alignItemWithTriggerActiveRef.current) {
-          setOpen(false, createChangeEventDetails(REASONS.none, event.nativeEvent));
+        if (open && store.context.alignItemWithTriggerActiveRef.current) {
+          store.context.setOpen(false, createChangeEventDetails(REASONS.none, event.nativeEvent));
         }
 
         // Saves a re-render on initial click: `forceMount === true` mounts
@@ -202,7 +192,7 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
             return;
           }
 
-          setOpen(false, createChangeEventDetails(REASONS.cancelOpen, mouseEvent));
+          store.context.setOpen(false, createChangeEventDetails(REASONS.cancelOpen, mouseEvent));
         }
 
         // Firefox can fire this upon mousedown

--- a/packages/react/src/select/value/SelectValue.tsx
+++ b/packages/react/src/select/value/SelectValue.tsx
@@ -1,11 +1,9 @@
 'use client';
 import * as React from 'react';
-import { useStore } from '@base-ui/utils/store';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useSelectRootContext } from '../root/SelectRootContext';
 import { resolveMultipleLabels, resolveSelectedLabel } from '../../internals/resolveValueLabel';
-import { selectors } from '../store';
 import { StateAttributesMapping } from '../../internals/getStateAttributesProps';
 
 const stateAttributesMapping: StateAttributesMapping<SelectValueState> = {
@@ -31,15 +29,15 @@ export const SelectValue = React.forwardRef(function SelectValue(
     ...elementProps
   } = componentProps;
 
-  const { store, valueRef } = useSelectRootContext();
+  const store = useSelectRootContext();
 
-  const value = useStore(store, selectors.value);
-  const items = useStore(store, selectors.items);
-  const itemToStringLabel = useStore(store, selectors.itemToStringLabel);
-  const hasSelectedValue = useStore(store, selectors.hasSelectedValue);
+  const value = store.useState('value');
+  const items = store.useState('items');
+  const itemToStringLabel = store.useState('itemToStringLabel');
+  const hasSelectedValue = store.useState('hasSelectedValue');
 
   const shouldCheckNullItemLabel = !hasSelectedValue && placeholder != null && childrenProp == null;
-  const hasNullLabel = useStore(store, selectors.hasNullItemLabel, shouldCheckNullItemLabel);
+  const hasNullLabel = store.useState('hasNullItemLabel', shouldCheckNullItemLabel);
 
   const state: SelectValueState = {
     value,
@@ -61,7 +59,7 @@ export const SelectValue = React.forwardRef(function SelectValue(
 
   const element = useRenderElement('span', componentProps, {
     state,
-    ref: [forwardedRef, valueRef],
+    ref: [forwardedRef, store.context.valueRef],
     props: [{ children }, elementProps],
     stateAttributesMapping,
   });


### PR DESCRIPTION
Select keeps refs, callbacks, reactive options, and the Floating UI context in one memoized React context. Changing any dependency rerenders every Select part.

This PR applies the store split from #5581 without changing when Select props reach its parts:

- makes `SelectRootContext` provide the stable `ReactStore`
- moves 13 refs and four commands into the non-reactive store context
- keeps root props and `itemProps` in a separate synchronous React context
- registers Select selectors and reads them through `store.useState()`
- gives the Floating UI context its own provider
- uses `EMPTY_OBJECT` for the initial prop bags
- covers atomic store synchronization, first-commit command availability, and commit-time disabled updates

No public API, DOM, or behavior change is intended.

Verification:

- `pnpm test:jsdom Select --no-watch` (506 passed, 71 skipped)
- `pnpm test:chromium Select --no-watch` (558 passed, 19 skipped)
- `pnpm typescript`
- `pnpm eslint`
- `pnpm exec prettier --check packages/react/src/select docs/src/error-codes.json`
- `pnpm extract-error-codes`