### PR TITLE
[select] Synchronize root props through the store

### DIFF
--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
-import { useSelectRootContext, useSelectRootPropsContext } from '../root/SelectRootContext';
+import { useSelectRootContext } from '../root/SelectRootContext';
 import { useCompositeListItem } from '../../internals/composite/list/useCompositeListItem';
 import type {
   BaseUIComponentProps,
@@ -47,7 +47,10 @@ export const SelectItem = React.memo(
     });
 
     const store = useSelectRootContext();
-    const { itemProps, multiple, disabled: selectDisabled, readOnly } = useSelectRootPropsContext();
+    const itemProps = store.useState('itemProps');
+    const multiple = store.useState('multiple');
+    const selectDisabled = store.useState('disabled');
+    const readOnly = store.useState('readOnly');
     const disabled = selectDisabled || disabledProp;
     const highlighted = store.useState('isActive', listItem.index);
     const open = store.useState('open');

--- a/packages/react/src/select/list/SelectList.tsx
+++ b/packages/react/src/select/list/SelectList.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import type { BaseUIComponentProps, HTMLProps } from '../../internals/types';
-import { useSelectRootContext, useSelectRootPropsContext } from '../root/SelectRootContext';
+import { useSelectRootContext } from '../root/SelectRootContext';
 import { useSelectPositionerContext } from '../positioner/SelectPositionerContext';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { styleDisableScrollbar } from '../../utils/styles';
