### PR TITLE
[slider] Move state to ReactStore

### DIFF
--- a/docs/src/error-codes.json
+++ b/docs/src/error-codes.json
@@ -98,5 +98,6 @@
   "98": "Base UI: OTPFieldRootContext is missing. OTPField parts must be placed within <OTPField.Root>.",
   "99": "Base UI: %sHandle.open() was called with the trigger id \"%s\", but no matching trigger is registered with this handle. An anchored popup cannot open without a trigger to anchor to. Pass the id of a mounted %s.Trigger that has this handle set on its \"handle\" prop.",
   "100": "Base UI: the `items` prop received an object that is not a collection, so its items cannot be read. Pass an array of items, an array of groups with items, or the result of `createItems()`. See https://base-ui.com/react/components/combobox#createitems",
-  "101": "Base UI: SelectRootPropsContext is missing. Select parts must be placed within <Select.Root>."
+  "101": "Base UI: SelectRootPropsContext is missing. Select parts must be placed within <Select.Root>.",
+  "102": "Base UI: SliderRootPropsContext is missing. Slider parts must be placed within <Slider.Root>."
 }

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -94,6 +94,21 @@ describe('<Popover.Root />', () => {
     });
 
     describe('controlled open', () => {
+      it('falls back to the internal open state when the open prop is removed', async () => {
+        const { setProps } = await render(<TestPopover rootProps={{ open: true }} />);
+        expect(screen.getByText('Content')).not.toBe(null);
+
+        await expect(async () => {
+          await setProps({ rootProps: { open: undefined } });
+        }).toErrorDev([
+          'A component is changing the controlled state of openProp to be uncontrolled. Elements should not switch from uncontrolled to controlled (or vice versa).',
+        ]);
+
+        await waitFor(() => {
+          expect(screen.queryByText('Content')).toBe(null);
+        });
+      });
+
       it('should call onChange when the open state changes', async () => {
         const handleChange = vi.fn();
 

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -92,18 +92,14 @@ export const SliderControl = React.forwardRef(function SliderControl(
   const { disabled, inset, renderBeforeHydration, state, thumbCollisionBehavior } =
     useSliderRootPropsContext();
   const { dragging, max, min, minStepsBetweenValues, orientation, step, values } = state;
+  const { registerFieldControlRef, setActive, setDragging, setValue } = store;
   const {
     lastChangeReasonRef,
-    onValueCommitted,
     pressedThumbCenterOffsetRef,
     pressedThumbIndexRef,
     pressedValuesRef,
-    registerFieldControlRef,
-    setActive,
-    setDragging,
-    setValue,
     thumbRefs,
-  } = store;
+  } = store.context;
 
   const direction = useDirection();
   const range = values.length > 1;
@@ -351,7 +347,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
 
     if (currentInteractionValueRef.current != null) {
       const commitReason = lastChangeReasonRef.current;
-      onValueCommitted(
+      store.context.onValueCommitted(
         currentInteractionValueRef.current,
         createGenericEventDetails(commitReason, nativeEvent),
       );

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -92,14 +92,6 @@ export const SliderControl = React.forwardRef(function SliderControl(
   const { disabled, inset, renderBeforeHydration, state, thumbCollisionBehavior } =
     useSliderRootPropsContext();
   const { dragging, max, min, minStepsBetweenValues, orientation, step, values } = state;
-  const { registerFieldControlRef, setActive, setDragging, setValue } = store;
-  const {
-    lastChangeReasonRef,
-    pressedThumbCenterOffsetRef,
-    pressedThumbIndexRef,
-    pressedValuesRef,
-    thumbRefs,
-  } = store.context;
 
   const direction = useDirection();
   const range = values.length > 1;
@@ -128,15 +120,15 @@ export const SliderControl = React.forwardRef(function SliderControl(
   }
 
   function updatePressedThumb(nextIndex: number) {
-    pressedThumbIndexRef.current = nextIndex;
-    if (!thumbRefs.current[nextIndex]) {
-      pressedThumbCenterOffsetRef.current = null;
+    store.context.pressedThumbIndexRef.current = nextIndex;
+    if (!store.context.thumbRefs.current[nextIndex]) {
+      store.context.pressedThumbCenterOffsetRef.current = null;
     }
   }
 
   function resetPressedThumb() {
-    pressedThumbIndexRef.current = -1;
-    pressedThumbCenterOffsetRef.current = null;
+    store.context.pressedThumbIndexRef.current = -1;
+    store.context.pressedThumbCenterOffsetRef.current = null;
   }
 
   function isTargetDisabledThumb(target: EventTarget | null) {
@@ -144,7 +136,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
       return false;
     }
 
-    return thumbRefs.current.some((thumbEl) => {
+    return store.context.thumbRefs.current.some((thumbEl) => {
       if (!isElement(thumbEl) || !contains(thumbEl, target)) {
         return false;
       }
@@ -155,7 +147,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
 
   function getFingerState(fingerCoords: Coords): FingerState | null {
     const control = controlRef.current;
-    const thumbIndex = pressedThumbIndexRef.current;
+    const thumbIndex = store.context.pressedThumbIndexRef.current;
 
     if (!control || thumbIndex < 0 || thumbIndex >= values.length) {
       if (thumbIndex >= values.length) {
@@ -170,7 +162,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
     const insetThumbOffset = insetThumbOffsetRef.current;
     const controlSize =
       (vertical ? height : width) - controlOffset.start - controlOffset.end - insetThumbOffset * 2;
-    const thumbCenterOffset = pressedThumbCenterOffsetRef.current ?? 0;
+    const thumbCenterOffset = store.context.pressedThumbCenterOffsetRef.current ?? 0;
     const fingerX = fingerCoords.x - thumbCenterOffset;
     const fingerY = fingerCoords.y - thumbCenterOffset;
 
@@ -196,7 +188,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
       thumbCollisionBehavior,
       values,
       latestValuesRef.current,
-      pressedValuesRef.current,
+      store.context.pressedValuesRef.current,
       thumbIndex,
       newValue,
       min,
@@ -207,11 +199,11 @@ export const SliderControl = React.forwardRef(function SliderControl(
   }
 
   function startPressing(fingerCoords: Coords) {
-    pressedValuesRef.current = range ? values.slice() : null;
+    store.context.pressedValuesRef.current = range ? values.slice() : null;
     currentInteractionValueRef.current = null;
     latestValuesRef.current = values;
 
-    const pressedThumbIndex = pressedThumbIndexRef.current;
+    const pressedThumbIndex = store.context.pressedThumbIndexRef.current;
     let closestThumbIndex = pressedThumbIndex;
 
     if (pressedThumbIndex > -1 && pressedThumbIndex < values.length) {
@@ -231,8 +223,8 @@ export const SliderControl = React.forwardRef(function SliderControl(
 
       closestThumbIndex = -1;
 
-      for (let i = 0; i < thumbRefs.current.length; i += 1) {
-        const thumbEl = thumbRefs.current[i];
+      for (let i = 0; i < store.context.thumbRefs.current.length; i += 1) {
+        const thumbEl = store.context.thumbRefs.current[i];
         if (isElement(thumbEl) && !getThumbInput(thumbEl)?.disabled) {
           const midpoint = getMidpoint(thumbEl, vertical);
           const distance = Math.abs(fingerCoords[axis] - midpoint);
@@ -250,7 +242,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
     }
 
     if (inset) {
-      const thumbEl = thumbRefs.current[closestThumbIndex];
+      const thumbEl = store.context.thumbRefs.current[closestThumbIndex];
       if (isElement(thumbEl)) {
         const thumbRect = thumbEl.getBoundingClientRect();
         const side = !vertical ? 'width' : 'height';
@@ -260,7 +252,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
   }
 
   function focusThumb(thumbIndex: number) {
-    const input = getThumbInput(thumbRefs.current?.[thumbIndex]);
+    const input = getThumbInput(store.context.thumbRefs.current?.[thumbIndex]);
     if (!input) {
       return;
     }
@@ -278,7 +270,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
     reason: typeof REASONS.trackPress | typeof REASONS.drag,
     nativeEvent: TouchEvent | PointerEvent,
   ) {
-    const applied = setValue(
+    const applied = store.setValue(
       finger.value,
       createChangeEventDetails(reason, nativeEvent, undefined, {
         activeThumbIndex: finger.thumbIndex,
@@ -324,7 +316,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
 
     if (validateMinimumDistance(finger.value, step, minStepsBetweenValues)) {
       if (!dragging && moveCountRef.current > INTENTIONAL_DRAG_COUNT_THRESHOLD) {
-        setDragging(true);
+        store.setDragging(true);
       }
 
       setValueFromPointer(finger, REASONS.drag, nativeEvent);
@@ -332,10 +324,10 @@ export const SliderControl = React.forwardRef(function SliderControl(
   });
 
   const handleTouchEnd = useStableCallback((nativeEvent: TouchEvent | PointerEvent) => {
-    setActive(-1);
-    setDragging(false);
+    store.setActive(-1);
+    store.setDragging(false);
 
-    pressedThumbCenterOffsetRef.current = null;
+    store.context.pressedThumbCenterOffsetRef.current = null;
 
     // If the value array shrank or grew mid-drag, the cached interaction value no longer
     // matches the current thumbs (the pressed index can still be in range), so dropping it
@@ -346,7 +338,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
     }
 
     if (currentInteractionValueRef.current != null) {
-      const commitReason = lastChangeReasonRef.current;
+      const commitReason = store.context.lastChangeReasonRef.current;
       store.context.onValueCommitted(
         currentInteractionValueRef.current,
         createGenericEventDetails(commitReason, nativeEvent),
@@ -360,7 +352,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
       controlRef.current?.releasePointerCapture(nativeEvent.pointerId);
     }
 
-    pressedThumbIndexRef.current = -1;
+    store.context.pressedThumbIndexRef.current = -1;
     touchIdRef.current = null;
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     stopListening();
@@ -407,7 +399,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
     doc.removeEventListener('pointerup', handleTouchEnd);
     doc.removeEventListener('touchmove', handleTouchMove);
     doc.removeEventListener('touchend', handleTouchEnd);
-    pressedValuesRef.current = null;
+    store.context.pressedValuesRef.current = null;
     currentInteractionValueRef.current = null;
   });
 
@@ -439,7 +431,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
 
   const element = useRenderElement('div', componentProps, {
     state,
-    ref: [forwardedRef, registerFieldControlRef, controlRef, setStylesRef],
+    ref: [forwardedRef, store.registerFieldControlRef, controlRef, setStylesRef],
     props: [
       {
         ['data-base-ui-slider-control' as string]: renderBeforeHydration ? '' : undefined,
@@ -473,7 +465,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
           }
 
           const pressedOnFocusedThumb = contains(
-            thumbRefs.current[finger.thumbIndex],
+            store.context.thumbRefs.current[finger.thumbIndex],
             activeElement(ownerDocument(control)),
           );
 
@@ -485,9 +477,9 @@ export const SliderControl = React.forwardRef(function SliderControl(
             });
           }
 
-          setDragging(true);
+          store.setDragging(true);
 
-          const pressedOnAnyThumb = pressedThumbCenterOffsetRef.current != null;
+          const pressedOnAnyThumb = store.context.pressedThumbCenterOffsetRef.current != null;
           if (!pressedOnAnyThumb) {
             setValueFromPointer(finger, REASONS.trackPress, event.nativeEvent);
           }

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -17,7 +17,7 @@ import {
 import { REASONS } from '../../internals/reasons';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { useDirection } from '../../internals/direction-context/DirectionContext';
-import { useSliderRootContext } from '../root/SliderRootContext';
+import { useSliderRootContext, useSliderRootPropsContext } from '../root/SliderRootContext';
 import { sliderStateAttributesMapping } from '../root/stateAttributesMapping';
 import type { SliderRootState } from '../root/SliderRoot';
 import { getMidpoint } from '../utils/getMidpoint';
@@ -88,30 +88,22 @@ export const SliderControl = React.forwardRef(function SliderControl(
 ) {
   const { render: renderProp, className, style, ...elementProps } = componentProps;
 
+  const store = useSliderRootContext();
+  const { disabled, inset, renderBeforeHydration, state, thumbCollisionBehavior } =
+    useSliderRootPropsContext();
+  const { dragging, max, min, minStepsBetweenValues, orientation, step, values } = state;
   const {
-    disabled,
-    dragging,
-    inset,
     lastChangeReasonRef,
-    max,
-    min,
-    minStepsBetweenValues,
     onValueCommitted,
-    orientation,
     pressedThumbCenterOffsetRef,
     pressedThumbIndexRef,
     pressedValuesRef,
     registerFieldControlRef,
-    renderBeforeHydration,
     setActive,
     setDragging,
     setValue,
-    state,
-    step,
-    thumbCollisionBehavior,
     thumbRefs,
-    values,
-  } = useSliderRootContext();
+  } = store;
 
   const direction = useDirection();
   const range = values.length > 1;

--- a/packages/react/src/slider/indicator/SliderIndicator.tsx
+++ b/packages/react/src/slider/indicator/SliderIndicator.tsx
@@ -4,7 +4,7 @@ import type { BaseUIComponentProps } from '../../internals/types';
 import { valueToPercent } from '../../utils/valueToPercent';
 import { useIsHydrating } from '../../utils/useIsHydrating';
 import { useRenderElement } from '../../internals/useRenderElement';
-import { useSliderRootContext } from '../root/SliderRootContext';
+import { useSliderRootContext, useSliderRootPropsContext } from '../root/SliderRootContext';
 import { sliderStateAttributesMapping } from '../root/stateAttributesMapping';
 import type { SliderRootState } from '../root/SliderRoot';
 
@@ -56,8 +56,10 @@ export const SliderIndicator = React.forwardRef(function SliderIndicator(
 ) {
   const { render, className, style: styleProp, ...elementProps } = componentProps;
 
-  const { indicatorPosition, inset, max, min, orientation, renderBeforeHydration, state, values } =
-    useSliderRootContext();
+  const store = useSliderRootContext();
+  const indicatorPosition = store.useState('indicatorPosition');
+  const { inset, renderBeforeHydration, state } = useSliderRootPropsContext();
+  const { max, min, orientation, values } = state;
 
   const isHydrating = useIsHydrating();
 

--- a/packages/react/src/slider/label/SliderLabel.tsx
+++ b/packages/react/src/slider/label/SliderLabel.tsx
@@ -6,7 +6,7 @@ import { focusElementWithVisible, useLabel } from '../../internals/labelable-pro
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
 import type { SliderRoot } from '../root/SliderRoot';
-import { useSliderRootContext } from '../root/SliderRootContext';
+import { useSliderRootContext, useSliderRootPropsContext } from '../root/SliderRootContext';
 import { sliderStateAttributesMapping } from '../root/stateAttributesMapping';
 
 /**
@@ -24,7 +24,9 @@ export const SliderLabel = React.forwardRef(function SliderLabel(
   const elementPropsWithoutId = elementProps as typeof elementProps & { id?: string | undefined };
   delete elementPropsWithoutId.id;
 
-  const { state, setLabelId, controlRef, rootLabelId } = useSliderRootContext();
+  const store = useSliderRootContext();
+  const { rootLabelId, state } = useSliderRootPropsContext();
+  const { setLabelId, controlRef } = store;
 
   function focusControl(event: React.MouseEvent, controlId: string | undefined) {
     if (controlId) {

--- a/packages/react/src/slider/label/SliderLabel.tsx
+++ b/packages/react/src/slider/label/SliderLabel.tsx
@@ -26,8 +26,6 @@ export const SliderLabel = React.forwardRef(function SliderLabel(
 
   const store = useSliderRootContext();
   const { rootLabelId, state } = useSliderRootPropsContext();
-  const { setLabelId } = store;
-  const { controlRef } = store.context;
 
   function focusControl(event: React.MouseEvent, controlId: string | undefined) {
     if (controlId) {
@@ -38,7 +36,8 @@ export const SliderLabel = React.forwardRef(function SliderLabel(
       }
     }
 
-    const fallbackInputs = controlRef.current?.querySelectorAll('input[type="range"]');
+    const fallbackInputs =
+      store.context.controlRef.current?.querySelectorAll('input[type="range"]');
     const fallbackInput = fallbackInputs?.length === 1 ? fallbackInputs[0] : null;
     if (isHTMLElement(fallbackInput)) {
       focusElementWithVisible(fallbackInput);
@@ -47,7 +46,7 @@ export const SliderLabel = React.forwardRef(function SliderLabel(
 
   const labelProps = useLabel({
     id: rootLabelId,
-    setLabelId,
+    setLabelId: store.setLabelId,
     focusControl,
   });
 

--- a/packages/react/src/slider/label/SliderLabel.tsx
+++ b/packages/react/src/slider/label/SliderLabel.tsx
@@ -26,7 +26,8 @@ export const SliderLabel = React.forwardRef(function SliderLabel(
 
   const store = useSliderRootContext();
   const { rootLabelId, state } = useSliderRootPropsContext();
-  const { setLabelId, controlRef } = store;
+  const { setLabelId } = store;
+  const { controlRef } = store.context;
 
   function focusControl(event: React.MouseEvent, controlId: string | undefined) {
     if (controlId) {

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -28,7 +28,7 @@ import {
   type SliderRootPropsContextValue,
 } from './SliderRootContext';
 import { SliderStore } from '../store';
-import { REASONS } from '../../internals/reasons';
+import type { REASONS } from '../../internals/reasons';
 
 /**
  * Groups all parts of the slider.
@@ -102,11 +102,9 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
       minStepsBetweenValues,
       name,
       step,
-      interaction: {
-        active: -1,
-        dragging: false,
-        lastUsedThumbIndex: -1,
-      },
+      active: -1,
+      dragging: false,
+      lastUsedThumbIndex: -1,
       indicatorPosition: [undefined, undefined],
       registeredLabelId: undefined,
       thumbMap: new Map(),
@@ -117,8 +115,8 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
   const valueUnwrapped = store.useState('renderValue', valueProp);
   const range = Array.isArray(valueUnwrapped);
 
-  // The internal value is potentially unsorted, e.g. to support frozen arrays.
-  // https://github.com/mui/material-ui/pull/28472
+  // Derived from the render-time value and bounds so descendants (including ref callbacks) see
+  // the current props in this commit, before the store is synchronized in a layout effect.
   const values = store.useState('values', valueUnwrapped, min, max);
 
   const fieldValue = range ? values : values[0];
@@ -140,7 +138,8 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     setDirty(isDirty);
   });
 
-  const { active, dragging } = store.useState('interaction');
+  const active = store.useState('active');
+  const dragging = store.useState('dragging');
   const registeredLabelId = store.useState('registeredLabelId');
   const ariaLabelledby =
     ariaLabelledByProp ?? resolveAriaLabelledBy(fieldLabelId, registeredLabelId);
@@ -257,7 +256,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
   return (
     <SliderRootContext.Provider value={store}>
       <SliderRootPropsContext.Provider value={rootPropsContextValue}>
-        <CompositeList elementsRef={store.thumbRefs} onMapChange={store.setThumbMap}>
+        <CompositeList elementsRef={store.context.thumbRefs} onMapChange={store.setThumbMap}>
           {element}
         </CompositeList>
       </SliderRootPropsContext.Provider>

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -115,8 +115,6 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
   const valueUnwrapped = store.useState('renderValue', valueProp);
   const range = Array.isArray(valueUnwrapped);
 
-  // Derived from the render-time value and bounds so descendants (including ref callbacks) see
-  // the current props in this commit, before the store is synchronized in a layout effect.
   const values = store.useState('values', valueUnwrapped, min, max);
 
   const fieldValue = range ? values : values[0];

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -1,16 +1,12 @@
 'use client';
 import * as React from 'react';
 import { ownerDocument } from '@base-ui/utils/owner';
-import { useControlled } from '@base-ui/utils/useControlled';
-import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { warn } from '@base-ui/utils/warn';
-import { clamp } from '@base-ui/utils/clamp';
 import { areArraysEqual } from '@base-ui/utils/areArraysEqual';
+import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import type { BaseUIComponentProps, Orientation } from '../../internals/types';
 import {
-  createChangeEventDetails,
-  createGenericEventDetails,
   type BaseUIChangeEventDetails,
   type BaseUIGenericEventDetails,
 } from '../../internals/createBaseUIEventDetails';
@@ -18,33 +14,21 @@ import { useValueChanged } from '../../internals/useValueChanged';
 import { useBaseUiId } from '../../internals/useBaseUiId';
 import { useRenderElement } from '../../internals/useRenderElement';
 import { activeElement, contains } from '../../floating-ui-react/utils';
-import {
-  CompositeList,
-  type CompositeMetadata,
-} from '../../internals/composite/list/CompositeList';
+import { CompositeList } from '../../internals/composite/list/CompositeList';
 import type { FieldRootState } from '../../field/root/FieldRoot';
 import { useFieldRootContext } from '../../internals/field-root-context/FieldRootContext';
 import { useRegisterFieldControl } from '../../internals/field-register-control/useRegisterFieldControl';
 import { useFormContext } from '../../internals/form-context/FormContext';
 import { useLabelableContext } from '../../internals/labelable-provider/LabelableContext';
 import { resolveAriaLabelledBy, getDefaultLabelId } from '../../utils/resolveAriaLabelledBy';
-import { asc } from '../utils/asc';
-import { getSliderValue } from '../utils/getSliderValue';
-import { validateMinimumDistance } from '../utils/validateMinimumDistance';
-import type { ThumbMetadata } from '../thumb/SliderThumb';
 import { sliderStateAttributesMapping } from './stateAttributesMapping';
-import { SliderRootContext } from './SliderRootContext';
+import {
+  SliderRootContext,
+  SliderRootPropsContext,
+  type SliderRootPropsContextValue,
+} from './SliderRootContext';
+import { SliderStore } from '../store';
 import { REASONS } from '../../internals/reasons';
-
-function areValuesEqual(
-  newValue: number | readonly number[],
-  oldValue: number | readonly number[],
-) {
-  return (
-    newValue === oldValue ||
-    (Array.isArray(newValue) && Array.isArray(oldValue) && areArraysEqual(newValue, oldValue))
-  );
-}
 
 /**
  * Groups all parts of the slider.
@@ -83,18 +67,6 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
 
   const id = useBaseUiId(idProp);
   const defaultLabelId = getDefaultLabelId(id);
-  const onValueChange = useStableCallback(
-    onValueChangeProp as (
-      value: number | number[],
-      eventDetails: SliderRoot.ChangeEventDetails,
-    ) => void,
-  );
-  const onValueCommitted = useStableCallback(
-    onValueCommittedProp as (
-      value: number | readonly number[],
-      eventDetails: SliderRoot.CommitEventDetails,
-    ) => void,
-  );
 
   const { clearErrors } = useFormContext();
   const {
@@ -107,69 +79,47 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     validation,
   } = useFieldRootContext();
   const { labelId: fieldLabelId } = useLabelableContext();
-  const [labelId, setLabelId] = React.useState<string | undefined>();
 
-  const ariaLabelledby = ariaLabelledByProp ?? resolveAriaLabelledBy(fieldLabelId, labelId);
   const disabled = fieldDisabled || disabledProp;
   const name = fieldName ?? nameProp;
 
-  // The internal value is potentially unsorted, e.g. to support frozen arrays
-  // https://github.com/mui/material-ui/pull/28472
-  const [valueUnwrapped, setValueUnwrapped] = useControlled({
-    controlled: valueProp,
-    default: defaultValue ?? min,
-    name: 'Slider',
-  });
-
   const sliderRef = React.useRef<HTMLElement>(null);
-  const controlRef = React.useRef<HTMLElement>(null);
-  const thumbRefs = React.useRef<(HTMLElement | null)[]>([]);
-  // The px distance between the pointer and the center of a pressed thumb.
-  const pressedThumbCenterOffsetRef = React.useRef<number | null>(null);
-  // The index of the pressed thumb, or the closest thumb if the `Control` was pressed.
-  // This is updated on pointerdown, which is sooner than the `active/activeIndex`
-  // state which is updated later when the nested `input` receives focus.
-  const pressedThumbIndexRef = React.useRef(-1);
-  // The values when the current drag interaction started.
-  const pressedValuesRef = React.useRef<readonly number[] | null>(null);
-  const lastChangeReasonRef = React.useRef<SliderRoot.ChangeEventReason>(REASONS.none);
 
-  // We can't use the :active browser pseudo-classes.
-  // - The active state isn't triggered when clicking on the rail.
-  // - The active state isn't transferred when inversing a range slider.
-  const [active, setActiveState] = React.useState(-1);
-  const [lastUsedThumbIndex, setLastUsedThumbIndex] = React.useState(-1);
-  const [dragging, setDragging] = React.useState(false);
-  const [thumbMap, setThumbMap] = React.useState(
-    () => new Map<Node, CompositeMetadata<ThumbMetadata>>(),
-  );
-  const [indicatorPosition, setIndicatorPosition] = React.useState<(number | undefined)[]>([
-    undefined,
-    undefined,
-  ]);
-
-  const setActive = useStableCallback((value: number) => {
-    setActiveState(value);
-
-    if (value !== -1) {
-      setLastUsedThumbIndex(value);
+  /* istanbul ignore else -- `process.env.NODE_ENV` is a build-time constant under test */
+  if (process.env.NODE_ENV !== 'production') {
+    if (min >= max) {
+      warn('Slider `max` must be greater than `min`.');
     }
-  });
+  }
 
-  const registerFieldControlRef = useStableCallback((element: HTMLElement | null) => {
-    if (element) {
-      controlRef.current = element;
-    }
-  });
+  const store = useRefWithInit(() => {
+    return new SliderStore({
+      value: defaultValue ?? min,
+      valueProp,
+      disabled,
+      max,
+      min,
+      minStepsBetweenValues,
+      name,
+      step,
+      interaction: {
+        active: -1,
+        dragging: false,
+        lastUsedThumbIndex: -1,
+      },
+      indicatorPosition: [undefined, undefined],
+      registeredLabelId: undefined,
+      thumbMap: new Map(),
+    });
+  }).current;
 
+  store.useControlledProp('valueProp', valueProp);
+  const valueUnwrapped = store.useState('renderValue', valueProp);
   const range = Array.isArray(valueUnwrapped);
 
-  const values = React.useMemo(() => {
-    if (!range) {
-      return [clamp(valueUnwrapped as number, min, max)];
-    }
-    return valueUnwrapped.map((value) => clamp(value, min, max)).sort(asc);
-  }, [max, min, range, valueUnwrapped]);
+  // The internal value is potentially unsorted, e.g. to support frozen arrays.
+  // https://github.com/mui/material-ui/pull/28472
+  const values = store.useState('values', valueUnwrapped, min, max);
 
   const fieldValue = range ? values : values[0];
 
@@ -190,86 +140,10 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     setDirty(isDirty);
   });
 
-  const setValue = useStableCallback(
-    (newValue: number | number[], details: SliderRoot.ChangeEventDetails) => {
-      if (Number.isNaN(newValue) || areValuesEqual(newValue, valueUnwrapped)) {
-        return false;
-      }
-
-      // Redefine target to allow name and value to be read.
-      // This allows seamless integration with the most popular form libraries.
-      // https://github.com/mui/material-ui/issues/13485#issuecomment-676048492
-      // Clone the event to not override `target` of the original event.
-      const nativeEvent = details.event;
-      const EventConstructor = nativeEvent.constructor as typeof Event;
-      const clonedEvent = new EventConstructor(nativeEvent.type, nativeEvent);
-
-      Object.defineProperty(clonedEvent, 'target', {
-        writable: true,
-        value: { value: newValue, name },
-      });
-
-      details.event = clonedEvent;
-
-      onValueChange(newValue, details);
-
-      if (details.isCanceled) {
-        return false;
-      }
-
-      lastChangeReasonRef.current = details.reason;
-
-      setValueUnwrapped(newValue as Value);
-
-      return true;
-    },
-  );
-
-  const handleInputChange = useStableCallback(
-    (valueInput: number, index: number, event: React.KeyboardEvent | React.ChangeEvent) => {
-      const newValue = getSliderValue(valueInput, index, min, max, range, values);
-
-      if (validateMinimumDistance(newValue, step, minStepsBetweenValues)) {
-        const reason = 'key' in event ? REASONS.keyboard : REASONS.inputChange;
-        const applied = setValue(
-          newValue,
-          createChangeEventDetails(reason, event.nativeEvent, undefined, {
-            activeThumbIndex: index,
-          }),
-        );
-        setTouched(true);
-
-        if (applied) {
-          onValueCommitted(newValue, createGenericEventDetails(reason, event.nativeEvent));
-        }
-      }
-    },
-  );
-
-  /* istanbul ignore else -- `process.env.NODE_ENV` is a build-time constant under test */
-  if (process.env.NODE_ENV !== 'production') {
-    if (min >= max) {
-      warn('Slider `max` must be greater than `min`.');
-    }
-  }
-
-  useIsoLayoutEffect(() => {
-    if (!disabled) {
-      return;
-    }
-
-    const activeEl = activeElement(ownerDocument(sliderRef.current));
-    if (contains(sliderRef.current, activeEl)) {
-      // This is necessary because Firefox and Safari will keep focus
-      // on a disabled element:
-      // https://codesandbox.io/p/sandbox/mui-pr-22247-forked-h151h?file=/src/App.js
-      (activeEl as HTMLElement).blur();
-    }
-
-    if (active !== -1) {
-      setActive(-1);
-    }
-  }, [active, disabled, setActive]);
+  const { active, dragging } = store.useState('interaction');
+  const registeredLabelId = store.useState('registeredLabelId');
+  const ariaLabelledby =
+    ariaLabelledByProp ?? resolveAriaLabelledBy(fieldLabelId, registeredLabelId);
 
   const state: SliderRootState = React.useMemo(
     () => ({
@@ -298,76 +172,70 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     ],
   );
 
-  const contextValue: SliderRootContext = React.useMemo(
+  store.useContextCallback(
+    'onValueChange',
+    onValueChangeProp as
+      ((value: number | number[], eventDetails: SliderRoot.ChangeEventDetails) => void) | undefined,
+  );
+  store.useContextCallback(
+    'onValueCommitted',
+    onValueCommittedProp as
+      | ((value: number | readonly number[], eventDetails: SliderRoot.CommitEventDetails) => void)
+      | undefined,
+  );
+  store.useContextCallback('setTouched', setTouched);
+  store.useSyncedValues({
+    disabled,
+    max,
+    min,
+    minStepsBetweenValues,
+    name,
+    step,
+  });
+
+  useIsoLayoutEffect(() => {
+    if (!disabled) {
+      return;
+    }
+
+    const activeEl = activeElement(ownerDocument(sliderRef.current));
+    if (contains(sliderRef.current, activeEl)) {
+      // This is necessary because Firefox and Safari will keep focus
+      // on a disabled element:
+      // https://codesandbox.io/p/sandbox/mui-pr-22247-forked-h151h?file=/src/App.js
+      (activeEl as HTMLElement).blur();
+    }
+  }, [disabled]);
+
+  const rootPropsContextValue: SliderRootPropsContextValue = React.useMemo(
     () => ({
-      active,
-      controlRef,
       disabled,
-      dragging,
+      state,
       validation,
       format,
-      handleInputChange,
-      indicatorPosition,
       inset: thumbAlignment !== 'center',
       labelId: ariaLabelledby,
       rootLabelId: defaultLabelId,
       largeStep,
-      lastUsedThumbIndex,
-      lastChangeReasonRef,
-      form,
       locale,
-      max,
-      min,
-      minStepsBetweenValues,
+      form,
       name,
-      onValueCommitted,
-      orientation,
-      pressedThumbCenterOffsetRef,
-      pressedThumbIndexRef,
-      pressedValuesRef,
-      registerFieldControlRef,
       renderBeforeHydration: thumbAlignment === 'edge',
-      setActive,
-      setDragging,
-      setIndicatorPosition,
-      setLabelId,
-      setValue,
-      state,
-      step,
       thumbCollisionBehavior,
-      thumbMap,
-      thumbRefs,
-      values,
     }),
     [
-      active,
       ariaLabelledby,
       defaultLabelId,
       disabled,
-      dragging,
-      validation,
       format,
-      handleInputChange,
-      indicatorPosition,
-      largeStep,
-      lastUsedThumbIndex,
       form,
+      largeStep,
       locale,
-      max,
-      min,
-      minStepsBetweenValues,
       name,
-      onValueCommitted,
-      orientation,
-      registerFieldControlRef,
-      setActive,
-      setValue,
       state,
-      step,
-      thumbCollisionBehavior,
       thumbAlignment,
-      thumbMap,
-      values,
+      thumbCollisionBehavior,
+      validation,
     ],
   );
 
@@ -387,10 +255,12 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
   });
 
   return (
-    <SliderRootContext.Provider value={contextValue}>
-      <CompositeList elementsRef={thumbRefs} onMapChange={setThumbMap}>
-        {element}
-      </CompositeList>
+    <SliderRootContext.Provider value={store}>
+      <SliderRootPropsContext.Provider value={rootPropsContextValue}>
+        <CompositeList elementsRef={store.thumbRefs} onMapChange={store.setThumbMap}>
+          {element}
+        </CompositeList>
+      </SliderRootPropsContext.Provider>
     </SliderRootContext.Provider>
   );
 }) as {

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -28,6 +28,7 @@ import {
   type SliderRootPropsContextValue,
 } from './SliderRootContext';
 import { SliderStore } from '../store';
+import { normalizeValues } from '../utils/normalizeValues';
 import type { REASONS } from '../../internals/reasons';
 
 /**
@@ -115,7 +116,10 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
   const valueUnwrapped = store.useState('renderValue', valueProp);
   const range = Array.isArray(valueUnwrapped);
 
-  const values = store.useState('values', valueUnwrapped, min, max);
+  const values = React.useMemo(
+    () => normalizeValues(valueUnwrapped, min, max),
+    [max, min, valueUnwrapped],
+  );
 
   const fieldValue = range ? values : values[0];
 

--- a/packages/react/src/slider/root/SliderRootContext.ts
+++ b/packages/react/src/slider/root/SliderRootContext.ts
@@ -1,113 +1,45 @@
 'use client';
 import * as React from 'react';
-import type { Orientation } from '../../internals/types';
-import type { CompositeMetadata } from '../../internals/composite/list/CompositeList';
 import type { UseFieldValidationReturnValue } from '../../field/root/useFieldValidation';
-import type { ThumbMetadata } from '../thumb/SliderThumb';
+import type { SliderStore } from '../store';
 import type { SliderRoot, SliderRootState } from './SliderRoot';
 
-export interface SliderRootContext {
-  /**
-   * The index of the active thumb.
-   */
-  active: number;
-  /**
-   * The index of the most recently interacted thumb.
-   */
-  lastUsedThumbIndex: number;
-  controlRef: React.RefObject<HTMLElement | null>;
-  dragging: boolean;
+export interface SliderRootPropsContextValue {
   disabled: boolean;
+  state: SliderRootState;
   validation: UseFieldValidationReturnValue;
-  /**
-   * Options to format the value.
-   */
   format: Intl.NumberFormatOptions | undefined;
-  handleInputChange: (
-    valueInput: number,
-    index: number,
-    event: React.KeyboardEvent | React.ChangeEvent,
-  ) => void;
-  indicatorPosition: (number | undefined)[];
   inset: boolean;
-  labelId?: string | undefined;
-  rootLabelId?: string | undefined;
-  /**
-   * The large step value of the slider when incrementing or decrementing while the shift key is held,
-   * or when using Page-Up or Page-Down keys. Snaps to multiples of this value.
-   * @default 10
-   */
+  labelId: string | undefined;
+  rootLabelId: string | undefined;
   largeStep: number;
-  lastChangeReasonRef: React.RefObject<SliderRoot.ChangeEventReason>;
-  /**
-   * The locale used by `Intl.NumberFormat` when formatting the value.
-   * Defaults to the user's runtime locale.
-   */
-  locale?: Intl.LocalesArgument | undefined;
-  /**
-   * The maximum allowed value of the slider.
-   */
-  max: number;
-  /**
-   * The minimum allowed value of the slider.
-   */
-  min: number;
-  /**
-   * The minimum steps between values in a range slider.
-   */
-  minStepsBetweenValues: number;
+  locale: Intl.LocalesArgument | undefined;
   form: string | undefined;
   name: string | undefined;
-  /**
-   * Function to be called when drag ends and the pointer is released.
-   */
-  onValueCommitted: (
-    newValue: number | readonly number[],
-    data: SliderRoot.CommitEventDetails,
-  ) => void;
-  /**
-   * The component orientation.
-   * @default 'horizontal'
-   */
-  orientation: Orientation;
-  pressedThumbCenterOffsetRef: React.RefObject<number | null>;
-  pressedThumbIndexRef: React.RefObject<number>;
-  pressedValuesRef: React.RefObject<readonly number[] | null>;
   renderBeforeHydration: boolean;
-  registerFieldControlRef: React.RefCallback<Element> | null;
-  setActive: (index: number) => void;
-  setDragging: React.Dispatch<React.SetStateAction<boolean>>;
-  setIndicatorPosition: React.Dispatch<React.SetStateAction<(number | undefined)[]>>;
-  setLabelId: React.Dispatch<React.SetStateAction<string | undefined>>;
-  /**
-   * Applies a new value through `onValueChange` for keyboard, input, track-press,
-   * and drag interactions. Returns `true` when the value was applied, or `false`
-   * when it was invalid (NaN), unchanged, or the change was canceled.
-   */
-  setValue: (newValue: number | number[], details: SliderRoot.ChangeEventDetails) => boolean;
-  state: SliderRootState;
-  /**
-   * The step increment of the slider when incrementing or decrementing. It will snap
-   * to multiples of this value. Decimal values are supported.
-   * @default 1
-   */
-  step: number;
-  thumbCollisionBehavior: 'push' | 'swap' | 'none';
-  thumbMap: Map<Node, CompositeMetadata<ThumbMetadata>>;
-  thumbRefs: React.RefObject<(HTMLElement | null)[]>;
-  /**
-   * The value(s) of the slider
-   */
-  values: readonly number[];
+  thumbCollisionBehavior: NonNullable<SliderRoot.Props['thumbCollisionBehavior']>;
 }
 
-export const SliderRootContext = React.createContext<SliderRootContext | undefined>(undefined);
+export const SliderRootContext = React.createContext<SliderStore | undefined>(undefined);
+export const SliderRootPropsContext = React.createContext<SliderRootPropsContextValue | undefined>(
+  undefined,
+);
 
 export function useSliderRootContext() {
-  const context = React.useContext(SliderRootContext);
-  if (context === undefined) {
+  const store = React.useContext(SliderRootContext);
+  if (store === undefined) {
     throw new Error(
       'Base UI: SliderRootContext is missing. Slider parts must be placed within <Slider.Root>.',
+    );
+  }
+  return store;
+}
+
+export function useSliderRootPropsContext() {
+  const context = React.useContext(SliderRootPropsContext);
+  if (context === undefined) {
+    throw new Error(
+      'Base UI: SliderRootPropsContext is missing. Slider parts must be placed within <Slider.Root>.',
     );
   }
   return context;

--- a/packages/react/src/slider/root/SliderRootContext.ts
+++ b/packages/react/src/slider/root/SliderRootContext.ts
@@ -4,6 +4,17 @@ import type { UseFieldValidationReturnValue } from '../../field/root/useFieldVal
 import type { SliderStore } from '../store';
 import type { SliderRoot, SliderRootState } from './SliderRoot';
 
+/**
+ * Derived from the public prop so the literal union stays the single source of truth.
+ */
+export type SliderThumbCollisionBehavior = NonNullable<SliderRoot.Props['thumbCollisionBehavior']>;
+
+/**
+ * Root values consumed during render. Keep these outside `useSyncedValues` so descendant ref
+ * callbacks see the current props during the same commit: the store is only synchronized in a
+ * layout effect, after descendants have rendered. `state` lives here for the same reason, since
+ * it carries `values`, `activeThumbIndex`, and `dragging`.
+ */
 export interface SliderRootPropsContextValue {
   disabled: boolean;
   state: SliderRootState;
@@ -17,7 +28,7 @@ export interface SliderRootPropsContextValue {
   form: string | undefined;
   name: string | undefined;
   renderBeforeHydration: boolean;
-  thumbCollisionBehavior: NonNullable<SliderRoot.Props['thumbCollisionBehavior']>;
+  thumbCollisionBehavior: SliderThumbCollisionBehavior;
 }
 
 export const SliderRootContext = React.createContext<SliderStore | undefined>(undefined);

--- a/packages/react/src/slider/root/SliderRootContext.ts
+++ b/packages/react/src/slider/root/SliderRootContext.ts
@@ -4,16 +4,11 @@ import type { UseFieldValidationReturnValue } from '../../field/root/useFieldVal
 import type { SliderStore } from '../store';
 import type { SliderRoot, SliderRootState } from './SliderRoot';
 
-/**
- * Derived from the public prop so the literal union stays the single source of truth.
- */
 export type SliderThumbCollisionBehavior = NonNullable<SliderRoot.Props['thumbCollisionBehavior']>;
 
 /**
  * Root values consumed during render. Keep these outside `useSyncedValues` so descendant ref
- * callbacks see the current props during the same commit: the store is only synchronized in a
- * layout effect, after descendants have rendered. `state` lives here for the same reason, since
- * it carries `values`, `activeThumbIndex`, and `dragging`.
+ * callbacks see the current props during the same commit.
  */
 export interface SliderRootPropsContextValue {
   disabled: boolean;

--- a/packages/react/src/slider/store.test.tsx
+++ b/packages/react/src/slider/store.test.tsx
@@ -71,16 +71,11 @@ describe('slider store', () => {
     }
 
     const { setProps } = await render(<Fixture value={10} />);
-    const initialValue = storeRef.current!.select('value');
-    const initialValues = storeRef.current!.select('values', initialValue, 0, 100);
+    expect(storeRef.current!.select('value')).toBe(10);
 
     await setProps({ value: 40 });
 
-    const value = storeRef.current!.select('value');
-    const values = storeRef.current!.select('values', value, 0, 100);
-    expect(value).toBe(40);
-    expect(values).toEqual([40]);
-    expect(values).not.toBe(initialValues);
+    expect(storeRef.current!.select('value')).toBe(40);
     expect(screen.getByRole('slider')).toHaveValue('40');
   });
 
@@ -101,24 +96,6 @@ describe('slider store', () => {
     await setProps({ max: 30 });
 
     expect(screen.getByRole('slider')).toHaveAttribute('aria-valuenow', '30');
-  });
-
-  it('keeps the values of the previous arguments cached', async () => {
-    const storeRef: { current: SliderStore | null } = { current: null };
-
-    await render(
-      <Slider.Root defaultValue={10}>
-        <StoreProbe storeRef={storeRef} />
-      </Slider.Root>,
-    );
-
-    const store = storeRef.current!;
-    const first = store.select('values', 10, 0, 100);
-    const second = store.select('values', 20, 0, 100);
-
-    expect(store.select('values', 10, 0, 100)).toBe(first);
-    expect(store.select('values', 20, 0, 100)).toBe(second);
-    expect(store.select('values', NaN, 0, 100)).toBe(store.select('values', NaN, 0, 100));
   });
 
   it('renders a NaN value without an update loop', async () => {

--- a/packages/react/src/slider/store.test.tsx
+++ b/packages/react/src/slider/store.test.tsx
@@ -1,0 +1,325 @@
+import { expect, vi } from 'vitest';
+import * as React from 'react';
+import { act, screen } from '@mui/internal-test-utils';
+import { createRenderer } from '#test-utils';
+import { Slider } from '@base-ui/react/slider';
+import { useSliderRootContext, useSliderRootPropsContext } from './root/SliderRootContext';
+import type { SliderStore } from './store';
+import type { SliderRootState } from './root/SliderRoot';
+
+describe('slider store', () => {
+  const { render } = createRenderer();
+
+  function StoreProbe({ storeRef }: { storeRef: { current: SliderStore | null } }) {
+    storeRef.current = useSliderRootContext();
+    return null;
+  }
+
+  function StateProbe({ stateRef }: { stateRef: { current: SliderRootState | null } }) {
+    stateRef.current = useSliderRootPropsContext().state;
+    return null;
+  }
+
+  it('publishes external values in a single transaction', async () => {
+    const storeRef: { current: SliderStore | null } = { current: null };
+
+    function Fixture({ disabled, max }: { disabled: boolean; max: number }) {
+      return (
+        <Slider.Root disabled={disabled} max={max}>
+          <StoreProbe storeRef={storeRef} />
+          <Slider.Control>
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>
+      );
+    }
+
+    const { setProps } = await render(<Fixture disabled={false} max={100} />);
+    const store = storeRef.current!;
+    const snapshots: Array<{ disabled: boolean; max: number }> = [];
+    const unsubscribe = store.subscribe((storeState) => {
+      snapshots.push({
+        disabled: storeState.disabled,
+        max: storeState.max,
+      });
+    });
+
+    try {
+      await setProps({ disabled: true, max: 200 });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(snapshots.some((snapshot) => snapshot.disabled && snapshot.max === 100)).toBe(false);
+    expect(snapshots.some((snapshot) => !snapshot.disabled && snapshot.max === 200)).toBe(false);
+    expect(snapshots).toContainEqual({ disabled: true, max: 200 });
+  });
+
+  it('synchronizes a controlled value through the store', async () => {
+    const storeRef: { current: SliderStore | null } = { current: null };
+
+    function Fixture({ value }: { value: number }) {
+      return (
+        <Slider.Root value={value}>
+          <StoreProbe storeRef={storeRef} />
+          <Slider.Control>
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>
+      );
+    }
+
+    const { setProps } = await render(<Fixture value={10} />);
+    const initialValue = storeRef.current!.select('value');
+    const initialValues = storeRef.current!.select('values', initialValue, 0, 100);
+
+    await setProps({ value: 40 });
+
+    const value = storeRef.current!.select('value');
+    const values = storeRef.current!.select('values', value, 0, 100);
+    expect(value).toBe(40);
+    expect(values).toEqual([40]);
+    expect(values).not.toBe(initialValues);
+    expect(screen.getByRole('slider')).toHaveValue('40');
+  });
+
+  it('provides commands to descendant ref callbacks on the first commit', async () => {
+    const storeRef: { current: SliderStore | null } = { current: null };
+    const stateRef: { current: SliderRootState | null } = { current: null };
+    let invoked = false;
+
+    function CommandProbe() {
+      const store = useSliderRootContext();
+      storeRef.current = store;
+
+      return (
+        <div
+          ref={(element) => {
+            if (element && !invoked) {
+              invoked = true;
+              store.setActive(0);
+            }
+          }}
+        />
+      );
+    }
+
+    await render(
+      <Slider.Root>
+        <CommandProbe />
+        <StateProbe stateRef={stateRef} />
+        <Slider.Control>
+          <Slider.Thumb />
+        </Slider.Control>
+      </Slider.Root>,
+    );
+
+    expect(invoked).toBe(true);
+    expect(storeRef.current!.state.interaction.active).toBe(0);
+    expect(stateRef.current!.activeThumbIndex).toBe(0);
+  });
+
+  it('uses the current disabled prop during descendant ref callbacks', async () => {
+    let observeOnUpdate = false;
+    let observedDisabled: boolean | undefined;
+
+    function DisabledProbe() {
+      const { disabled } = useSliderRootPropsContext();
+
+      return (
+        <div
+          ref={(element) => {
+            if (element && observeOnUpdate) {
+              observedDisabled = disabled;
+            }
+          }}
+        />
+      );
+    }
+
+    function Fixture({ disabled }: { disabled: boolean }) {
+      return (
+        <Slider.Root disabled={disabled}>
+          <DisabledProbe />
+        </Slider.Root>
+      );
+    }
+
+    const { setProps } = await render(<Fixture disabled={false} />);
+
+    observeOnUpdate = true;
+    await setProps({ disabled: true });
+
+    expect(observedDisabled).toBe(true);
+  });
+
+  it('uses the current controlled value during descendant ref callbacks', async () => {
+    let observeOnUpdate = false;
+    let observedValue: string | undefined;
+
+    function Fixture({ value }: { value: number }) {
+      return (
+        <Slider.Root value={value}>
+          <Slider.Control>
+            <Slider.Thumb
+              inputRef={(input) => {
+                if (input && observeOnUpdate) {
+                  observedValue = input.value;
+                }
+              }}
+            />
+          </Slider.Control>
+        </Slider.Root>
+      );
+    }
+
+    const { setProps } = await render(<Fixture value={10} />);
+
+    observeOnUpdate = true;
+    await setProps({ value: 40 });
+
+    expect(observedValue).toBe('40');
+  });
+
+  it('uses the latest value change callbacks', async () => {
+    const initialOnValueChange = vi.fn();
+    const initialOnValueCommitted = vi.fn();
+    const nextOnValueChange = vi.fn();
+    const nextOnValueCommitted = vi.fn();
+
+    function Fixture(props: {
+      onValueChange: (value: number | number[]) => void;
+      onValueCommitted: (value: number | readonly number[]) => void;
+    }) {
+      return (
+        <Slider.Root defaultValue={0} {...props}>
+          <Slider.Control>
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>
+      );
+    }
+
+    const { setProps, user } = await render(
+      <Fixture onValueChange={initialOnValueChange} onValueCommitted={initialOnValueCommitted} />,
+    );
+
+    await setProps({
+      onValueChange: nextOnValueChange,
+      onValueCommitted: nextOnValueCommitted,
+    });
+
+    const input = screen.getByRole('slider');
+    act(() => input.focus());
+    await user.keyboard('[ArrowRight]');
+
+    expect(initialOnValueChange).not.toHaveBeenCalled();
+    expect(initialOnValueCommitted).not.toHaveBeenCalled();
+    expect(nextOnValueChange).toHaveBeenCalledWith(1, expect.any(Object));
+    expect(nextOnValueCommitted).toHaveBeenCalledWith(1, expect.any(Object));
+  });
+
+  it('keeps the active thumb reset while disabled', async () => {
+    const storeRef: { current: SliderStore | null } = { current: null };
+    const stateRef: { current: SliderRootState | null } = { current: null };
+
+    await render(
+      <Slider.Root disabled>
+        <StoreProbe storeRef={storeRef} />
+        <StateProbe stateRef={stateRef} />
+      </Slider.Root>,
+    );
+
+    act(() => {
+      storeRef.current!.setActive(0);
+    });
+
+    expect(storeRef.current!.state.interaction.active).toBe(-1);
+    expect(stateRef.current!.activeThumbIndex).toBe(-1);
+  });
+
+  it('resets the active thumb in one transaction when becoming disabled', async () => {
+    const storeRef: { current: SliderStore | null } = { current: null };
+    const stateRef: { current: SliderRootState | null } = { current: null };
+
+    function Fixture({ disabled }: { disabled: boolean }) {
+      return (
+        <Slider.Root disabled={disabled}>
+          <StoreProbe storeRef={storeRef} />
+          <StateProbe stateRef={stateRef} />
+        </Slider.Root>
+      );
+    }
+
+    const { setProps } = await render(<Fixture disabled={false} />);
+
+    act(() => storeRef.current!.setActive(0));
+
+    const snapshots: Array<{ active: number; disabled: boolean }> = [];
+    const unsubscribe = storeRef.current!.subscribe((storeState) => {
+      snapshots.push({
+        active: storeState.interaction.active,
+        disabled: storeState.disabled,
+      });
+    });
+
+    try {
+      await setProps({ disabled: true });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(snapshots.some((snapshot) => snapshot.disabled && snapshot.active !== -1)).toBe(false);
+    expect(storeRef.current!.state.interaction.active).toBe(-1);
+    expect(stateRef.current!.activeThumbIndex).toBe(-1);
+  });
+
+  it('publishes interaction state once per command', async () => {
+    const storeRef: { current: SliderStore | null } = { current: null };
+
+    await render(
+      <Slider.Root>
+        <StoreProbe storeRef={storeRef} />
+      </Slider.Root>,
+    );
+
+    const snapshots: number[] = [];
+    const unsubscribe = storeRef.current!.subscribe((storeState) => {
+      snapshots.push(storeState.interaction.active);
+    });
+
+    try {
+      act(() => storeRef.current!.setActive(0));
+    } finally {
+      unsubscribe();
+    }
+
+    expect(snapshots).toEqual([0]);
+  });
+
+  it('does not notify public-state subscribers for indicator measurements', async () => {
+    const storeRef: { current: SliderStore | null } = { current: null };
+    const renderSpy = vi.fn();
+
+    const PublicStateProbe = React.memo(function PublicStateProbe() {
+      useSliderRootPropsContext();
+      renderSpy();
+      return null;
+    });
+
+    await render(
+      <Slider.Root>
+        <StoreProbe storeRef={storeRef} />
+        <PublicStateProbe />
+      </Slider.Root>,
+    );
+
+    const renderCount = renderSpy.mock.calls.length;
+
+    act(() => {
+      storeRef.current!.set('indicatorPosition', [25, 75]);
+    });
+
+    expect(renderSpy).toHaveBeenCalledTimes(renderCount);
+  });
+});

--- a/packages/react/src/slider/store.test.tsx
+++ b/packages/react/src/slider/store.test.tsx
@@ -1,8 +1,9 @@
 import { expect, vi } from 'vitest';
 import * as React from 'react';
-import { act, screen } from '@mui/internal-test-utils';
+import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';
 import { Slider } from '@base-ui/react/slider';
+import { Field } from '@base-ui/react/field';
 import { useSliderRootContext, useSliderRootPropsContext } from './root/SliderRootContext';
 import type { SliderStore } from './store';
 import type { SliderRootState } from './root/SliderRoot';
@@ -83,6 +84,117 @@ describe('slider store', () => {
     expect(screen.getByRole('slider')).toHaveValue('40');
   });
 
+  it('clamps the value to updated bounds', async () => {
+    function Fixture({ max }: { max: number }) {
+      return (
+        <Slider.Root value={50} max={max}>
+          <Slider.Control>
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>
+      );
+    }
+
+    const { setProps } = await render(<Fixture max={100} />);
+    expect(screen.getByRole('slider')).toHaveAttribute('aria-valuenow', '50');
+
+    await setProps({ max: 30 });
+
+    expect(screen.getByRole('slider')).toHaveAttribute('aria-valuenow', '30');
+  });
+
+  it('keeps the values of the previous arguments cached', async () => {
+    const storeRef: { current: SliderStore | null } = { current: null };
+
+    await render(
+      <Slider.Root defaultValue={10}>
+        <StoreProbe storeRef={storeRef} />
+      </Slider.Root>,
+    );
+
+    const store = storeRef.current!;
+    const first = store.select('values', 10, 0, 100);
+    const second = store.select('values', 20, 0, 100);
+
+    expect(store.select('values', 10, 0, 100)).toBe(first);
+    expect(store.select('values', 20, 0, 100)).toBe(second);
+    expect(store.select('values', NaN, 0, 100)).toBe(store.select('values', NaN, 0, 100));
+  });
+
+  it('renders a NaN value without an update loop', async () => {
+    await expect(async () => {
+      await render(
+        <Slider.Root value={NaN}>
+          <Slider.Control>
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>,
+      );
+    }).toErrorDev(['Received NaN for the `value` attribute.']);
+
+    expect(screen.getByRole('slider')).toBeInTheDocument();
+  });
+
+  it('commits once per value change when controlled', async () => {
+    const validate = vi.fn(() => null);
+    const onValueChange = vi.fn();
+
+    function Fixture() {
+      const [value, setValue] = React.useState<number[]>([20, 50]);
+      return (
+        <Field.Root validate={validate} validationMode="onChange">
+          <Slider.Root
+            value={value}
+            onValueChange={(nextValue) => {
+              onValueChange(nextValue);
+              setValue(nextValue);
+            }}
+          >
+            <Slider.Control>
+              <Slider.Thumb />
+              <Slider.Thumb />
+            </Slider.Control>
+          </Slider.Root>
+        </Field.Root>
+      );
+    }
+
+    const { user } = await render(<Fixture />);
+    const [input] = screen.getAllByRole('slider');
+    act(() => input.focus());
+    validate.mockClear();
+
+    await user.keyboard('[ArrowRight]');
+
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(validate).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports rejected changes against the controlled value', async () => {
+    const storeRef: { current: SliderStore | null } = { current: null };
+    const onValueChange = vi.fn();
+
+    const { user } = await render(
+      <Slider.Root value={0} onValueChange={onValueChange}>
+        <StoreProbe storeRef={storeRef} />
+        <Slider.Control>
+          <Slider.Thumb />
+        </Slider.Control>
+      </Slider.Root>,
+    );
+
+    const input = screen.getByRole('slider');
+    act(() => input.focus());
+    await user.keyboard('[ArrowRight]');
+    await user.keyboard('[ArrowRight]');
+
+    expect(onValueChange).toHaveBeenCalledTimes(2);
+    expect(onValueChange).toHaveBeenNthCalledWith(1, 1, expect.any(Object));
+    expect(onValueChange).toHaveBeenNthCalledWith(2, 1, expect.any(Object));
+    expect(input).toHaveAttribute('aria-valuenow', '0');
+    expect(storeRef.current!.state.value).toBe(0);
+  });
+
   it('provides commands to descendant ref callbacks on the first commit', async () => {
     const storeRef: { current: SliderStore | null } = { current: null };
     const stateRef: { current: SliderRootState | null } = { current: null };
@@ -115,7 +227,7 @@ describe('slider store', () => {
     );
 
     expect(invoked).toBe(true);
-    expect(storeRef.current!.state.interaction.active).toBe(0);
+    expect(storeRef.current!.state.active).toBe(0);
     expect(stateRef.current!.activeThumbIndex).toBe(0);
   });
 
@@ -155,7 +267,7 @@ describe('slider store', () => {
 
   it('uses the current controlled value during descendant ref callbacks', async () => {
     let observeOnUpdate = false;
-    let observedValue: string | undefined;
+    const observedValues: string[] = [];
 
     function Fixture({ value }: { value: number }) {
       return (
@@ -164,7 +276,7 @@ describe('slider store', () => {
             <Slider.Thumb
               inputRef={(input) => {
                 if (input && observeOnUpdate) {
-                  observedValue = input.value;
+                  observedValues.push(input.value);
                 }
               }}
             />
@@ -178,7 +290,7 @@ describe('slider store', () => {
     observeOnUpdate = true;
     await setProps({ value: 40 });
 
-    expect(observedValue).toBe('40');
+    expect(observedValues[0]).toBe('40');
   });
 
   it('uses the latest value change callbacks', async () => {
@@ -219,6 +331,48 @@ describe('slider store', () => {
     expect(nextOnValueCommitted).toHaveBeenCalledWith(1, expect.any(Object));
   });
 
+  it('marks the field as touched on keyboard changes', async () => {
+    const { user } = await render(
+      <Field.Root>
+        <Slider.Root data-testid="root">
+          <Slider.Control>
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>
+      </Field.Root>,
+    );
+
+    const root = screen.getByTestId('root');
+    const input = screen.getByRole('slider');
+    act(() => input.focus());
+    expect(root).not.toHaveAttribute('data-touched');
+
+    await user.keyboard('[ArrowRight]');
+
+    expect(root).toHaveAttribute('data-touched', '');
+  });
+
+  it('uses the field name on the change event target', async () => {
+    const onValueChange = vi
+      .fn()
+      .mockImplementation((newValue, details) => (details as any).event.target);
+
+    await render(
+      <Field.Root name="field-slider">
+        <Slider.Root value={3} onValueChange={onValueChange}>
+          <Slider.Control>
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>
+      </Field.Root>,
+    );
+
+    fireEvent.change(screen.getByRole('slider'), { target: { value: 4 } });
+
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange.mock.results[0]?.value).toEqual({ value: 4, name: 'field-slider' });
+  });
+
   it('keeps the active thumb reset while disabled', async () => {
     const storeRef: { current: SliderStore | null } = { current: null };
     const stateRef: { current: SliderRootState | null } = { current: null };
@@ -234,19 +388,32 @@ describe('slider store', () => {
       storeRef.current!.setActive(0);
     });
 
-    expect(storeRef.current!.state.interaction.active).toBe(-1);
+    expect(storeRef.current!.state.active).toBe(-1);
     expect(stateRef.current!.activeThumbIndex).toBe(-1);
   });
 
-  it('resets the active thumb in one transaction when becoming disabled', async () => {
+  it('resets the active thumb before the disabled commit can be observed', async () => {
     const storeRef: { current: SliderStore | null } = { current: null };
     const stateRef: { current: SliderRootState | null } = { current: null };
+    const observed: Array<{ disabled: boolean; active: number }> = [];
+
+    // Passive effects run after every layout effect of the commit, which is the earliest
+    // anything outside the slider (or the browser paint) can observe the new `disabled` prop.
+    function EffectProbe() {
+      const store = useSliderRootContext();
+      const { disabled } = useSliderRootPropsContext();
+      React.useEffect(() => {
+        observed.push({ disabled, active: store.state.active });
+      });
+      return null;
+    }
 
     function Fixture({ disabled }: { disabled: boolean }) {
       return (
         <Slider.Root disabled={disabled}>
           <StoreProbe storeRef={storeRef} />
           <StateProbe stateRef={stateRef} />
+          <EffectProbe />
         </Slider.Root>
       );
     }
@@ -254,23 +421,13 @@ describe('slider store', () => {
     const { setProps } = await render(<Fixture disabled={false} />);
 
     act(() => storeRef.current!.setActive(0));
+    expect(stateRef.current!.activeThumbIndex).toBe(0);
+    observed.length = 0;
 
-    const snapshots: Array<{ active: number; disabled: boolean }> = [];
-    const unsubscribe = storeRef.current!.subscribe((storeState) => {
-      snapshots.push({
-        active: storeState.interaction.active,
-        disabled: storeState.disabled,
-      });
-    });
+    await setProps({ disabled: true });
 
-    try {
-      await setProps({ disabled: true });
-    } finally {
-      unsubscribe();
-    }
-
-    expect(snapshots.some((snapshot) => snapshot.disabled && snapshot.active !== -1)).toBe(false);
-    expect(storeRef.current!.state.interaction.active).toBe(-1);
+    expect(observed.some((entry) => entry.disabled && entry.active !== -1)).toBe(false);
+    expect(observed.at(-1)).toEqual({ disabled: true, active: -1 });
     expect(stateRef.current!.activeThumbIndex).toBe(-1);
   });
 
@@ -283,43 +440,56 @@ describe('slider store', () => {
       </Slider.Root>,
     );
 
-    const snapshots: number[] = [];
+    const snapshots: Array<{ active: number; lastUsedThumbIndex: number }> = [];
     const unsubscribe = storeRef.current!.subscribe((storeState) => {
-      snapshots.push(storeState.interaction.active);
+      snapshots.push({
+        active: storeState.active,
+        lastUsedThumbIndex: storeState.lastUsedThumbIndex,
+      });
     });
 
     try {
       act(() => storeRef.current!.setActive(0));
+      act(() => storeRef.current!.setActive(-1));
     } finally {
       unsubscribe();
     }
 
-    expect(snapshots).toEqual([0]);
+    expect(snapshots).toEqual([
+      { active: 0, lastUsedThumbIndex: 0 },
+      { active: -1, lastUsedThumbIndex: 0 },
+    ]);
   });
 
-  it('does not notify public-state subscribers for indicator measurements', async () => {
+  it('does not re-render the root for indicator measurements', async () => {
     const storeRef: { current: SliderStore | null } = { current: null };
-    const renderSpy = vi.fn();
-
-    const PublicStateProbe = React.memo(function PublicStateProbe() {
-      useSliderRootPropsContext();
-      renderSpy();
-      return null;
-    });
+    const rootRenders = vi.fn();
 
     await render(
-      <Slider.Root>
+      <Slider.Root
+        render={(props) => {
+          rootRenders();
+          return <div {...props} />;
+        }}
+      >
         <StoreProbe storeRef={storeRef} />
-        <PublicStateProbe />
       </Slider.Root>,
     );
 
-    const renderCount = renderSpy.mock.calls.length;
+    const store = storeRef.current!;
+    const renderCount = rootRenders.mock.calls.length;
+    const notifications = vi.fn();
+    const unsubscribe = store.subscribe(notifications);
 
-    act(() => {
-      storeRef.current!.set('indicatorPosition', [25, 75]);
-    });
+    try {
+      act(() => store.setIndicatorPosition(0, 25));
+      act(() => store.setIndicatorPosition(0, 25));
+    } finally {
+      unsubscribe();
+    }
 
-    expect(renderSpy).toHaveBeenCalledTimes(renderCount);
+    expect(notifications).toHaveBeenCalledTimes(1);
+    expect(store.state.indicatorPosition).toEqual([25, undefined]);
+    expect(rootRenders).toHaveBeenCalledTimes(renderCount);
   });
 });

--- a/packages/react/src/slider/store.test.tsx
+++ b/packages/react/src/slider/store.test.tsx
@@ -397,8 +397,6 @@ describe('slider store', () => {
     const stateRef: { current: SliderRootState | null } = { current: null };
     const observed: Array<{ disabled: boolean; active: number }> = [];
 
-    // Passive effects run after every layout effect of the commit, which is the earliest
-    // anything outside the slider (or the browser paint) can observe the new `disabled` prop.
     function EffectProbe() {
       const store = useSliderRootContext();
       const { disabled } = useSliderRootPropsContext();

--- a/packages/react/src/slider/store.test.tsx
+++ b/packages/react/src/slider/store.test.tsx
@@ -172,6 +172,42 @@ describe('slider store', () => {
     expect(storeRef.current!.state.value).toBe(0);
   });
 
+  it('falls back to the internal value when the controlled value is removed', async () => {
+    const storeRef: { current: SliderStore | null } = { current: null };
+    const onValueChange = vi.fn();
+
+    function Fixture({ value }: { value: number | undefined }) {
+      return (
+        <Slider.Root value={value} onValueChange={onValueChange}>
+          <StoreProbe storeRef={storeRef} />
+          <Slider.Control>
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>
+      );
+    }
+
+    const { setProps, user } = await render(<Fixture value={40} />);
+    const input = screen.getByRole('slider');
+    expect(input).toHaveAttribute('aria-valuenow', '40');
+
+    await expect(async () => {
+      await setProps({ value: undefined });
+    }).toErrorDev([
+      'A component is changing the controlled state of valueProp to be uncontrolled. Elements should not switch from uncontrolled to controlled (or vice versa).',
+    ]);
+
+    // Renders the internal (default) value, and commands compute from the same value.
+    expect(input).toHaveAttribute('aria-valuenow', '0');
+    expect(storeRef.current!.select('value')).toBe(0);
+
+    act(() => input.focus());
+    await user.keyboard('[ArrowRight]');
+
+    expect(onValueChange).toHaveBeenCalledWith(1, expect.any(Object));
+    expect(input).toHaveAttribute('aria-valuenow', '1');
+  });
+
   it('provides commands to descendant ref callbacks on the first commit', async () => {
     const storeRef: { current: SliderStore | null } = { current: null };
     const stateRef: { current: SliderRootState | null } = { current: null };

--- a/packages/react/src/slider/store.ts
+++ b/packages/react/src/slider/store.ts
@@ -23,8 +23,6 @@ export interface SliderStoreState {
   value: number | readonly number[];
   /**
    * The value of the slider (external prop).
-   * Synchronized by `useControlledProp` in a layout effect, so it lags one commit behind the
-   * render that received a new prop. Use the `renderValue` selector during render.
    */
   readonly valueProp: number | readonly number[] | undefined;
   disabled: boolean;
@@ -74,12 +72,8 @@ export interface SliderStoreContext {
   readonly thumbRefs: React.RefObject<(HTMLElement | null)[]>;
 
   // Callback props. Seeded with `NOOP` when the store is constructed and assigned during the
-  // root's render through `useContextCallback`, so they are not `readonly`.
+  // root's render, so they are not `readonly`.
   onValueChange: (value: number | number[], eventDetails: SliderRoot.ChangeEventDetails) => void;
-  /**
-   * Called when a value change is committed: when a drag ends, or immediately for keyboard
-   * and input changes.
-   */
   onValueCommitted: (
     value: number | readonly number[],
     eventDetails: SliderRoot.CommitEventDetails,
@@ -94,20 +88,9 @@ interface ValuesCacheEntry {
   values: readonly number[];
 }
 
-/**
- * Selectors are created per store because `values` memoizes its result.
- *
- * `values` is keyed on its `(value, min, max)` arguments rather than on the store state: the
- * root passes render-time props so it can derive `values` during the render that received
- * them, before `useControlledProp` and `useSyncedValues` write them into the store in a layout
- * effect. Descendant ref callbacks therefore see the current values in the same commit.
- *
- * The cache keeps the two most recent entries. `useSyncExternalStore` only swaps a
- * subscription's snapshot function in a passive effect, so a store write during layout effects
- * (`useControlledProp`, `setIndicatorPosition`) still reads through the previous render's
- * arguments. A single entry would be evicted by the new arguments, produce a new array reference
- * for the old ones, and force an extra render of the whole slider on every value change.
- */
+// Created per store: `values` is keyed on render-time arguments (the store is only synchronized
+// in a layout effect) and keeps the two most recent results, because `useSyncExternalStore`
+// still reads through the previous render's arguments until its passive effect runs.
 function createSelectors() {
   let current: ValuesCacheEntry | undefined;
   let previous: ValuesCacheEntry | undefined;
@@ -122,21 +105,13 @@ function createSelectors() {
   }
 
   return {
-    /**
-     * The current value, used by commands after the store has been synchronized.
-     */
     value: (storeState: SliderStoreState) => storeState.valueProp ?? storeState.value,
-    /**
-     * The value to render. Takes the `value` prop as an argument because `state.valueProp` is
-     * only synchronized in a layout effect and is stale during the render that changed it.
-     */
+    // Takes the `value` prop as an argument because `state.valueProp` is stale during the render
+    // that changed it.
     renderValue: (
       storeState: SliderStoreState,
       valueProp: number | readonly number[] | undefined,
     ) => valueProp ?? storeState.value,
-    /**
-     * The normalized values: one per thumb, clamped to the bounds and sorted.
-     */
     values: (
       _storeState: SliderStoreState,
       value: number | readonly number[],
@@ -195,13 +170,8 @@ export class SliderStore extends ReactStore<
       createSelectors(),
     );
 
-    // Resets the active thumb when the slider becomes disabled.
-    // This must stay the first listener registered on the store: `Store.setState` stops
-    // notifying the remaining listeners once a nested update has run, so React subscribers only
-    // ever observe `{ disabled: true, active: -1 }` as a single transaction. Registering it
-    // later (for example from an effect in the root) would let them render the intermediate
-    // state. The unsubscribe function is discarded on purpose: the observer only references
-    // this store and shares its lifetime.
+    // Must be the first listener registered on the store so React subscribers never observe
+    // `disabled` with an active thumb. Never unsubscribed: the observer shares the store's lifetime.
     void this.observe('activeWhileDisabled', (activeWhileDisabled) => {
       if (activeWhileDisabled) {
         this.setActive(-1);
@@ -209,13 +179,13 @@ export class SliderStore extends ReactStore<
     });
   }
 
-  readonly registerFieldControlRef = (element: HTMLElement | null) => {
+  registerFieldControlRef = (element: HTMLElement | null) => {
     if (element) {
       this.context.controlRef.current = element;
     }
   };
 
-  readonly setActive = (index: number) => {
+  setActive = (index: number) => {
     if (index === -1) {
       this.set('active', -1);
     } else {
@@ -223,23 +193,23 @@ export class SliderStore extends ReactStore<
     }
   };
 
-  readonly setDragging = (dragging: boolean) => {
+  setDragging = (dragging: boolean) => {
     this.set('dragging', dragging);
   };
 
-  readonly setIndicatorPosition = (index: 0 | 1, value: number | undefined) => {
+  setIndicatorPosition = (index: 0 | 1, value: number | undefined) => {
     const current = this.state.indicatorPosition;
     if (current[index] !== value) {
       this.set('indicatorPosition', index === 0 ? [value, current[1]] : [current[0], value]);
     }
   };
 
-  readonly setLabelId: React.Dispatch<React.SetStateAction<string | undefined>> = (value) => {
+  setLabelId: React.Dispatch<React.SetStateAction<string | undefined>> = (value) => {
     const current = this.state.registeredLabelId;
     this.set('registeredLabelId', typeof value === 'function' ? value(current) : value);
   };
 
-  readonly setThumbMap = (thumbMap: Map<Node, CompositeMetadata<ThumbMetadata>>) => {
+  setThumbMap = (thumbMap: Map<Node, CompositeMetadata<ThumbMetadata>>) => {
     this.set('thumbMap', thumbMap);
   };
 
@@ -248,7 +218,7 @@ export class SliderStore extends ReactStore<
    * and drag interactions. Returns `true` when the value was applied, or `false`
    * when it was invalid (NaN), unchanged, or the change was canceled.
    */
-  readonly setValue = (newValue: number | number[], details: SliderRoot.ChangeEventDetails) => {
+  setValue = (newValue: number | number[], details: SliderRoot.ChangeEventDetails) => {
     const value = this.select('value');
     if (Number.isNaN(newValue) || areValuesEqual(newValue, value)) {
       return false;
@@ -276,8 +246,6 @@ export class SliderStore extends ReactStore<
 
     this.context.lastChangeReasonRef.current = details.reason;
 
-    // Only the uncontrolled value lives in the store. When controlled, the parent owns the
-    // value and reflects the change through the `value` prop.
     if (this.state.valueProp === undefined) {
       this.set('value', newValue);
     }
@@ -285,7 +253,7 @@ export class SliderStore extends ReactStore<
     return true;
   };
 
-  readonly handleInputChange = (
+  handleInputChange = (
     valueInput: number,
     index: number,
     event: React.KeyboardEvent | React.ChangeEvent,

--- a/packages/react/src/slider/store.ts
+++ b/packages/react/src/slider/store.ts
@@ -15,7 +15,17 @@ import { validateMinimumDistance } from './utils/validateMinimumDistance';
 import { asc } from './utils/asc';
 
 export interface SliderStoreState {
+  /**
+   * The value of the slider (internal state).
+   * Potentially unsorted, e.g. to support frozen arrays.
+   * https://github.com/mui/material-ui/pull/28472
+   */
   value: number | readonly number[];
+  /**
+   * The value of the slider (external prop).
+   * Synchronized by `useControlledProp` in a layout effect, so it lags one commit behind the
+   * render that received a new prop. Use the `renderValue` selector during render.
+   */
   readonly valueProp: number | readonly number[] | undefined;
   disabled: boolean;
   max: number;
@@ -23,18 +33,53 @@ export interface SliderStoreState {
   minStepsBetweenValues: number;
   name: string | undefined;
   step: number;
-  interaction: {
-    active: number;
-    dragging: boolean;
-    lastUsedThumbIndex: number;
-  };
+  /**
+   * The index of the active thumb.
+   * We can't use the `:active` browser pseudo-class:
+   * - The active state isn't triggered when clicking on the rail.
+   * - The active state isn't transferred when inversing a range slider.
+   */
+  active: number;
+  dragging: boolean;
+  /**
+   * The index of the most recently interacted thumb.
+   */
+  lastUsedThumbIndex: number;
   indicatorPosition: (number | undefined)[];
   registeredLabelId: string | undefined;
   thumbMap: Map<Node, CompositeMetadata<ThumbMetadata>>;
 }
 
-interface SliderStoreContext {
+/**
+ * Non-reactive values shared with the slider parts. Nothing here is observable through
+ * `selectors`, so writing to a ref never notifies subscribers.
+ */
+export interface SliderStoreContext {
+  readonly controlRef: React.RefObject<HTMLElement | null>;
+  readonly lastChangeReasonRef: React.RefObject<SliderRoot.ChangeEventReason>;
+  /**
+   * The px distance between the pointer and the center of a pressed thumb.
+   */
+  readonly pressedThumbCenterOffsetRef: React.RefObject<number | null>;
+  /**
+   * The index of the pressed thumb, or the closest thumb if the `Control` was pressed.
+   * This is updated on pointerdown, which is sooner than the `active` state which is
+   * updated later when the nested `input` receives focus.
+   */
+  readonly pressedThumbIndexRef: React.RefObject<number>;
+  /**
+   * The values when the current drag interaction started.
+   */
+  readonly pressedValuesRef: React.RefObject<readonly number[] | null>;
+  readonly thumbRefs: React.RefObject<(HTMLElement | null)[]>;
+
+  // Callback props. Seeded with `NOOP` when the store is constructed and assigned during the
+  // root's render through `useContextCallback`, so they are not `readonly`.
   onValueChange: (value: number | number[], eventDetails: SliderRoot.ChangeEventDetails) => void;
+  /**
+   * Called when a value change is committed: when a drag ends, or immediately for keyboard
+   * and input changes.
+   */
   onValueCommitted: (
     value: number | readonly number[],
     eventDetails: SliderRoot.CommitEventDetails,
@@ -42,38 +87,84 @@ interface SliderStoreContext {
   setTouched: (touched: boolean) => void;
 }
 
+interface ValuesCacheEntry {
+  value: number | readonly number[];
+  min: number;
+  max: number;
+  values: readonly number[];
+}
+
+/**
+ * Selectors are created per store because `values` memoizes its result.
+ *
+ * `values` is keyed on its `(value, min, max)` arguments rather than on the store state: the
+ * root passes render-time props so it can derive `values` during the render that received
+ * them, before `useControlledProp` and `useSyncedValues` write them into the store in a layout
+ * effect. Descendant ref callbacks therefore see the current values in the same commit.
+ *
+ * The cache keeps the two most recent entries. `useSyncExternalStore` only swaps a
+ * subscription's snapshot function in a passive effect, so a store write during layout effects
+ * (`useControlledProp`, `setIndicatorPosition`) still reads through the previous render's
+ * arguments. A single entry would be evicted by the new arguments, produce a new array reference
+ * for the old ones, and force an extra render of the whole slider on every value change.
+ */
 function createSelectors() {
-  let cachedValue: number | readonly number[] | undefined;
-  let cachedMin: number | undefined;
-  let cachedMax: number | undefined;
-  let cachedValues: readonly number[] = [];
+  let current: ValuesCacheEntry | undefined;
+  let previous: ValuesCacheEntry | undefined;
+
+  function matches(entry: ValuesCacheEntry | undefined, value: unknown, min: number, max: number) {
+    return (
+      entry !== undefined &&
+      Object.is(entry.value, value) &&
+      Object.is(entry.min, min) &&
+      Object.is(entry.max, max)
+    );
+  }
 
   return {
+    /**
+     * The current value, used by commands after the store has been synchronized.
+     */
     value: (storeState: SliderStoreState) => storeState.valueProp ?? storeState.value,
+    /**
+     * The value to render. Takes the `value` prop as an argument because `state.valueProp` is
+     * only synchronized in a layout effect and is stale during the render that changed it.
+     */
     renderValue: (
       storeState: SliderStoreState,
       valueProp: number | readonly number[] | undefined,
     ) => valueProp ?? storeState.value,
+    /**
+     * The normalized values: one per thumb, clamped to the bounds and sorted.
+     */
     values: (
       _storeState: SliderStoreState,
       value: number | readonly number[],
       min: number,
       max: number,
     ) => {
-      if (cachedValue !== value || cachedMin !== min || cachedMax !== max) {
-        cachedValue = value;
-        cachedMin = min;
-        cachedMax = max;
-        cachedValues = Array.isArray(value)
-          ? value.map((item) => clamp(item, min, max)).sort(asc)
-          : [clamp(value as number, min, max)];
+      if (matches(current, value, min, max)) {
+        return current!.values;
       }
 
-      return cachedValues;
+      if (matches(previous, value, min, max)) {
+        return previous!.values;
+      }
+
+      const values = Array.isArray(value)
+        ? value.map((item) => clamp(item, min, max)).sort(asc)
+        : [clamp(value as number, min, max)];
+
+      previous = current;
+      current = { value, min, max, values };
+
+      return values;
     },
+    active: (storeState: SliderStoreState) => storeState.active,
     activeWhileDisabled: (storeState: SliderStoreState) =>
-      storeState.disabled && storeState.interaction.active !== -1,
-    interaction: (storeState: SliderStoreState) => storeState.interaction,
+      storeState.disabled && storeState.active !== -1,
+    dragging: (storeState: SliderStoreState) => storeState.dragging,
+    lastUsedThumbIndex: (storeState: SliderStoreState) => storeState.lastUsedThumbIndex,
     indicatorPosition: (storeState: SliderStoreState) => storeState.indicatorPosition,
     registeredLabelId: (storeState: SliderStoreState) => storeState.registeredLabelId,
     thumbMap: (storeState: SliderStoreState) => storeState.thumbMap,
@@ -91,6 +182,12 @@ export class SliderStore extends ReactStore<
     super(
       state,
       {
+        controlRef: { current: null },
+        lastChangeReasonRef: { current: REASONS.none },
+        pressedThumbCenterOffsetRef: { current: null },
+        pressedThumbIndexRef: { current: -1 },
+        pressedValuesRef: { current: null },
+        thumbRefs: { current: [] },
         onValueChange: NOOP,
         onValueCommitted: NOOP,
         setTouched: NOOP,
@@ -98,7 +195,13 @@ export class SliderStore extends ReactStore<
       createSelectors(),
     );
 
-    // The observer and its listener are both owned by this store and share its lifetime.
+    // Resets the active thumb when the slider becomes disabled.
+    // This must stay the first listener registered on the store: `Store.setState` stops
+    // notifying the remaining listeners once a nested update has run, so React subscribers only
+    // ever observe `{ disabled: true, active: -1 }` as a single transaction. Registering it
+    // later (for example from an effect in the root) would let them render the intermediate
+    // state. The unsubscribe function is discarded on purpose: the observer only references
+    // this store and shares its lifetime.
     void this.observe('activeWhileDisabled', (activeWhileDisabled) => {
       if (activeWhileDisabled) {
         this.setActive(-1);
@@ -106,49 +209,22 @@ export class SliderStore extends ReactStore<
     });
   }
 
-  readonly controlRef: React.RefObject<HTMLElement | null> = { current: null };
-
-  readonly lastChangeReasonRef: React.RefObject<SliderRoot.ChangeEventReason> = {
-    current: REASONS.none,
-  };
-
-  readonly pressedThumbCenterOffsetRef: React.RefObject<number | null> = { current: null };
-
-  readonly pressedThumbIndexRef: React.RefObject<number> = { current: -1 };
-
-  readonly pressedValuesRef: React.RefObject<readonly number[] | null> = { current: null };
-
-  readonly thumbRefs: React.RefObject<(HTMLElement | null)[]> = { current: [] };
-
   readonly registerFieldControlRef = (element: HTMLElement | null) => {
     if (element) {
-      this.controlRef.current = element;
+      this.context.controlRef.current = element;
     }
   };
 
   readonly setActive = (index: number) => {
-    const { interaction } = this.state;
-    const { active, lastUsedThumbIndex } = interaction;
-    const nextLastUsedThumbIndex = index === -1 ? lastUsedThumbIndex : index;
-
-    if (active === index && lastUsedThumbIndex === nextLastUsedThumbIndex) {
-      return;
+    if (index === -1) {
+      this.set('active', -1);
+    } else {
+      this.update({ active: index, lastUsedThumbIndex: index });
     }
-
-    this.update({
-      interaction: {
-        ...interaction,
-        active: index,
-        lastUsedThumbIndex: nextLastUsedThumbIndex,
-      },
-    });
   };
 
   readonly setDragging = (dragging: boolean) => {
-    const { interaction } = this.state;
-    if (dragging !== interaction.dragging) {
-      this.set('interaction', { ...interaction, dragging });
-    }
+    this.set('dragging', dragging);
   };
 
   readonly setIndicatorPosition = (index: 0 | 1, value: number | undefined) => {
@@ -167,13 +243,21 @@ export class SliderStore extends ReactStore<
     this.set('thumbMap', thumbMap);
   };
 
+  /**
+   * Applies a new value through `onValueChange` for keyboard, input, track-press,
+   * and drag interactions. Returns `true` when the value was applied, or `false`
+   * when it was invalid (NaN), unchanged, or the change was canceled.
+   */
   readonly setValue = (newValue: number | number[], details: SliderRoot.ChangeEventDetails) => {
-    const { onValueChange } = this.context;
     const value = this.select('value');
     if (Number.isNaN(newValue) || areValuesEqual(newValue, value)) {
       return false;
     }
 
+    // Redefine target to allow name and value to be read.
+    // This allows seamless integration with the most popular form libraries.
+    // https://github.com/mui/material-ui/issues/13485#issuecomment-676048492
+    // Clone the event to not override `target` of the original event.
     const nativeEvent = details.event;
     const EventConstructor = nativeEvent.constructor as typeof Event;
     const clonedEvent = new EventConstructor(nativeEvent.type, nativeEvent);
@@ -184,14 +268,20 @@ export class SliderStore extends ReactStore<
     });
 
     details.event = clonedEvent;
-    onValueChange(newValue, details);
+    this.context.onValueChange(newValue, details);
 
     if (details.isCanceled) {
       return false;
     }
 
-    this.lastChangeReasonRef.current = details.reason;
-    this.set('value', newValue);
+    this.context.lastChangeReasonRef.current = details.reason;
+
+    // Only the uncontrolled value lives in the store. When controlled, the parent owns the
+    // value and reflects the change through the `value` prop.
+    if (this.state.valueProp === undefined) {
+      this.set('value', newValue);
+    }
+
     return true;
   };
 
@@ -219,15 +309,8 @@ export class SliderStore extends ReactStore<
     this.context.setTouched(true);
 
     if (applied) {
-      this.onValueCommitted(newValue, createGenericEventDetails(reason, event.nativeEvent));
+      this.context.onValueCommitted(newValue, createGenericEventDetails(reason, event.nativeEvent));
     }
-  };
-
-  readonly onValueCommitted = (
-    value: number | readonly number[],
-    details: SliderRoot.CommitEventDetails,
-  ) => {
-    this.context.onValueCommitted(value, details);
   };
 }
 

--- a/packages/react/src/slider/store.ts
+++ b/packages/react/src/slider/store.ts
@@ -1,0 +1,242 @@
+import { areArraysEqual } from '@base-ui/utils/areArraysEqual';
+import { clamp } from '@base-ui/utils/clamp';
+import { NOOP } from '@base-ui/utils/empty';
+import { ReactStore } from '@base-ui/utils/store';
+import type { CompositeMetadata } from '../internals/composite/list/CompositeList';
+import {
+  createChangeEventDetails,
+  createGenericEventDetails,
+} from '../internals/createBaseUIEventDetails';
+import { REASONS } from '../internals/reasons';
+import type { SliderRoot } from './root/SliderRoot';
+import type { ThumbMetadata } from './thumb/SliderThumb';
+import { getSliderValue } from './utils/getSliderValue';
+import { validateMinimumDistance } from './utils/validateMinimumDistance';
+import { asc } from './utils/asc';
+
+export interface SliderStoreState {
+  value: number | readonly number[];
+  readonly valueProp: number | readonly number[] | undefined;
+  disabled: boolean;
+  max: number;
+  min: number;
+  minStepsBetweenValues: number;
+  name: string | undefined;
+  step: number;
+  interaction: {
+    active: number;
+    dragging: boolean;
+    lastUsedThumbIndex: number;
+  };
+  indicatorPosition: (number | undefined)[];
+  registeredLabelId: string | undefined;
+  thumbMap: Map<Node, CompositeMetadata<ThumbMetadata>>;
+}
+
+interface SliderStoreContext {
+  onValueChange: (value: number | number[], eventDetails: SliderRoot.ChangeEventDetails) => void;
+  onValueCommitted: (
+    value: number | readonly number[],
+    eventDetails: SliderRoot.CommitEventDetails,
+  ) => void;
+  setTouched: (touched: boolean) => void;
+}
+
+function createSelectors() {
+  let cachedValue: number | readonly number[] | undefined;
+  let cachedMin: number | undefined;
+  let cachedMax: number | undefined;
+  let cachedValues: readonly number[] = [];
+
+  return {
+    value: (storeState: SliderStoreState) => storeState.valueProp ?? storeState.value,
+    renderValue: (
+      storeState: SliderStoreState,
+      valueProp: number | readonly number[] | undefined,
+    ) => valueProp ?? storeState.value,
+    values: (
+      _storeState: SliderStoreState,
+      value: number | readonly number[],
+      min: number,
+      max: number,
+    ) => {
+      if (cachedValue !== value || cachedMin !== min || cachedMax !== max) {
+        cachedValue = value;
+        cachedMin = min;
+        cachedMax = max;
+        cachedValues = Array.isArray(value)
+          ? value.map((item) => clamp(item, min, max)).sort(asc)
+          : [clamp(value as number, min, max)];
+      }
+
+      return cachedValues;
+    },
+    activeWhileDisabled: (storeState: SliderStoreState) =>
+      storeState.disabled && storeState.interaction.active !== -1,
+    interaction: (storeState: SliderStoreState) => storeState.interaction,
+    indicatorPosition: (storeState: SliderStoreState) => storeState.indicatorPosition,
+    registeredLabelId: (storeState: SliderStoreState) => storeState.registeredLabelId,
+    thumbMap: (storeState: SliderStoreState) => storeState.thumbMap,
+  };
+}
+
+type SliderStoreSelectors = ReturnType<typeof createSelectors>;
+
+export class SliderStore extends ReactStore<
+  SliderStoreState,
+  SliderStoreContext,
+  SliderStoreSelectors
+> {
+  constructor(state: SliderStoreState) {
+    super(
+      state,
+      {
+        onValueChange: NOOP,
+        onValueCommitted: NOOP,
+        setTouched: NOOP,
+      },
+      createSelectors(),
+    );
+
+    // The observer and its listener are both owned by this store and share its lifetime.
+    void this.observe('activeWhileDisabled', (activeWhileDisabled) => {
+      if (activeWhileDisabled) {
+        this.setActive(-1);
+      }
+    });
+  }
+
+  readonly controlRef: React.RefObject<HTMLElement | null> = { current: null };
+
+  readonly lastChangeReasonRef: React.RefObject<SliderRoot.ChangeEventReason> = {
+    current: REASONS.none,
+  };
+
+  readonly pressedThumbCenterOffsetRef: React.RefObject<number | null> = { current: null };
+
+  readonly pressedThumbIndexRef: React.RefObject<number> = { current: -1 };
+
+  readonly pressedValuesRef: React.RefObject<readonly number[] | null> = { current: null };
+
+  readonly thumbRefs: React.RefObject<(HTMLElement | null)[]> = { current: [] };
+
+  readonly registerFieldControlRef = (element: HTMLElement | null) => {
+    if (element) {
+      this.controlRef.current = element;
+    }
+  };
+
+  readonly setActive = (index: number) => {
+    const { interaction } = this.state;
+    const { active, lastUsedThumbIndex } = interaction;
+    const nextLastUsedThumbIndex = index === -1 ? lastUsedThumbIndex : index;
+
+    if (active === index && lastUsedThumbIndex === nextLastUsedThumbIndex) {
+      return;
+    }
+
+    this.update({
+      interaction: {
+        ...interaction,
+        active: index,
+        lastUsedThumbIndex: nextLastUsedThumbIndex,
+      },
+    });
+  };
+
+  readonly setDragging = (dragging: boolean) => {
+    const { interaction } = this.state;
+    if (dragging !== interaction.dragging) {
+      this.set('interaction', { ...interaction, dragging });
+    }
+  };
+
+  readonly setIndicatorPosition = (index: 0 | 1, value: number | undefined) => {
+    const current = this.state.indicatorPosition;
+    if (current[index] !== value) {
+      this.set('indicatorPosition', index === 0 ? [value, current[1]] : [current[0], value]);
+    }
+  };
+
+  readonly setLabelId: React.Dispatch<React.SetStateAction<string | undefined>> = (value) => {
+    const current = this.state.registeredLabelId;
+    this.set('registeredLabelId', typeof value === 'function' ? value(current) : value);
+  };
+
+  readonly setThumbMap = (thumbMap: Map<Node, CompositeMetadata<ThumbMetadata>>) => {
+    this.set('thumbMap', thumbMap);
+  };
+
+  readonly setValue = (newValue: number | number[], details: SliderRoot.ChangeEventDetails) => {
+    const { onValueChange } = this.context;
+    const value = this.select('value');
+    if (Number.isNaN(newValue) || areValuesEqual(newValue, value)) {
+      return false;
+    }
+
+    const nativeEvent = details.event;
+    const EventConstructor = nativeEvent.constructor as typeof Event;
+    const clonedEvent = new EventConstructor(nativeEvent.type, nativeEvent);
+
+    Object.defineProperty(clonedEvent, 'target', {
+      writable: true,
+      value: { value: newValue, name: this.state.name },
+    });
+
+    details.event = clonedEvent;
+    onValueChange(newValue, details);
+
+    if (details.isCanceled) {
+      return false;
+    }
+
+    this.lastChangeReasonRef.current = details.reason;
+    this.set('value', newValue);
+    return true;
+  };
+
+  readonly handleInputChange = (
+    valueInput: number,
+    index: number,
+    event: React.KeyboardEvent | React.ChangeEvent,
+  ) => {
+    const { max, min, minStepsBetweenValues, step } = this.state;
+    const value = this.select('value');
+    const values = this.select('values', value, min, max);
+    const newValue = getSliderValue(valueInput, index, min, max, Array.isArray(value), values);
+
+    if (!validateMinimumDistance(newValue, step, minStepsBetweenValues)) {
+      return;
+    }
+
+    const reason = 'key' in event ? REASONS.keyboard : REASONS.inputChange;
+    const applied = this.setValue(
+      newValue,
+      createChangeEventDetails(reason, event.nativeEvent, undefined, {
+        activeThumbIndex: index,
+      }),
+    );
+    this.context.setTouched(true);
+
+    if (applied) {
+      this.onValueCommitted(newValue, createGenericEventDetails(reason, event.nativeEvent));
+    }
+  };
+
+  readonly onValueCommitted = (
+    value: number | readonly number[],
+    details: SliderRoot.CommitEventDetails,
+  ) => {
+    this.context.onValueCommitted(value, details);
+  };
+}
+
+function areValuesEqual(
+  newValue: number | readonly number[],
+  oldValue: number | readonly number[],
+) {
+  return (
+    newValue === oldValue ||
+    (Array.isArray(newValue) && Array.isArray(oldValue) && areArraysEqual(newValue, oldValue))
+  );
+}

--- a/packages/react/src/slider/store.ts
+++ b/packages/react/src/slider/store.ts
@@ -1,5 +1,4 @@
 import { areArraysEqual } from '@base-ui/utils/areArraysEqual';
-import { clamp } from '@base-ui/utils/clamp';
 import { NOOP } from '@base-ui/utils/empty';
 import { ReactStore } from '@base-ui/utils/store';
 import type { CompositeMetadata } from '../internals/composite/list/CompositeList';
@@ -12,7 +11,7 @@ import type { SliderRoot } from './root/SliderRoot';
 import type { ThumbMetadata } from './thumb/SliderThumb';
 import { getSliderValue } from './utils/getSliderValue';
 import { validateMinimumDistance } from './utils/validateMinimumDistance';
-import { asc } from './utils/asc';
+import { normalizeValues } from './utils/normalizeValues';
 
 export interface SliderStoreState {
   /**
@@ -81,77 +80,26 @@ export interface SliderStoreContext {
   setTouched: (touched: boolean) => void;
 }
 
-interface ValuesCacheEntry {
-  value: number | readonly number[];
-  min: number;
-  max: number;
-  values: readonly number[];
-}
-
-// Created per store: `values` is keyed on render-time arguments (the store is only synchronized
-// in a layout effect) and keeps the two most recent results, because `useSyncExternalStore`
-// still reads through the previous render's arguments until its passive effect runs.
-function createSelectors() {
-  let current: ValuesCacheEntry | undefined;
-  let previous: ValuesCacheEntry | undefined;
-
-  function matches(entry: ValuesCacheEntry | undefined, value: unknown, min: number, max: number) {
-    return (
-      entry !== undefined &&
-      Object.is(entry.value, value) &&
-      Object.is(entry.min, min) &&
-      Object.is(entry.max, max)
-    );
-  }
-
-  return {
-    value: (storeState: SliderStoreState) => storeState.valueProp ?? storeState.value,
-    // Takes the `value` prop as an argument because `state.valueProp` is stale during the render
-    // that changed it.
-    renderValue: (
-      storeState: SliderStoreState,
-      valueProp: number | readonly number[] | undefined,
-    ) => valueProp ?? storeState.value,
-    values: (
-      _storeState: SliderStoreState,
-      value: number | readonly number[],
-      min: number,
-      max: number,
-    ) => {
-      if (matches(current, value, min, max)) {
-        return current!.values;
-      }
-
-      if (matches(previous, value, min, max)) {
-        return previous!.values;
-      }
-
-      const values = Array.isArray(value)
-        ? value.map((item) => clamp(item, min, max)).sort(asc)
-        : [clamp(value as number, min, max)];
-
-      previous = current;
-      current = { value, min, max, values };
-
-      return values;
-    },
-    active: (storeState: SliderStoreState) => storeState.active,
-    activeWhileDisabled: (storeState: SliderStoreState) =>
-      storeState.disabled && storeState.active !== -1,
-    dragging: (storeState: SliderStoreState) => storeState.dragging,
-    lastUsedThumbIndex: (storeState: SliderStoreState) => storeState.lastUsedThumbIndex,
-    indicatorPosition: (storeState: SliderStoreState) => storeState.indicatorPosition,
-    registeredLabelId: (storeState: SliderStoreState) => storeState.registeredLabelId,
-    thumbMap: (storeState: SliderStoreState) => storeState.thumbMap,
-  };
-}
-
-type SliderStoreSelectors = ReturnType<typeof createSelectors>;
+export const selectors = {
+  value: (storeState: SliderStoreState) => storeState.valueProp ?? storeState.value,
+  // Takes the `value` prop as an argument because `state.valueProp` is stale during the render
+  // that changed it.
+  renderValue: (storeState: SliderStoreState, valueProp: number | readonly number[] | undefined) =>
+    valueProp ?? storeState.value,
+  active: (storeState: SliderStoreState) => storeState.active,
+  activeWhileDisabled: (storeState: SliderStoreState) =>
+    storeState.disabled && storeState.active !== -1,
+  dragging: (storeState: SliderStoreState) => storeState.dragging,
+  lastUsedThumbIndex: (storeState: SliderStoreState) => storeState.lastUsedThumbIndex,
+  indicatorPosition: (storeState: SliderStoreState) => storeState.indicatorPosition,
+  registeredLabelId: (storeState: SliderStoreState) => storeState.registeredLabelId,
+  thumbMap: (storeState: SliderStoreState) => storeState.thumbMap,
+};
 
 export class SliderStore extends ReactStore<
   SliderStoreState,
   SliderStoreContext,
-  SliderStoreSelectors
+  typeof selectors
 > {
   constructor(state: SliderStoreState) {
     super(
@@ -167,7 +115,7 @@ export class SliderStore extends ReactStore<
         onValueCommitted: NOOP,
         setTouched: NOOP,
       },
-      createSelectors(),
+      selectors,
     );
 
     // Must be the first listener registered on the store so React subscribers never observe
@@ -260,7 +208,7 @@ export class SliderStore extends ReactStore<
   ) => {
     const { max, min, minStepsBetweenValues, step } = this.state;
     const value = this.select('value');
-    const values = this.select('values', value, min, max);
+    const values = normalizeValues(value, min, max);
     const newValue = getSliderValue(valueInput, index, min, max, Array.isArray(value), values);
 
     if (!validateMinimumDistance(newValue, step, minStepsBetweenValues)) {

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -114,7 +114,6 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
   const id = useBaseUiId(idProp);
 
   const store = useSliderRootContext();
-  // `lastUsedThumbIndex` is not part of the public `state`, so it is read from the store directly.
   const lastUsedThumbIndex = store.useState('lastUsedThumbIndex');
   const {
     disabled: contextDisabled,
@@ -138,9 +137,6 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
     step,
     values: sliderValues,
   } = state;
-  const { handleInputChange, setActive, setIndicatorPosition } = store;
-  const { controlRef, pressedThumbCenterOffsetRef, pressedThumbIndexRef, thumbRefs } =
-    store.context;
 
   const direction = useDirection();
 
@@ -199,7 +195,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
     lastUsedThumbIndex >= 0 && lastUsedThumbIndex < sliderValues.length ? lastUsedThumbIndex : -1;
 
   const getInsetPosition = useStableCallback(() => {
-    const control = controlRef.current;
+    const control = store.context.controlRef.current;
     const thumb = thumbRef.current;
     if (!control || !thumb) {
       return;
@@ -222,9 +218,9 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
     setPositionPercent(nextInsetPosition);
 
     if (index === 0) {
-      setIndicatorPosition(0, nextInsetPosition);
+      store.setIndicatorPosition(0, nextInsetPosition);
     } else if (last) {
-      setIndicatorPosition(1, nextInsetPosition);
+      store.setIndicatorPosition(1, nextInsetPosition);
     }
   });
 
@@ -245,7 +241,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
       return undefined;
     }
 
-    const control = controlRef.current;
+    const control = store.context.controlRef.current;
     const thumb = thumbRef.current;
 
     if (!control || !thumb) {
@@ -265,7 +261,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
     return () => {
       resizeObserver.disconnect();
     };
-  }, [controlRef, getInsetPosition, inset]);
+  }, [store.context.controlRef, getInsetPosition, inset]);
 
   const startEdge = vertical ? 'bottom' : 'insetInlineStart';
   const crossOffsetProperty = vertical ? 'left' : 'top';
@@ -327,12 +323,12 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
       min,
       name,
       onChange(event) {
-        handleInputChange(event.currentTarget.valueAsNumber, index, event);
+        store.handleInputChange(event.currentTarget.valueAsNumber, index, event);
       },
       onFocus(event) {
         const isRestoringFocusVisible = restoringFocusVisibleRef.current;
         restoringFocusVisibleRef.current = false;
-        setActive(index);
+        store.setActive(index);
         setFocused(true);
 
         if (isRestoringFocusVisible) {
@@ -345,11 +341,11 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
           return;
         }
 
-        setActive(-1);
+        store.setActive(-1);
 
         // Keep field-level blur logic from running while focus moves to another thumb
         // of the same slider, so validation doesn't commit mid-interaction.
-        if (thumbRefs.current.some((thumb) => contains(thumb, event.relatedTarget))) {
+        if (store.context.thumbRefs.current.some((thumb) => contains(thumb, event.relatedTarget))) {
           return;
         }
 
@@ -432,7 +428,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
             });
           }
 
-          handleInputChange(newValue, index, event);
+          store.handleInputChange(newValue, index, event);
           event.preventDefault();
         }
       },
@@ -477,9 +473,9 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
             return;
           }
 
-          pressedThumbIndexRef.current = index;
+          store.context.pressedThumbIndexRef.current = index;
           const midpoint = getMidpoint(event.currentTarget, vertical);
-          pressedThumbCenterOffsetRef.current =
+          store.context.pressedThumbCenterOffsetRef.current =
             (vertical ? event.clientY : event.clientX) - midpoint;
         },
         style: thumbStyle,

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -36,7 +36,7 @@ import { getMidpoint } from '../utils/getMidpoint';
 import { getSliderValue } from '../utils/getSliderValue';
 import { getDecimalPrecision, roundValueToStep } from '../utils/roundValueToStep';
 import type { SliderRootState } from '../root/SliderRoot';
-import { useSliderRootContext } from '../root/SliderRootContext';
+import { useSliderRootContext, useSliderRootPropsContext } from '../root/SliderRootContext';
 import { sliderStateAttributesMapping } from '../root/stateAttributesMapping';
 import * as SliderThumbDataAttributes from './SliderThumbDataAttributes';
 
@@ -113,34 +113,39 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
 
   const id = useBaseUiId(idProp);
 
+  const store = useSliderRootContext();
+  const { lastUsedThumbIndex } = store.useState('interaction');
   const {
-    active: activeIndex,
-    lastUsedThumbIndex,
-    controlRef,
     disabled: contextDisabled,
     validation,
     format,
-    handleInputChange,
     inset,
     labelId,
     largeStep,
     locale,
+    form,
+    name,
+    renderBeforeHydration,
+    state,
+  } = useSliderRootPropsContext();
+  const {
+    activeThumbIndex: activeIndex,
     max,
     min,
     minStepsBetweenValues,
-    form,
-    name,
     orientation,
+    step,
+    values: sliderValues,
+  } = state;
+  const {
+    controlRef,
+    handleInputChange,
     pressedThumbCenterOffsetRef,
     pressedThumbIndexRef,
-    renderBeforeHydration,
     setActive,
     setIndicatorPosition,
-    state,
-    step,
     thumbRefs,
-    values: sliderValues,
-  } = useSliderRootContext();
+  } = store;
 
   const direction = useDirection();
 
@@ -222,9 +227,9 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
     setPositionPercent(nextInsetPosition);
 
     if (index === 0) {
-      setIndicatorPosition((prevPosition) => [nextInsetPosition, prevPosition[1]]);
+      setIndicatorPosition(0, nextInsetPosition);
     } else if (last) {
-      setIndicatorPosition((prevPosition) => [prevPosition[0], nextInsetPosition]);
+      setIndicatorPosition(1, nextInsetPosition);
     }
   });
 

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -114,7 +114,8 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
   const id = useBaseUiId(idProp);
 
   const store = useSliderRootContext();
-  const { lastUsedThumbIndex } = store.useState('interaction');
+  // `lastUsedThumbIndex` is not part of the public `state`, so it is read from the store directly.
+  const lastUsedThumbIndex = store.useState('lastUsedThumbIndex');
   const {
     disabled: contextDisabled,
     validation,
@@ -137,15 +138,9 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
     step,
     values: sliderValues,
   } = state;
-  const {
-    controlRef,
-    handleInputChange,
-    pressedThumbCenterOffsetRef,
-    pressedThumbIndexRef,
-    setActive,
-    setIndicatorPosition,
-    thumbRefs,
-  } = store;
+  const { handleInputChange, setActive, setIndicatorPosition } = store;
+  const { controlRef, pressedThumbCenterOffsetRef, pressedThumbIndexRef, thumbRefs } =
+    store.context;
 
   const direction = useDirection();
 

--- a/packages/react/src/slider/track/SliderTrack.tsx
+++ b/packages/react/src/slider/track/SliderTrack.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
-import { useSliderRootContext } from '../root/SliderRootContext';
+import { useSliderRootPropsContext } from '../root/SliderRootContext';
 import type { SliderRootState } from '../root/SliderRoot';
 import { sliderStateAttributesMapping } from '../root/stateAttributesMapping';
 
@@ -18,7 +18,7 @@ export const SliderTrack = React.forwardRef(function SliderTrack(
 ) {
   const { render, className, style, ...elementProps } = componentProps;
 
-  const { state } = useSliderRootContext();
+  const { state } = useSliderRootPropsContext();
 
   const element = useRenderElement('div', componentProps, {
     state,

--- a/packages/react/src/slider/utils/normalizeValues.ts
+++ b/packages/react/src/slider/utils/normalizeValues.ts
@@ -1,0 +1,16 @@
+import { clamp } from '@base-ui/utils/clamp';
+import { asc } from './asc';
+
+/**
+ * Returns one value per thumb, clamped to the bounds and sorted.
+ */
+export function normalizeValues(
+  value: number | readonly number[],
+  min: number,
+  max: number,
+): readonly number[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => clamp(item, min, max)).sort(asc);
+  }
+  return [clamp(value as number, min, max)];
+}

--- a/packages/react/src/slider/utils/resolveThumbCollision.ts
+++ b/packages/react/src/slider/utils/resolveThumbCollision.ts
@@ -1,5 +1,6 @@
 import { clamp } from '@base-ui/utils/clamp';
 import { getPushedThumbValues } from './getPushedThumbValues';
+import type { SliderThumbCollisionBehavior } from '../root/SliderRootContext';
 
 export interface ResolveThumbCollisionResult {
   value: number | number[];
@@ -12,7 +13,7 @@ export interface ResolveThumbCollisionResult {
  * minify, so passing them positionally keeps this internal helper smaller in the bundle.
  */
 export function resolveThumbCollision(
-  behavior: 'push' | 'swap' | 'none',
+  behavior: SliderThumbCollisionBehavior,
   values: readonly number[],
   currentValues: readonly number[] | null | undefined,
   initialValues: readonly number[] | null | undefined,

--- a/packages/react/src/slider/utils/resolveThumbCollision.ts
+++ b/packages/react/src/slider/utils/resolveThumbCollision.ts
@@ -1,6 +1,5 @@
 import { clamp } from '@base-ui/utils/clamp';
 import { getPushedThumbValues } from './getPushedThumbValues';
-import { SliderRootContext } from '../root/SliderRootContext';
 
 export interface ResolveThumbCollisionResult {
   value: number | number[];
@@ -13,7 +12,7 @@ export interface ResolveThumbCollisionResult {
  * minify, so passing them positionally keeps this internal helper smaller in the bundle.
  */
 export function resolveThumbCollision(
-  behavior: SliderRootContext['thumbCollisionBehavior'],
+  behavior: 'push' | 'swap' | 'none',
   values: readonly number[],
   currentValues: readonly number[] | null | undefined,
   initialValues: readonly number[] | null | undefined,

--- a/packages/react/src/slider/value/SliderValue.tsx
+++ b/packages/react/src/slider/value/SliderValue.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { formatNumber } from '@base-ui/utils/formatNumber';
 import type { BaseUIComponentProps } from '../../internals/types';
 import { useRenderElement } from '../../internals/useRenderElement';
-import { useSliderRootContext } from '../root/SliderRootContext';
+import { useSliderRootContext, useSliderRootPropsContext } from '../root/SliderRootContext';
 import { sliderStateAttributesMapping } from '../root/stateAttributesMapping';
 import type { SliderRootState } from '../root/SliderRoot';
 
@@ -26,7 +26,10 @@ export const SliderValue = React.forwardRef(function SliderValue(
     ...elementProps
   } = componentProps;
 
-  const { thumbMap, state, values, format, locale } = useSliderRootContext();
+  const store = useSliderRootContext();
+  const thumbMap = store.useState('thumbMap');
+  const { format, locale, state } = useSliderRootPropsContext();
+  const { values } = state;
 
   const outputFor =
     Array.from(thumbMap.values(), ({ inputId }) => inputId)

--- a/packages/utils/src/store/ReactStore.test.tsx
+++ b/packages/utils/src/store/ReactStore.test.tsx
@@ -69,8 +69,7 @@ describe('ReactStore', () => {
     expect(() => {
       act(() => setProps({ controlled: 1 }));
     }).toErrorDev([
-      'A component is changing the controlled state of value to be uncontrolled. Elements should not switch from uncontrolled to controlled (or vice versa).',
-      'A component is changing the controlled state of value to be uncontrolled. Elements should not switch from uncontrolled to controlled (or vice versa).',
+      'A component is changing the uncontrolled state of value to be controlled. Elements should not switch from uncontrolled to controlled (or vice versa).',
     ]);
   });
 
@@ -86,9 +85,34 @@ describe('ReactStore', () => {
     expect(() => {
       act(() => setProps({ controlled: undefined }));
     }).toErrorDev([
-      'A component is changing the uncontrolled state of value to be controlled. Elements should not switch from uncontrolled to controlled (or vice versa).',
-      'A component is changing the uncontrolled state of value to be controlled. Elements should not switch from uncontrolled to controlled (or vice versa).',
+      'A component is changing the controlled state of value to be uncontrolled. Elements should not switch from uncontrolled to controlled (or vice versa).',
     ]);
+  });
+
+  it('clears the key when the controlled prop becomes undefined', () => {
+    let store!: ReactStore<TestState>;
+
+    function Test({ controlled }: { controlled?: number }) {
+      store = useStableStore<TestState>({ value: 0, label: '' });
+      store.useControlledProp('value', controlled);
+      return null;
+    }
+
+    const { setProps } = render(<Test controlled={1} />);
+    expect(store.state.value).toBe(1);
+
+    expect(() => {
+      act(() => setProps({ controlled: undefined }));
+    }).toErrorDev([
+      'A component is changing the controlled state of value to be uncontrolled. Elements should not switch from uncontrolled to controlled (or vice versa).',
+    ]);
+
+    expect(store.state.value).toBe(undefined);
+
+    // Subsequent renders in the same mode do not warn again.
+    expect(() => {
+      act(() => setProps({ controlled: undefined }));
+    }).not.toErrorDev();
   });
 
   it('useProp updates a single key when the passed value changes', () => {

--- a/packages/utils/src/store/ReactStore.ts
+++ b/packages/utils/src/store/ReactStore.ts
@@ -115,7 +115,9 @@ export class ReactStore<
 
   /**
    * Registers a controllable prop pair (`controlled`, `defaultValue`) for a specific key. If `controlled`
-   * is non-undefined, the store's state at `key` is updated to match `controlled`.
+   * is non-undefined, the store's state at `key` is updated to match `controlled`. If a previously
+   * controlled prop becomes `undefined`, the state at `key` is cleared so that selectors fall back to
+   * the internal (uncontrolled) value instead of the last controlled one.
    */
   useControlledProp<Key extends keyof State>(key: Key, controlled: State[Key] | undefined): void {
     React.useDebugValue(key);
@@ -124,24 +126,31 @@ export class ReactStore<
     const isControlled = controlled !== undefined;
 
     useIsoLayoutEffect(() => {
-      if (isControlled && !Object.is(store.state[key], controlled)) {
-        // Set the internal state to match the controlled value.
-        store.setState({ ...store.state, [key]: controlled });
+      if (isControlled) {
+        if (!Object.is(store.state[key], controlled)) {
+          // Set the internal state to match the controlled value.
+          store.setState({ ...store.state, [key]: controlled });
+        }
+      } else if (store.state[key] !== undefined) {
+        // The controlled prop was removed. Clear it so the internal value takes over;
+        // otherwise commands would keep computing from a value that is no longer rendered.
+        store.setState({ ...store.state, [key]: undefined });
       }
     }, [store, key, controlled, isControlled]);
 
     if (process.env.NODE_ENV !== 'production') {
       // eslint-disable-next-line
       const cache = ((this as any).controlledValues ??= new Map<keyof State, boolean>());
-      if (!cache.has(key)) {
-        cache.set(key, isControlled);
-      }
       const previouslyControlled = cache.get(key);
-      if (previouslyControlled !== undefined && previouslyControlled !== isControlled) {
+      if (previouslyControlled === undefined) {
+        cache.set(key, isControlled);
+      } else if (previouslyControlled !== isControlled) {
+        // Record the new mode so the warning is logged once per switch rather than on every render.
+        cache.set(key, isControlled);
         console.error(
           `A component is changing the ${
-            isControlled ? '' : 'un'
-          }controlled state of ${key.toString()} to be ${isControlled ? 'un' : ''}controlled. Elements should not switch from uncontrolled to controlled (or vice versa).`,
+            previouslyControlled ? '' : 'un'
+          }controlled state of ${key.toString()} to be ${previouslyControlled ? 'un' : ''}controlled. Elements should not switch from uncontrolled to controlled (or vice versa).`,
         );
       }
     }


### PR DESCRIPTION
Slider currently keeps value state, interaction state, refs, and lifecycle commands across `Slider.Root` and one large memoized context. This PR moves that lifecycle into a `SliderStore` based on `ReactStore`.

The change:

- moves value updates, commits, interaction state, indicator measurements, label registration, and thumb registration into the store
- moves refs and callbacks into the non-reactive store context
- handles controlled values with `useControlledProp` and callback props with `useContextCallback`
- derives the normalized `values` array through a memoized per-store selector instead of storing a second copy
- reads mutable store data through selectors so unrelated updates remain isolated
- keeps render-time root props in a separate React context so descendants receive current values during the same commit
- adds focused tests for controlled synchronization, current callback props, disabled transitions, atomic interaction updates, and selector isolation

No public API, DOM, or behavior change is intended.

## Tradeoff

The standalone Slider entry now includes the `ReactStore` machinery, which produces a noticeable relative increase for consumers importing only Slider. The full library already includes `ReactStore` through other components, so its increase is much smaller.

| Entry | Parsed delta | Gzip delta |
| --- | ---: | ---: |
| `@base-ui/react` | +1,694 B (+0.37%) | +512 B (+0.34%) |
| `@base-ui/react/slider` | +5,416 B (+17.06%) | +1,608 B (+13.00%) |

This trades 1.6 kB gzip for standalone Slider consumers for one owner of the component lifecycle and alignment with the newer store-based components. The whole-library cost is 512 B gzip.

Keeping root props such as `disabled` outside the synchronized store state is deliberate. `useSyncedValues` writes in a layout effect, after descendants render. Storing those props only in the store would let descendant callbacks observe the previous render during the same commit.

## Verification

- `pnpm test:jsdom Slider --no-watch` (337 passed, 82 skipped)
- `pnpm test:chromium Slider --no-watch` (417 passed, 2 skipped)
- `pnpm typescript`
- `pnpm eslint`
- `pnpm prettier`
- `pnpm stylelint`
- `pnpm extract-error-codes`
- `pnpm -F @base-ui/react build`
- `pnpm size:snapshot`

- [x] I have followed the PR section of the contributing guide.
