### PR TITLE
[field] Publish neutral validity while async validation is in flight

### DIFF
--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -718,6 +718,59 @@ describe('<Field.Root />', () => {
       });
 
       (['onChange', 'onBlur'] as const).forEach((validationMode) => {
+        it(`retires a previously valid result to neutral while revalidating in ${validationMode} mode`, async () => {
+          const resolvers: Array<(value: string | null) => void> = [];
+          const validate = vi.fn(
+            () =>
+              new Promise<string | null>((resolve) => {
+                resolvers.push(resolve);
+              }),
+          );
+
+          await render(
+            <Field.Root data-testid="root" validationMode={validationMode} validate={validate}>
+              <Field.Control data-testid="control" />
+              <Field.Error data-testid="error" />
+            </Field.Root>,
+          );
+
+          const root = screen.getByTestId('root');
+          const control = screen.getByTestId('control');
+
+          fireEvent.change(control, { target: { value: 'good' } });
+          if (validationMode === 'onBlur') {
+            fireEvent.blur(control);
+          }
+
+          await act(async () => {
+            resolvers[0](null);
+            await flushMicrotasks();
+          });
+
+          expect(root).toHaveAttribute('data-valid', '');
+
+          if (validationMode === 'onBlur') {
+            fireEvent.focus(control);
+            fireEvent.blur(control);
+          } else {
+            fireEvent.change(control, { target: { value: 'taken' } });
+          }
+
+          // A valid result never blocks submission, so it retires to neutral mid-flight.
+          expect(root).not.toHaveAttribute('data-valid');
+          expect(root).not.toHaveAttribute('data-invalid');
+
+          await act(async () => {
+            resolvers[1]('Username is taken');
+            await flushMicrotasks();
+          });
+
+          expect(root).toHaveAttribute('data-invalid', '');
+          expect(screen.getByTestId('error')).toHaveTextContent('Username is taken');
+        });
+      });
+
+      (['onChange', 'onBlur'] as const).forEach((validationMode) => {
         it(`keeps a previously resolved error while revalidating in ${validationMode} mode`, async () => {
           const resolvers: Array<(value: string | null) => void> = [];
           const validate = vi.fn(
@@ -841,11 +894,12 @@ describe('<Field.Root />', () => {
         expect(screen.queryByTestId('error')).toBe(null);
 
         await act(async () => {
-          resolvers[1]('Username is taken');
+          resolvers[1](null);
           await flushMicrotasks();
         });
 
-        expect(root).toHaveAttribute('data-invalid', '');
+        expect(root).toHaveAttribute('data-valid', '');
+        expect(screen.queryByTestId('error')).toBe(null);
       });
     });
 

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -780,11 +780,21 @@ describe('<Field.Root />', () => {
               }),
           );
 
+          const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
+
           await render(
-            <Field.Root data-testid="root" validationMode={validationMode} validate={validate}>
-              <Field.Control data-testid="control" />
-              <Field.Error data-testid="error" />
-            </Field.Root>,
+            <Form onSubmit={onSubmit}>
+              <Field.Root
+                data-testid="root"
+                name="username"
+                validationMode={validationMode}
+                validate={validate}
+              >
+                <Field.Control data-testid="control" />
+                <Field.Error data-testid="error" />
+              </Field.Root>
+              <button type="submit">submit</button>
+            </Form>,
           );
 
           const root = screen.getByTestId('root');
@@ -815,14 +825,75 @@ describe('<Field.Root />', () => {
           expect(root).toHaveAttribute('data-invalid', '');
           expect(screen.getByTestId('error')).toHaveTextContent('Username is taken');
 
+          fireEvent.click(screen.getByText('submit'));
+
+          expect(onSubmit).not.toHaveBeenCalled();
+
           await act(async () => {
-            resolvers[1](null);
+            resolvers[resolvers.length - 1](null);
             await flushMicrotasks();
           });
 
           expect(root).not.toHaveAttribute('data-invalid');
           expect(screen.queryByTestId('error')).toBe(null);
         });
+      });
+
+      it('retires a stale native error to neutral once the constraint passes again', async () => {
+        const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
+        const resolvers: Array<(value: string | null) => void> = [];
+        const validate = vi.fn(
+          () =>
+            new Promise<string | null>((resolve) => {
+              resolvers.push(resolve);
+            }),
+        );
+
+        await render(
+          <Form onSubmit={onSubmit}>
+            <Field.Root
+              data-testid="root"
+              name="email"
+              validationMode="onChange"
+              validate={validate}
+            >
+              <Field.Control data-testid="control" type="email" />
+              <Field.Error data-testid="error" />
+            </Field.Root>
+            <button type="submit">submit</button>
+          </Form>,
+        );
+
+        const root = screen.getByTestId('root');
+        const control = screen.getByTestId('control');
+
+        fireEvent.change(control, { target: { value: 'nope' } });
+
+        await act(async () => {
+          resolvers[resolvers.length - 1](null);
+          await flushMicrotasks();
+        });
+
+        expect(root).toHaveAttribute('data-invalid', '');
+
+        fireEvent.change(control, { target: { value: 'name@example.com' } });
+
+        // `nextState` already carries the fresh native verdict, so the previous native error must
+        // not survive the pending window and keep blocking submission.
+        expect(root).not.toHaveAttribute('data-invalid');
+        expect(root).not.toHaveAttribute('data-valid');
+        expect(screen.queryByTestId('error')).toBe(null);
+
+        fireEvent.click(screen.getByText('submit'));
+
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+          resolvers[resolvers.length - 1](null);
+          await flushMicrotasks();
+        });
+
+        expect(root).toHaveAttribute('data-valid', '');
       });
 
       (['onSubmit', 'onChange', 'onBlur'] as const).forEach((validationMode) => {
@@ -847,6 +918,9 @@ describe('<Field.Root />', () => {
 
           fireEvent.click(screen.getByText('submit'));
 
+          // In `onBlur` mode a native failure short-circuits the validator, so nothing is in
+          // flight and the failure is published by the regular end-of-commit path instead.
+          expect(validate).toHaveBeenCalledTimes(validationMode === 'onBlur' ? 0 : 1);
           expect(onSubmit).not.toHaveBeenCalled();
           expect(screen.getByTestId('root')).toHaveAttribute('data-invalid', '');
           expect(screen.getByTestId('control')).toHaveAttribute('aria-invalid', 'true');
@@ -856,6 +930,7 @@ describe('<Field.Root />', () => {
       });
 
       it('retires a resolved async error to neutral while revalidating in onSubmit mode', async () => {
+        const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
         const resolvers: Array<(value: string | null) => void> = [];
         const validate = vi.fn(
           () =>
@@ -865,7 +940,7 @@ describe('<Field.Root />', () => {
         );
 
         await render(
-          <Form onSubmit={(event) => event.preventDefault()}>
+          <Form onSubmit={onSubmit}>
             <Field.Root data-testid="root" name="username" validate={validate}>
               <Field.Control data-testid="control" />
               <Field.Error data-testid="error" />
@@ -888,6 +963,9 @@ describe('<Field.Root />', () => {
 
         fireEvent.click(screen.getByText('submit'));
 
+        // An async result can't block submission in `onSubmit` mode, so the neutral state lets
+        // the second submit through.
+        expect(onSubmit).toHaveBeenCalledTimes(2);
         expect(root).not.toHaveAttribute('data-valid');
         expect(root).not.toHaveAttribute('data-invalid');
         expect(control).not.toHaveAttribute('aria-invalid');

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -772,27 +772,34 @@ describe('<Field.Root />', () => {
         });
       });
 
-      it('keeps a native constraint failure published while the validator is in flight', async () => {
-        const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
-        const validate = vi.fn(() => new Promise<string | null>(() => {}));
+      (['onSubmit', 'onChange', 'onBlur'] as const).forEach((validationMode) => {
+        it(`keeps a native constraint failure published while the validator is in flight in ${validationMode} mode`, async () => {
+          const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
+          const validate = vi.fn(() => new Promise<string | null>(() => {}));
 
-        await render(
-          <Form onSubmit={onSubmit}>
-            <Field.Root data-testid="root" name="username" validate={validate}>
-              <Field.Control data-testid="control" required />
-              <Field.Error data-testid="error" />
-            </Field.Root>
-            <button type="submit">submit</button>
-          </Form>,
-        );
+          await render(
+            <Form onSubmit={onSubmit}>
+              <Field.Root
+                data-testid="root"
+                name="username"
+                validationMode={validationMode}
+                validate={validate}
+              >
+                <Field.Control data-testid="control" required />
+                <Field.Error data-testid="error" />
+              </Field.Root>
+              <button type="submit">submit</button>
+            </Form>,
+          );
 
-        fireEvent.click(screen.getByText('submit'));
+          fireEvent.click(screen.getByText('submit'));
 
-        expect(onSubmit).not.toHaveBeenCalled();
-        expect(screen.getByTestId('root')).toHaveAttribute('data-invalid', '');
-        expect(screen.getByTestId('control')).toHaveAttribute('aria-invalid', 'true');
+          expect(onSubmit).not.toHaveBeenCalled();
+          expect(screen.getByTestId('root')).toHaveAttribute('data-invalid', '');
+          expect(screen.getByTestId('control')).toHaveAttribute('aria-invalid', 'true');
 
-        await flushMicrotasks();
+          await flushMicrotasks();
+        });
       });
 
       it('retires a resolved async error to neutral while revalidating in onSubmit mode', async () => {

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -717,6 +717,84 @@ describe('<Field.Root />', () => {
         });
       });
 
+      (['onChange', 'onBlur'] as const).forEach((validationMode) => {
+        it(`keeps a previously resolved error while revalidating in ${validationMode} mode`, async () => {
+          const resolvers: Array<(value: string | null) => void> = [];
+          const validate = vi.fn(
+            () =>
+              new Promise<string | null>((resolve) => {
+                resolvers.push(resolve);
+              }),
+          );
+
+          await render(
+            <Field.Root data-testid="root" validationMode={validationMode} validate={validate}>
+              <Field.Control data-testid="control" />
+              <Field.Error data-testid="error" />
+            </Field.Root>,
+          );
+
+          const root = screen.getByTestId('root');
+          const control = screen.getByTestId('control');
+
+          fireEvent.change(control, { target: { value: 'taken' } });
+          if (validationMode === 'onBlur') {
+            fireEvent.blur(control);
+          }
+
+          await act(async () => {
+            resolvers[0]('Username is taken');
+            await flushMicrotasks();
+          });
+
+          expect(root).toHaveAttribute('data-invalid', '');
+
+          // A keystroke would optimistically clear the error through the revalidate path, so
+          // re-trigger validation without changing the value.
+          if (validationMode === 'onBlur') {
+            fireEvent.focus(control);
+            fireEvent.blur(control);
+          } else {
+            fireEvent.change(control, { target: { value: 'taken2' } });
+          }
+
+          // The resolved error stays published mid-flight so it keeps blocking submission.
+          expect(root).toHaveAttribute('data-invalid', '');
+          expect(screen.getByTestId('error')).toHaveTextContent('Username is taken');
+
+          await act(async () => {
+            resolvers[1](null);
+            await flushMicrotasks();
+          });
+
+          expect(root).not.toHaveAttribute('data-invalid');
+          expect(screen.queryByTestId('error')).toBe(null);
+        });
+      });
+
+      it('keeps a native constraint failure published while the validator is in flight', async () => {
+        const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
+        const validate = vi.fn(() => new Promise<string | null>(() => {}));
+
+        await render(
+          <Form onSubmit={onSubmit}>
+            <Field.Root data-testid="root" name="username" validate={validate}>
+              <Field.Control data-testid="control" required />
+              <Field.Error data-testid="error" />
+            </Field.Root>
+            <button type="submit">submit</button>
+          </Form>,
+        );
+
+        fireEvent.click(screen.getByText('submit'));
+
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(screen.getByTestId('root')).toHaveAttribute('data-invalid', '');
+        expect(screen.getByTestId('control')).toHaveAttribute('aria-invalid', 'true');
+
+        await flushMicrotasks();
+      });
+
       it('retires a resolved async error to neutral while revalidating in onSubmit mode', async () => {
         const resolvers: Array<(value: string | null) => void> = [];
         const validate = vi.fn(

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -664,6 +664,106 @@ describe('<Field.Root />', () => {
       });
     });
 
+    describe('async validation pending state', () => {
+      (['onSubmit', 'onChange', 'onBlur'] as const).forEach((validationMode) => {
+        it(`publishes neutral validity while a validator is in flight in ${validationMode} mode`, async () => {
+          let resolveValidate: ((value: string | null) => void) | undefined;
+          const validate = vi.fn(
+            () =>
+              new Promise<string | null>((resolve) => {
+                resolveValidate = resolve;
+              }),
+          );
+
+          await render(
+            <Form onSubmit={(event) => event.preventDefault()}>
+              <Field.Root
+                data-testid="root"
+                name="username"
+                validationMode={validationMode}
+                validate={validate}
+              >
+                <Field.Control data-testid="control" />
+                <Field.Error data-testid="error" />
+              </Field.Root>
+              <button type="submit">submit</button>
+            </Form>,
+          );
+
+          const root = screen.getByTestId('root');
+          const control = screen.getByTestId('control');
+
+          fireEvent.change(control, { target: { value: 'taken' } });
+          if (validationMode === 'onBlur') {
+            fireEvent.blur(control);
+          } else if (validationMode === 'onSubmit') {
+            fireEvent.click(screen.getByText('submit'));
+          }
+
+          expect(validate).toHaveBeenCalledTimes(1);
+          expect(root).not.toHaveAttribute('data-valid');
+          expect(root).not.toHaveAttribute('data-invalid');
+          expect(control).not.toHaveAttribute('aria-invalid');
+          expect(screen.queryByTestId('error')).toBe(null);
+
+          await act(async () => {
+            resolveValidate?.('Username is taken');
+            await flushMicrotasks();
+          });
+
+          expect(root).toHaveAttribute('data-invalid', '');
+          expect(control).toHaveAttribute('aria-invalid', 'true');
+          expect(screen.getByTestId('error')).toHaveTextContent('Username is taken');
+        });
+      });
+
+      it('retires a resolved async error to neutral while revalidating in onSubmit mode', async () => {
+        const resolvers: Array<(value: string | null) => void> = [];
+        const validate = vi.fn(
+          () =>
+            new Promise<string | null>((resolve) => {
+              resolvers.push(resolve);
+            }),
+        );
+
+        await render(
+          <Form onSubmit={(event) => event.preventDefault()}>
+            <Field.Root data-testid="root" name="username" validate={validate}>
+              <Field.Control data-testid="control" />
+              <Field.Error data-testid="error" />
+            </Field.Root>
+            <button type="submit">submit</button>
+          </Form>,
+        );
+
+        const root = screen.getByTestId('root');
+        const control = screen.getByTestId('control');
+
+        fireEvent.click(screen.getByText('submit'));
+
+        await act(async () => {
+          resolvers[0]('Username is taken');
+          await flushMicrotasks();
+        });
+
+        expect(root).toHaveAttribute('data-invalid', '');
+
+        fireEvent.click(screen.getByText('submit'));
+
+        expect(root).not.toHaveAttribute('data-valid');
+        expect(root).not.toHaveAttribute('data-invalid');
+        expect(control).not.toHaveAttribute('aria-invalid');
+        expect(screen.queryByTestId('error')).toBe(null);
+
+        await act(async () => {
+          resolvers[1]('Username is taken');
+          await flushMicrotasks();
+        });
+
+        expect(root).toHaveAttribute('data-invalid', '');
+      });
+    });
+
     it('accepts synchronous and async validators with no return value', async () => {
       await render(
         <React.Fragment>

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -305,14 +305,12 @@ export function useFieldValidation(
         resultOrPromise !== null &&
         'then' in resultOrPromise
       ) {
-        // Retire a previous async result while the validator runs, but keep anything that must
-        // block submission synchronously: native failures here, the previous result in other modes.
-        if (validationMode === 'onSubmit') {
-          if (nextState.valid === false) {
-            publish(nextState, validationErrors);
-          } else {
-            publish({ ...nextState, valid: null }, EMPTY_ARRAY);
-          }
+        // Publish native failures in every mode and retire a previous async result in onSubmit
+        // mode: the form reads validity synchronously to block submission.
+        if (nextState.valid === false) {
+          publish(nextState, validationErrors);
+        } else if (validationMode === 'onSubmit') {
+          publish({ ...nextState, valid: null }, EMPTY_ARRAY);
         }
 
         // A rejected validator keeps the previously published state, so a transient

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { EMPTY_ARRAY, EMPTY_OBJECT } from '@base-ui/utils/empty';
+import { EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { useTimeout } from '@base-ui/utils/useTimeout';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
@@ -280,7 +280,7 @@ export function useFieldValidation(
     // Do not read Base UI's previous message back as a native constraint.
     clearCustomValidity();
 
-    let nextState = refreshState();
+    let nextState: FieldValidityData['state'] = refreshState();
     let validationErrors = getNativeErrors(element);
 
     const isValidatingOnChange = shouldValidateOnChange();
@@ -312,7 +312,8 @@ export function useFieldValidation(
         if (nextState.valid === false) {
           publish(nextState, validationErrors);
         } else if (validationMode === 'onSubmit' || !validityData.state.customError) {
-          publish({ ...nextState, valid: null }, EMPTY_ARRAY);
+          nextState.valid = null;
+          publish(nextState, validationErrors);
         }
 
         // A rejected validator keeps the previously published state, so a transient

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -305,11 +305,11 @@ export function useFieldValidation(
         resultOrPromise !== null &&
         'then' in resultOrPromise
       ) {
-        // Publish native failures in every mode and retire a previous async result in onSubmit
-        // mode: the form reads validity synchronously to block submission.
+        // Validity is unknown while the validator runs, so go neutral, but keep what must block
+        // submission synchronously: native failures, and a previous error outside onSubmit mode.
         if (nextState.valid === false) {
           publish(nextState, validationErrors);
-        } else if (validationMode === 'onSubmit') {
+        } else if (validationMode === 'onSubmit' || validityData.state.valid !== false) {
           publish({ ...nextState, valid: null }, EMPTY_ARRAY);
         }
 

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -306,10 +306,12 @@ export function useFieldValidation(
         'then' in resultOrPromise
       ) {
         // Validity is unknown while the validator runs, so go neutral, but keep what must block
-        // submission synchronously: native failures, and a previous error outside onSubmit mode.
+        // submission synchronously: native failures, and a previous custom error outside onSubmit
+        // mode. A previous native error is never kept, since `nextState` already carries the fresh
+        // native verdict.
         if (nextState.valid === false) {
           publish(nextState, validationErrors);
-        } else if (validationMode === 'onSubmit' || validityData.state.valid !== false) {
+        } else if (validationMode === 'onSubmit' || !validityData.state.customError) {
           publish({ ...nextState, valid: null }, EMPTY_ARRAY);
         }
 

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { EMPTY_OBJECT } from '@base-ui/utils/empty';
+import { EMPTY_ARRAY, EMPTY_OBJECT } from '@base-ui/utils/empty';
 import { useTimeout } from '@base-ui/utils/useTimeout';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
@@ -150,7 +150,7 @@ export function useFieldValidation(
     }
 
     function makeValidityData(
-      validityState: Record<keyof ValidityState, boolean>,
+      validityState: FieldValidityData['state'],
       errorMessages: string[],
     ): FieldValidityData {
       // `valueMissing` may be suppressed while the native message remains non-empty.
@@ -182,7 +182,7 @@ export function useFieldValidation(
     }
 
     function publish(
-      validityState: Record<keyof ValidityState, boolean>,
+      validityState: FieldValidityData['state'],
       errorMessages: string[],
       externalInvalid?: boolean,
     ) {
@@ -305,9 +305,11 @@ export function useFieldValidation(
         resultOrPromise !== null &&
         'then' in resultOrPromise
       ) {
-        // Retire a previous async result before an onSubmit validation begins.
+        // Validity is unknown while the validator runs, so retire a previous async result before an
+        // onSubmit validation begins. Other modes keep it: the form reads the last resolved result
+        // synchronously to block submission.
         if (validationMode === 'onSubmit') {
-          publish(nextState, validationErrors);
+          publish({ ...nextState, valid: null }, EMPTY_ARRAY);
         }
 
         // A rejected validator keeps the previously published state, so a transient

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -305,11 +305,14 @@ export function useFieldValidation(
         resultOrPromise !== null &&
         'then' in resultOrPromise
       ) {
-        // Validity is unknown while the validator runs, so retire a previous async result before an
-        // onSubmit validation begins. Other modes keep it: the form reads the last resolved result
-        // synchronously to block submission.
+        // Retire a previous async result while the validator runs, but keep anything that must
+        // block submission synchronously: native failures here, the previous result in other modes.
         if (validationMode === 'onSubmit') {
-          publish({ ...nextState, valid: null }, EMPTY_ARRAY);
+          if (nextState.valid === false) {
+            publish(nextState, validationErrors);
+          } else {
+            publish({ ...nextState, valid: null }, EMPTY_ARRAY);
+          }
         }
 
         // A rejected validator keeps the previously published state, so a transient


### PR DESCRIPTION
While an async `validate` function is in flight, the field published `data-valid` (a fresh all-clear from native constraints) even though the result is unknown, and only `validationMode="onSubmit"` retired the previous result. It also dropped known native failures in that window, so a `required` or `type="email"` field could submit past its native constraint when paired with an async validator.

The pending window now maps to the existing neutral state (`valid: null`, no `data-valid`/`data-invalid`/`aria-invalid`), consistently across modes. The only results kept mid-flight are the ones the form must read synchronously to block submission:

- native constraint failures, published in every mode
- a previously resolved async error in `onChange`/`onBlur` (async results can't block in `onSubmit` mode, per the `validate` docs)

A previously valid result retires in every mode, so no stale success shows for a value that was never validated.

`publish`/`makeValidityData` accept `valid: null` internally; public types already allowed it.