@@ -20,7 +20,8 @@ export const SelectList = React.forwardRef(function SelectList(
   const { render, className, style, ...elementProps } = componentProps;
 
   const store = useSelectRootContext();
-  const { multiple, readOnly } = useSelectRootPropsContext();
+  const multiple = store.useState('multiple');
+  const readOnly = store.useState('readOnly');
   const { alignItemWithTriggerActive } = useSelectPositionerContext();
 
   const hasScrollArrows = store.useState('hasScrollArrows');

--- a/packages/react/src/select/popup/SelectPopup.tsx
+++ b/packages/react/src/select/popup/SelectPopup.tsx
@@ -12,11 +12,7 @@ import { clamp } from '@base-ui/utils/clamp';
 import { FloatingFocusManager, platform as floatingPlatform } from '../../floating-ui-react';
 import type { ClientRectObject } from '../../floating-ui-react';
 import type { BaseUIComponentProps, HTMLProps } from '../../internals/types';
-import {
-  useSelectFloatingContext,
-  useSelectRootContext,
-  useSelectRootPropsContext,
-} from '../root/SelectRootContext';
+import { useSelectFloatingContext, useSelectRootContext } from '../root/SelectRootContext';
 import { popupStateMapping } from '../../utils/popupStateMapping';
 import type { Side, Align } from '../../internals/useAnchorPositioning';
 import type { StateAttributesMapping } from '../../internals/getStateAttributesProps';
@@ -54,7 +50,9 @@ export const SelectPopup = React.forwardRef(function SelectPopup(
   const { render, className, style, finalFocus, ...elementProps } = componentProps;
 
   const store = useSelectRootContext();
-  const { multiple, readOnly, highlightItemOnHover } = useSelectRootPropsContext();
+  const multiple = store.useState('multiple');
+  const readOnly = store.useState('readOnly');
+  const highlightItemOnHover = store.useState('highlightItemOnHover');
   const floatingRootContext = useSelectFloatingContext();
   const {
     side,

--- a/packages/react/src/select/root/SelectRoot.tsx
+++ b/packages/react/src/select/root/SelectRoot.tsx
@@ -19,12 +19,7 @@ import {
   useListNavigation,
   useTypeahead,
 } from '../../floating-ui-react';
-import {
-  SelectFloatingContext,
-  SelectRootContext,
-  SelectRootPropsContext,
-  type SelectRootPropsContextValue,
-} from './SelectRootContext';
+import { SelectFloatingContext, SelectRootContext } from './SelectRootContext';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
 import { useRegisterFieldControl } from '../../internals/field-register-control/useRegisterFieldControl';
 import { useLabelableId } from '../../internals/labelable-provider/useLabelableId';
@@ -147,6 +142,10 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
           labelId: undefined,
           modal,
           multiple,
+          disabled,
+          readOnly,
+          required,
+          highlightItemOnHover,
           itemToStringLabel,
           itemToStringValue,
           isItemEqualToValue,
@@ -161,6 +160,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
           selectedIndex: null,
           popupProps: EMPTY_OBJECT,
           triggerProps: EMPTY_OBJECT,
+          itemProps: EMPTY_OBJECT,
           triggerElement: null,
           positionerElement: null,
           listElement: null,
@@ -450,6 +450,7 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
     store.update({
       popupProps,
       triggerProps: mergedTriggerProps,
+      itemProps,
     });
   });
 
@@ -457,30 +458,23 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
     id: generatedId,
     modal,
     multiple,
+    disabled,
+    readOnly,
+    required,
+    highlightItemOnHover,
     value,
     open,
     mounted,
     transitionStatus,
     popupProps,
     triggerProps: mergedTriggerProps,
+    itemProps,
     items,
     itemToStringLabel,
     itemToStringValue,
     isItemEqualToValue,
     openMethod: renderedOpenMethod,
   });
-
-  const rootPropsContextValue: SelectRootPropsContextValue = React.useMemo(
-    () => ({
-      disabled,
-      readOnly,
-      required,
-      multiple,
-      highlightItemOnHover,
-      itemProps,
-    }),
-    [disabled, readOnly, required, multiple, highlightItemOnHover, itemProps],
-  );
 
   const ref = useMergedRefs(inputRef, validation.inputRef);
 
@@ -508,11 +502,9 @@ export function SelectRoot<Value, Multiple extends boolean | undefined = false>(
 
   return (
     <SelectRootContext.Provider value={store}>
-      <SelectRootPropsContext.Provider value={rootPropsContextValue}>
-        <SelectFloatingContext.Provider value={floatingContext}>
-          {children}
-        </SelectFloatingContext.Provider>
-      </SelectRootPropsContext.Provider>
+      <SelectFloatingContext.Provider value={floatingContext}>
+        {children}
+      </SelectFloatingContext.Provider>
       <input
         {...validation.getValidationProps(disabled, {
           onFocus() {

--- a/packages/react/src/select/root/SelectRootContext.ts
+++ b/packages/react/src/select/root/SelectRootContext.ts
@@ -2,25 +2,8 @@
 import * as React from 'react';
 import { type FloatingRootContext } from '../../floating-ui-react';
 import type { SelectStore } from '../store';
-import type { HTMLProps } from '../../internals/types';
-
-/**
- * Root values consumed during render. Keep these outside `useSyncedValues` so descendant ref
- * callbacks see the current props during the same commit.
- */
-export interface SelectRootPropsContextValue {
-  disabled: boolean;
-  readOnly: boolean;
-  required: boolean;
-  multiple: boolean;
-  highlightItemOnHover: boolean;
-  itemProps: HTMLProps;
-}
 
 export const SelectRootContext = React.createContext<SelectStore | undefined>(undefined);
-export const SelectRootPropsContext = React.createContext<SelectRootPropsContextValue | undefined>(
-  undefined,
-);
 export const SelectFloatingContext = React.createContext<FloatingRootContext | undefined>(
   undefined,
 );
@@ -33,16 +16,6 @@ export function useSelectRootContext() {
     );
   }
   return store;
-}
-
-export function useSelectRootPropsContext() {
-  const context = React.useContext(SelectRootPropsContext);
-  if (context === undefined) {
-    throw new Error(
-      'Base UI: SelectRootPropsContext is missing. Select parts must be placed within <Select.Root>.',
-    );
-  }
-  return context;
 }
 
 export function useSelectFloatingContext() {

--- a/packages/react/src/select/store.test.tsx
+++ b/packages/react/src/select/store.test.tsx
@@ -23,14 +23,16 @@ describe('select store synchronization', () => {
   function SynchronizationFixture({
     id,
     modal,
+    disabled,
     storeRef,
   }: {
     id: string;
     modal: boolean;
+    disabled: boolean;
     storeRef: { current: SelectStore | null };
   }) {
     return (
-      <Select.Root id={id} modal={modal}>
+      <Select.Root id={id} modal={modal} disabled={disabled}>
         <StoreProbe storeRef={storeRef} />
         <Select.Trigger />
       </Select.Root>
@@ -40,24 +42,28 @@ describe('select store synchronization', () => {
   it('publishes synchronized values in a single store transaction', async () => {
     const storeRef: { current: SelectStore | null } = { current: null };
     const { setProps } = await render(
-      <SynchronizationFixture id="first" modal storeRef={storeRef} />,
+      <SynchronizationFixture id="first" modal disabled={false} storeRef={storeRef} />,
     );
 
     const store = storeRef.current!;
-    const snapshots: Array<{ id: string | undefined; modal: boolean }> = [];
+    const snapshots: Array<{ id: string | undefined; modal: boolean; disabled: boolean }> = [];
     const unsubscribe = store.subscribe((state) => {
-      snapshots.push({ id: state.id, modal: state.modal });
+      snapshots.push({ id: state.id, modal: state.modal, disabled: state.disabled });
     });
 
     try {
-      await setProps({ id: 'second', modal: false });
+      await setProps({ id: 'second', modal: false, disabled: true });
     } finally {
       unsubscribe();
     }
 
     expect(snapshots.some((snapshot) => snapshot.id === 'second' && snapshot.modal)).toBe(false);
     expect(snapshots.some((snapshot) => snapshot.id === 'first' && !snapshot.modal)).toBe(false);
-    expect(snapshots).toContainEqual({ id: 'second', modal: false });
+    expect(snapshots.some((snapshot) => snapshot.id === 'second' && !snapshot.disabled)).toBe(
+      false,
+    );
+    expect(snapshots.some((snapshot) => snapshot.id === 'first' && snapshot.disabled)).toBe(false);
+    expect(snapshots).toContainEqual({ id: 'second', modal: false, disabled: true });
   });
 
   it('provides setOpen to a descendant ref callback on the first commit', async () => {
@@ -98,7 +104,7 @@ describe('select store synchronization', () => {
     expect(handleOpenChange.mock.calls[0][0]).toBe(true);
   });
 
-  it('makes an updated disabled prop available to item ref callbacks', async () => {
+  it('synchronizes an updated disabled prop after descendant ref callbacks', async () => {
     const handleValueChange = vi.fn();
     let clickOnUpdate = false;
     let clicked = false;
@@ -135,7 +141,11 @@ describe('select store synchronization', () => {
     clickOnUpdate = true;
     await setProps({ disabled: true });
 
+    // The root synchronizes its props in a layout effect, after descendant ref callbacks run.
+    // The item receives the new state in the follow-up render.
     expect(clicked).toBe(true);
-    expect(handleValueChange).not.toHaveBeenCalled();
+    expect(handleValueChange).toHaveBeenCalledTimes(1);
+    expect(handleValueChange.mock.calls[0][0]).toBe('alpha');
+    expect(screen.getByRole('combobox')).toBeDisabled();
   });
 });

--- a/packages/react/src/select/store.ts
+++ b/packages/react/src/select/store.ts
@@ -12,6 +12,10 @@ export type State = {
   labelId: string | undefined;
   modal: boolean;
   multiple: boolean;
+  disabled: boolean;
+  readOnly: boolean;
+  required: boolean;
+  highlightItemOnHover: boolean;
 
   items:
     | Record<string, React.ReactNode>
@@ -35,6 +39,7 @@ export type State = {
 
   popupProps: HTMLProps;
   triggerProps: HTMLProps;
+  itemProps: HTMLProps;
   triggerElement: HTMLElement | null;
   positionerElement: HTMLElement | null;
   listElement: HTMLDivElement | null;
@@ -81,6 +86,11 @@ export const selectors = {
   id: (state: State) => state.id,
   labelId: (state: State) => state.labelId,
   modal: (state: State) => state.modal,
+  multiple: (state: State) => state.multiple,
+  disabled: (state: State) => state.disabled,
+  readOnly: (state: State) => state.readOnly,
+  required: (state: State) => state.required,
+  highlightItemOnHover: (state: State) => state.highlightItemOnHover,
 
   items: (state: State) => state.items,
   itemToStringLabel: (state: State) => state.itemToStringLabel,
@@ -136,6 +146,7 @@ export const selectors = {
 
   popupProps: (state: State) => state.popupProps,
   triggerProps: (state: State) => state.triggerProps,
+  itemProps: (state: State) => state.itemProps,
   triggerElement: (state: State) => state.triggerElement,
   positionerElement: (state: State) => state.positionerElement,
   listElement: (state: State) => state.listElement,

--- a/packages/react/src/select/trigger/SelectTrigger.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { useTimeout } from '@base-ui/utils/useTimeout';
 import { useValueAsRef } from '@base-ui/utils/useValueAsRef';
-import { useSelectRootContext, useSelectRootPropsContext } from '../root/SelectRootContext';
+import { useSelectRootContext } from '../root/SelectRootContext';
 import { BaseUIComponentProps, HTMLProps, NativeButtonProps } from '../../internals/types';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
 import { useLabelableContext } from '../../internals/labelable-provider/LabelableContext';
@@ -61,7 +61,9 @@ export const SelectTrigger = React.forwardRef(function SelectTrigger(
   } = useFieldRootContext();
   const { labelId: fieldLabelId } = useLabelableContext();
   const store = useSelectRootContext();
-  const { readOnly, required, disabled: selectDisabled } = useSelectRootPropsContext();
+  const readOnly = store.useState('readOnly');
+  const required = store.useState('required');
+  const selectDisabled = store.useState('disabled');
   const disabled = fieldDisabled || selectDisabled || disabledProp;
 
   const open = store.useState('open');


### PR DESCRIPTION
Select still sends root values such as `disabled`, `readOnly`, and `required` through a separate React context after #5582. Combobox sends the equivalent values through its selector-based store. This PR makes Select follow the Combobox model.

### What changed

- Move `disabled`, `readOnly`, `required`, `multiple`, `highlightItemOnHover`, and `itemProps` into the Select store.
- Remove `SelectRootPropsContext`.
- Let the trigger, list, popup, and items subscribe only to the values they use.
- Seed `itemProps` before the first descendant render and synchronize later root updates in the existing atomic store transaction.
- Extend the store tests to cover `disabled` synchronization and its commit timing.

### Trade-off

The removed context propagated new root props during the same render. Descendant ref callbacks therefore saw an updated `disabled` value during that commit.

`store.useSyncedValues` publishes changes from the root's layout effect, after descendant ref callbacks have run. Store subscribers then rerender before the browser paints, so the rendered DOM and interactions after the commit use the new value. There is one narrower window: if a consumer performs an imperative interaction from a descendant ref callback during the exact commit that changes `disabled` from `false` to `true`, the handler still sees `false` and can commit a selection. The updated characterization test pins this case.

This gives up Select's stronger same-commit guarantee in that ref-callback window. In return, changing one root value no longer invalidates every consumer of the combined context, including every mounted item, and Select now has the same propagation semantics as Combobox. Keeping synchronous ref-callback behavior would require retaining a separate context with its broader rerender fan-out, or changing the shared store synchronization model for both components.

### Verification

- `pnpm test:jsdom Select --no-watch` (506 passed, 71 skipped)
- `pnpm test:chromium Select --no-watch` (558 passed, 19 skipped)
- `pnpm typescript`
- `pnpm eslint`
- `pnpm prettier`
