### PR TITLE
[docs-infra] Fix types generation from deeply nested checkouts

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -70,7 +70,6 @@ const rootPackage = loadPackageJson();
 
 /** @type {import('@mui/internal-docs-infra/pipeline/loadPrecomputedTypes').LoaderOptions} */
 const typesGenerationOptions = {
-  socketDir: '.next/docs-infra',
   updateParentIndex: {
     baseDir,
     onlyUpdateIndexes: true,


### PR DESCRIPTION
## Problem

`pnpm docs:api` fails for every component when the repo is checked out anywhere under a deep path — a git worktree, most commonly:

```
Error processing src/app/(docs)/react/components/accordion/types.ts: Error: Socket file did not appear within 30000ms
... (×42)

✓ 0 files updated in 150.86s
✗ Validation failed with errors
```

`docs/next.config.mjs` set `socketDir: '.next/docs-infra'`, a *relative* path that docs-infra resolves against the docs directory. Unix domain socket paths are capped at 104 bytes on macOS (108 on Linux, the `sun_path` field of `sockaddr_un`), and a worktree checkout blows straight past it:

| checkout | socket path | bytes |
| --- | --- | --- |
| plain clone | `~/Projects/base-ui/docs/.next/docs-infra/types.sock` | 63 ✅ |
| worktree | `~/Projects/.claude/worktrees/base-ui/<name>/docs/.next/docs-infra/types.sock` | 109–113 ❌ |

`SocketServer.create` throws `Socket path exceeds the maximum length…`, so no socket is ever created. The worker that won the server-election lock then sits in `waitForSocketFile(…, 30_000)` until it times out, and so does every other worker — hence 30s × batches ≈ 150s and a non-zero exit, with nothing generated.

## Fix

Leave `socketDir` unset and let docs-infra pick the directory itself. Its fallback in `socketClient.mjs` already does the right thing:

```js
return `${getDefaultSocketDir()}/mui-docs-infra-${projectHash}`;
// getDefaultSocketDir(): RUNNER_TEMP ?? AGENT_TEMPDIRECTORY ?? tmpdir()
// projectHash:           sha256(process.cwd()).slice(0, 8)
```

That keeps the path short regardless of where the repo lives (83 bytes on macOS), prefers the CI runner's temp directory on GitHub Actions and Azure Pipelines, and — via the project-directory hash — keeps concurrent checkouts on separate sockets.

I also considered computing an absolute `socketDir` in `next.config.mjs` rooted at `os.tmpdir()`. It works (the validate CLI imports the config rather than parsing it statically, so a computed value is fine), but it would duplicate the logic above and silently drop the CI temp-directory handling unless that were replicated too.

## Verification

On a worktree whose socket path would be 113 bytes:

| | before | after |
| --- | --- | --- |
| `pnpm docs:api` | 150.86s, 0 files updated, exit 1, 42 errors | **9.64s, exit 0** |

- Plain checkout still passes (exit 0), and no `types.md` was regenerated in any run.
- Three checkouts running `pnpm docs:api` **simultaneously** all passed (16.3s / 17.2s / 16.4s), each against its own socket directory — `mui-docs-infra-8d653f13`, `-c800c047`, `-8354b5c4` — confirming no cross-checkout collision.
- `pnpm typescript`, `pnpm eslint`, `pnpm prettier` clean.

## Heads-up for @mui/infra

`withDocsInfra` hardcodes the same relative `socketDir: '.next/docs-infra'` for both the Turbopack and the webpack `loadPrecomputedTypes` rules, so **any** repo that configures itself through `withDocsInfra` hits this the moment its checkout path gets long enough — a worktree, a deeply nested CI workspace, or just a long `$HOME`. It fails as a 30s-per-worker timeout rather than as the underlying "socket path exceeds the maximum length" error, which makes it fairly hard to diagnose from the output alone.

This repo goes through `withDeploymentConfig`, which doesn't inject the option, so overriding it here is enough for base-ui. But the two hardcoded defaults in `withDocsInfra` are worth removing upstream — the fallback in `socketClient.mjs` is strictly better than the value they're passing, and dropping them would fix every consumer at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)