### PR TITLE
[select][combobox] Remove the inconsistent items data warning

### DIFF
--- a/packages/react/src/internals/resolveValueLabel.test.ts
+++ b/packages/react/src/internals/resolveValueLabel.test.ts
@@ -1,33 +1,19 @@
-import { beforeEach, expect, vi } from 'vitest';
-import { reset as resetError } from '@base-ui/utils/error';
+import { expect } from 'vitest';
 import { hasNullItemLabel, isGroupedItems, resolveSelectedLabel } from './resolveValueLabel';
 
 describe('resolveValueLabel', () => {
   describe('isGroupedItems', () => {
-    beforeEach(resetError);
-
     it.each([
       ['an undefined items field', [{ value: 'a', items: undefined }], false],
       ['a non-array items field', [{ value: 'a', items: 3 }], false],
       ['an array items field', [{ value: 'group', items: [] }], true],
+      [
+        'a list that starts with a flat item',
+        [{ value: 'a' }, { value: 'group', items: [] }],
+        false,
+      ],
     ])('classifies %s', (_name, items, expected) => {
       expect(isGroupedItems(items)).toBe(expected);
-    });
-
-    it.each([
-      ['a group follows a flat item', [{ value: 'a' }, { value: 'group', items: [] }], false],
-      ['a flat item follows a group', [{ value: 'group', items: [] }, { value: 'a' }], true],
-    ])('reports heterogeneous data when %s', (_name, items, expected) => {
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-      try {
-        expect(isGroupedItems(items)).toBe(expected);
-        expect(errorSpy).toHaveBeenCalledWith(
-          expect.stringContaining('Base UI: Some entries in the items data are groups'),
-        );
-      } finally {
-        errorSpy.mockRestore();
-      }
     });
   });
 

--- a/packages/react/src/internals/resolveValueLabel.tsx
+++ b/packages/react/src/internals/resolveValueLabel.tsx
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import { error } from '@base-ui/utils/error';
 import { serializeValue } from './serializeValue';
 
 type ItemRecord = Record<string, React.ReactNode>;
@@ -25,17 +24,7 @@ export function isGroupedItems(
 ): items is ReadonlyArray<Group<any>> {
   // A group must carry an actual `items` array: key presence alone would misclassify an item
   // with an unrelated or optional `items` field.
-  const grouped = isGroup(items?.[0]);
-
-  if (process.env.NODE_ENV !== 'production' && items?.some((item) => isGroup(item) !== grouped)) {
-    error(
-      'Some entries in the items data are groups with an `items` array and others are not, so ' +
-        'the list cannot be interpreted consistently. Use either a flat array of items or an ' +
-        'array of groups whose `items` fields are all arrays.',
-    );
-  }
-
-  return grouped;
+  return isGroup(items?.[0]);
 }
 
 export function flattenLeafItems<Item>(


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

The dev-only check in `isGroupedItems` warned about flat items data where a later entry happens to carry an unrelated `items` array. That data classifies and renders correctly, so the warning was a false positive.

It stayed silent on the shape that does break: a grouped list with a later non-group entry, which throws a `TypeError` in production where the dev check never runs. The check earned nothing and cost a full array walk on every render, so this removes it and restores the v1.7.0 behaviour.
