### PR TITLE
[menu][select][combobox][scroll area] Hide group labels and scrollbars from the accessibility tree

### DIFF
--- a/packages/react/src/combobox/group-label/ComboboxGroupLabel.test.tsx
+++ b/packages/react/src/combobox/group-label/ComboboxGroupLabel.test.tsx
@@ -39,6 +39,42 @@ describe('<Combobox.GroupLabel />', () => {
       expect(group).toHaveAttribute('aria-labelledby', label.id);
     });
 
+    it('is hidden from the accessibility tree by default', async () => {
+      await render(
+        <Combobox.Root open>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.Group>
+                  <Combobox.GroupLabel>Label</Combobox.GroupLabel>
+                </Combobox.Group>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByText('Label')).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('allows overriding aria-hidden', async () => {
+      await render(
+        <Combobox.Root open>
+          <Combobox.Portal>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.Group>
+                  <Combobox.GroupLabel aria-hidden={undefined}>Label</Combobox.GroupLabel>
+                </Combobox.Group>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>,
+      );
+
+      expect(screen.getByText('Label')).not.toHaveAttribute('aria-hidden');
+    });
+
     it('uses provided id in aria-labelledby', async () => {
       await render(
         <Combobox.Root open>

--- a/packages/react/src/combobox/group-label/ComboboxGroupLabel.tsx
+++ b/packages/react/src/combobox/group-label/ComboboxGroupLabel.tsx
@@ -31,7 +31,7 @@ export const ComboboxGroupLabel = React.forwardRef(function ComboboxGroupLabel(
 
   const element = useRenderElement('div', componentProps, {
     ref: forwardedRef,
-    props: [{ id }, elementProps],
+    props: [{ id, 'aria-hidden': true }, elementProps],
   });
 
   return element;

--- a/packages/react/src/menu/group-label/MenuGroupLabel.test.tsx
+++ b/packages/react/src/menu/group-label/MenuGroupLabel.test.tsx
@@ -41,25 +41,6 @@ describe('<Menu.GroupLabel />', () => {
   });
 
   describe('a11y attributes', () => {
-    it('should have the role `presentation`', async () => {
-      await render(
-        <Menu.Root open>
-          <Menu.Portal>
-            <Menu.Positioner>
-              <Menu.Popup>
-                <Menu.Group>
-                  <Menu.GroupLabel>Test group</Menu.GroupLabel>
-                </Menu.Group>
-              </Menu.Popup>
-            </Menu.Positioner>
-          </Menu.Portal>
-        </Menu.Root>,
-      );
-
-      const groupLabel = screen.getByText('Test group');
-      expect(groupLabel).toHaveAttribute('role', 'presentation');
-    });
-
     it('is hidden from the accessibility tree by default', async () => {
       await render(
         <Menu.Root open>

--- a/packages/react/src/menu/group-label/MenuGroupLabel.test.tsx
+++ b/packages/react/src/menu/group-label/MenuGroupLabel.test.tsx
@@ -60,6 +60,44 @@ describe('<Menu.GroupLabel />', () => {
       expect(groupLabel).toHaveAttribute('role', 'presentation');
     });
 
+    it('is hidden from the accessibility tree by default', async () => {
+      await render(
+        <Menu.Root open>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Group>
+                  <Menu.GroupLabel>Test group</Menu.GroupLabel>
+                </Menu.Group>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      );
+
+      const groupLabel = screen.getByText('Test group');
+      expect(groupLabel).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('allows overriding aria-hidden', async () => {
+      await render(
+        <Menu.Root open>
+          <Menu.Portal>
+            <Menu.Positioner>
+              <Menu.Popup>
+                <Menu.Group>
+                  <Menu.GroupLabel aria-hidden={undefined}>Test group</Menu.GroupLabel>
+                </Menu.Group>
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>,
+      );
+
+      const groupLabel = screen.getByText('Test group');
+      expect(groupLabel).not.toHaveAttribute('aria-hidden');
+    });
+
     it("should reference the generated id in Group's `aria-labelledby`", async () => {
       await render(
         <Menu.Root open>

--- a/packages/react/src/menu/group-label/MenuGroupLabel.tsx
+++ b/packages/react/src/menu/group-label/MenuGroupLabel.tsx
@@ -33,7 +33,6 @@ export const MenuGroupLabel = React.forwardRef(function MenuGroupLabel(
     ref: forwardedRef,
     props: {
       id,
-      role: 'presentation',
       'aria-hidden': true,
       ...elementProps,
     },

--- a/packages/react/src/menu/group-label/MenuGroupLabel.tsx
+++ b/packages/react/src/menu/group-label/MenuGroupLabel.tsx
@@ -34,6 +34,7 @@ export const MenuGroupLabel = React.forwardRef(function MenuGroupLabel(
     props: {
       id,
       role: 'presentation',
+      'aria-hidden': true,
       ...elementProps,
     },
   });

--- a/packages/react/src/scroll-area/corner/ScrollAreaCorner.test.tsx
+++ b/packages/react/src/scroll-area/corner/ScrollAreaCorner.test.tsx
@@ -47,6 +47,36 @@ describe('<ScrollArea.Corner />', () => {
     },
   }));
 
+  it('is hidden from the accessibility tree by default', async () => {
+    await render(
+      <ScrollArea.Root>
+        <ScrollArea.Viewport ref={mockViewportMetrics} style={{ width: 100, height: 100 }}>
+          <div style={{ width: 1000, height: 1000 }} />
+        </ScrollArea.Viewport>
+        <ScrollArea.Scrollbar orientation="vertical" keepMounted style={{ width: 10 }} />
+        <ScrollArea.Scrollbar orientation="horizontal" keepMounted style={{ height: 10 }} />
+        <ScrollArea.Corner data-testid="corner" />
+      </ScrollArea.Root>,
+    );
+
+    expect(screen.getByTestId('corner')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('allows overriding aria-hidden', async () => {
+    await render(
+      <ScrollArea.Root>
+        <ScrollArea.Viewport ref={mockViewportMetrics} style={{ width: 100, height: 100 }}>
+          <div style={{ width: 1000, height: 1000 }} />
+        </ScrollArea.Viewport>
+        <ScrollArea.Scrollbar orientation="vertical" keepMounted style={{ width: 10 }} />
+        <ScrollArea.Scrollbar orientation="horizontal" keepMounted style={{ height: 10 }} />
+        <ScrollArea.Corner data-testid="corner" aria-hidden={undefined} />
+      </ScrollArea.Root>,
+    );
+
+    expect(screen.getByTestId('corner')).not.toHaveAttribute('aria-hidden');
+  });
+
   describe.skipIf(isJSDOM)('interactions', () => {
     it('should apply correct corner size when both scrollbars are present', async () => {
       await render(

--- a/packages/react/src/scroll-area/corner/ScrollAreaCorner.tsx
+++ b/packages/react/src/scroll-area/corner/ScrollAreaCorner.tsx
@@ -22,6 +22,7 @@ export const ScrollAreaCorner = React.forwardRef(function ScrollAreaCorner(
     ref: [forwardedRef, cornerRef],
     props: [
       {
+        'aria-hidden': true,
         style: {
           position: 'absolute',
           bottom: 0,

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
@@ -16,6 +16,26 @@ describe('<ScrollArea.Scrollbar />', () => {
     },
   }));
 
+  it('is hidden from the accessibility tree by default', async () => {
+    await render(
+      <ScrollArea.Root>
+        <ScrollArea.Scrollbar keepMounted data-testid="scrollbar" />
+      </ScrollArea.Root>,
+    );
+
+    expect(screen.getByTestId('scrollbar')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('allows overriding aria-hidden', async () => {
+    await render(
+      <ScrollArea.Root>
+        <ScrollArea.Scrollbar keepMounted data-testid="scrollbar" aria-hidden={undefined} />
+      </ScrollArea.Root>,
+    );
+
+    expect(screen.getByTestId('scrollbar')).not.toHaveAttribute('aria-hidden');
+  });
+
   it('sets the orientation data attribute', async () => {
     await render(
       <ScrollArea.Root>

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.tsx
@@ -119,6 +119,7 @@ export const ScrollAreaScrollbar = React.forwardRef(function ScrollAreaScrollbar
 
   const props: HTMLProps = {
     ...(rootId && { 'data-id': `${rootId}-scrollbar` }),
+    'aria-hidden': true,
     onPointerDown(event) {
       if (event.button !== 0) {
         return;

--- a/packages/react/src/select/group-label/SelectGroupLabel.test.tsx
+++ b/packages/react/src/select/group-label/SelectGroupLabel.test.tsx
@@ -18,6 +18,30 @@ describe('<Select.GroupLabel />', () => {
     },
   }));
 
+  it('is hidden from the accessibility tree by default', async () => {
+    await render(
+      <Select.Root open>
+        <Select.Group>
+          <Select.GroupLabel>Fruits</Select.GroupLabel>
+        </Select.Group>
+      </Select.Root>,
+    );
+
+    expect(screen.getByText('Fruits')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('allows overriding aria-hidden', async () => {
+    await render(
+      <Select.Root open>
+        <Select.Group>
+          <Select.GroupLabel aria-hidden={undefined}>Fruits</Select.GroupLabel>
+        </Select.Group>
+      </Select.Root>,
+    );
+
+    expect(screen.getByText('Fruits')).not.toHaveAttribute('aria-hidden');
+  });
+
   it('throws a descriptive error when rendered outside <Select.Group>', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/packages/react/src/select/group-label/SelectGroupLabel.tsx
+++ b/packages/react/src/select/group-label/SelectGroupLabel.tsx
@@ -31,7 +31,7 @@ export const SelectGroupLabel = React.forwardRef(function SelectGroupLabel(
 
   const element = useRenderElement('div', componentProps, {
     ref: forwardedRef,
-    props: [{ id }, elementProps],
+    props: [{ id, 'aria-hidden': true }, elementProps],
   });
 
   return element;


### PR DESCRIPTION
`Menu.GroupLabel` and `ScrollArea.Scrollbar` are exposed in the accessibility tree, which causes problems for the screen reader:

- `ScrollArea.Scrollbar` is counted as an additional item in the surrounding container, suggesting there's more content to explore, even though the scrollbar can't be reached.
- `Menu.GroupLabel` is announced as a separate stop even though its text is already announced when focus enters the associated group (via the `aria-labelledby` relationship), so the same text is heard twice.

The same applies to the group labels in Select and Combobox, and to `ScrollArea.Corner`.

## Changes

Add `aria-hidden="true"` by default to:

- `Menu.GroupLabel`
- `Select.GroupLabel`
- `Combobox.GroupLabel` (also exported as `Autocomplete.GroupLabel`)
- `ScrollArea.Scrollbar`
- `ScrollArea.Corner`

Group labels stay the source of the group's accessible name or description via `aria-labelledby`/`aria-describedby`. Hidden text still contributes to a name or description when referenced this way, so the label can be removed as a standalone node without losing the group's name. Scrollbars and the corner remain visually and pointer operable.

`Menu.GroupLabel` also drops `role="presentation"`. ARIA's presentational roles conflict resolution makes user agents ignore that role once the element carries a global ARIA attribute, and `aria-hidden` is global, so the role no longer had an effect. `Select.GroupLabel` and `Combobox.GroupLabel` never set it, so the three parts now match.

The defaults are applied before user props are spread, so users can still override `aria-hidden`.

None of these elements are focusable or contain focusable content, so the browser does not warn about `aria-hidden`.

Closes #5585
