### PR TITLE
[all components] Fix roving tabindex in SSR markup

### DIFF
--- a/packages/react/src/combobox/item/ComboboxItem.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.tsx
@@ -46,7 +46,6 @@ function ComboboxItemInner(props: ComboboxItemInnerProps) {
 
   const textRef = React.useRef<HTMLElement | null>(null);
   const listItem = useCompositeListItem({
-    guess: true,
     index: indexProp,
     textRef,
   });

--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -44,7 +44,7 @@ describe('<CompositeList />', () => {
 
     it('keeps refs populated for items whose guessed index is already correct', async () => {
       function GuessedItem(props: { label: string }) {
-        const { ref } = useCompositeListItem({ guess: true, label: props.label });
+        const { ref } = useCompositeListItem({ label: props.label });
         return (
           <div ref={ref} data-testid={props.label}>
             {props.label}
@@ -170,7 +170,7 @@ describe('<CompositeList />', () => {
       };
 
       function GuessedItem(props: { label: string; index?: number }) {
-        const { ref, index } = useCompositeListItem({ guess: true, index: props.index });
+        const { ref, index } = useCompositeListItem({ index: props.index });
         const initialIndex = React.useRef(index).current;
         return <div ref={ref} data-testid={props.label} data-initial-index={initialIndex} />;
       }
@@ -387,7 +387,7 @@ describe('<CompositeList />', () => {
       const initialIndexes: Record<string, number> = {};
 
       function GuessedItem(props: { label: string }) {
-        const { ref, index } = useCompositeListItem({ guess: true });
+        const { ref, index } = useCompositeListItem();
         renderCounts[props.label] += 1;
         if (!(props.label in initialIndexes)) {
           initialIndexes[props.label] = index;
@@ -426,7 +426,7 @@ describe('<CompositeList />', () => {
       };
 
       function TrackedItem(props: { index?: number }) {
-        const { ref, index } = useCompositeListItem({ guess: true, index: props.index });
+        const { ref, index } = useCompositeListItem({ index: props.index });
         const trackingRef = React.useCallback(
           (node: HTMLElement | null) => {
             refCalls.push(node);
@@ -1027,7 +1027,7 @@ describe('<CompositeList />', () => {
       }> = [];
 
       function Item(props: { attempt?: number; label: string }) {
-        const { ref, index } = useCompositeListItem({ guess: true, label: props.label });
+        const { ref, index } = useCompositeListItem({ label: props.label });
         if (props.attempt != null && props.attempt >= 0) {
           suspenders[props.attempt].read();
         }
@@ -1126,8 +1126,8 @@ describe('<CompositeList />', () => {
       }
 
       const { hydrate } = renderToString(<App />);
-      expect(screen.getByTestId('a')).toHaveAttribute('data-index', '-1');
-      expect(screen.getByTestId('b')).toHaveAttribute('data-index', '-1');
+      expect(screen.getByTestId('a')).toHaveAttribute('data-index', '0');
+      expect(screen.getByTestId('b')).toHaveAttribute('data-index', '1');
 
       hydrate();
 

--- a/packages/react/src/internals/composite/list/CompositeListContext.ts
+++ b/packages/react/src/internals/composite/list/CompositeListContext.ts
@@ -13,6 +13,12 @@ export interface CompositeListContextValue<Metadata> {
   unregister: (node: Element) => void;
   subscribeMapChange: (fn: (map: Map<Element, Metadata>) => void) => () => void;
   nextIndexRef: React.RefObject<number>;
+  /**
+   * Present only on the default value. An item without a `CompositeList` above must not
+   * guess an index from `nextIndexRef`: the default ref is a module-level singleton, so
+   * consuming from it would leak state across unrelated orphan items.
+   */
+  orphan?: boolean | undefined;
 }
 
 export const CompositeListContext = React.createContext<CompositeListContextValue<any>>({
@@ -20,6 +26,7 @@ export const CompositeListContext = React.createContext<CompositeListContextValu
   unregister: () => {},
   subscribeMapChange: () => () => {},
   nextIndexRef: { current: 0 },
+  orphan: true,
 });
 
 export function useCompositeListContext() {

--- a/packages/react/src/internals/composite/list/useCompositeListItem.ts
+++ b/packages/react/src/internals/composite/list/useCompositeListItem.ts
@@ -4,12 +4,6 @@ import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useCompositeListContext } from './CompositeListContext';
 
 export interface UseCompositeListItemParameters<Metadata> {
-  /**
-   * Whether to guess the initial index from render order, avoiding a re-render after mount for
-   * flat lists.
-   * @default false
-   */
-  guess?: boolean | undefined;
   index?: number | undefined;
   label?: string | null | undefined;
   /**
@@ -32,16 +26,17 @@ interface UseCompositeListItemReturnValue {
 export function useCompositeListItem<Metadata>(
   params: UseCompositeListItemParameters<Metadata> = {},
 ): UseCompositeListItemReturnValue {
-  const { guess, label, metadata, textRef, index: externalIndex } = params;
+  const { label, metadata, textRef, index: externalIndex } = params;
 
-  const { register, unregister, subscribeMapChange, nextIndexRef } = useCompositeListContext();
+  const { register, unregister, subscribeMapChange, nextIndexRef, orphan } =
+    useCompositeListContext();
 
   // Guess the index from the render order. This avoids a re-render after mount for
   // flat lists rendered in DOM order; when the guess is wrong (grouped or out-of-order
   // rendering), the commit flush corrects it before paint.
   const indexRef = React.useRef(-1);
   const [internalIndex, setInternalIndex] = React.useState<number>(
-    externalIndex == null && guess
+    externalIndex == null && !orphan
       ? () => {
           if (indexRef.current === -1) {
             const newIndex = nextIndexRef.current;

--- a/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
+++ b/packages/react/src/menu/checkbox-item/MenuCheckboxItem.tsx
@@ -40,7 +40,7 @@ export const MenuCheckboxItem = React.forwardRef(function MenuCheckboxItem(
     ...elementProps
   } = componentProps;
 
-  const listItem = useCompositeListItem({ guess: true, label });
+  const listItem = useCompositeListItem({ label });
   const menuPositionerContext = useMenuPositionerContext(true);
   const id = useBaseUiId(idProp);
 

--- a/packages/react/src/menu/item/MenuItem.tsx
+++ b/packages/react/src/menu/item/MenuItem.tsx
@@ -30,7 +30,7 @@ export const MenuItem = React.forwardRef(function MenuItem(
     ...elementProps
   } = componentProps;
 
-  const listItem = useCompositeListItem({ guess: true, label });
+  const listItem = useCompositeListItem({ label });
   const menuPositionerContext = useMenuPositionerContext(true);
   const id = useBaseUiId(idProp);
 

--- a/packages/react/src/menu/link-item/MenuLinkItem.tsx
+++ b/packages/react/src/menu/link-item/MenuLinkItem.tsx
@@ -33,7 +33,7 @@ export const MenuLinkItem = React.forwardRef(function MenuLinkItem(
 
   const linkRef = React.useRef<HTMLAnchorElement | null>(null);
 
-  const listItem = useCompositeListItem({ guess: true, label });
+  const listItem = useCompositeListItem({ label });
   const menuPositionerContext = useMenuPositionerContext(true);
   const nodeId = menuPositionerContext?.context.nodeId;
 

--- a/packages/react/src/menu/radio-item/MenuRadioItem.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.tsx
@@ -37,7 +37,7 @@ export const MenuRadioItem = React.forwardRef(function MenuRadioItem(
     ...elementProps
   } = componentProps;
 
-  const listItem = useCompositeListItem({ guess: true, label });
+  const listItem = useCompositeListItem({ label });
   const menuPositionerContext = useMenuPositionerContext(true);
   const id = useBaseUiId(idProp);
 

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.tsx
@@ -51,7 +51,7 @@ export const MenuSubmenuTrigger = React.forwardRef(function MenuSubmenuTrigger(
     throw new Error('Base UI: <Menu.SubmenuTrigger> must be placed in <Menu.SubmenuRoot>.');
   }
 
-  const listItem = useCompositeListItem({ guess: true, label });
+  const listItem = useCompositeListItem({ label });
   const menuPositionerContext = useMenuPositionerContext();
 
   const { store } = useMenuRootContext();

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -19,7 +19,7 @@ describe('<Menubar />', () => {
     globalThis.BASE_UI_ANIMATIONS_DISABLED = true;
   });
 
-  const { render } = createRenderer();
+  const { render, renderToString } = createRenderer();
 
   describeConformance(<Menubar />, () => ({
     render: (node) => {
@@ -1191,6 +1191,24 @@ describe('<Menubar />', () => {
 
       await user.click(item);
       expect(handleClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('server-side rendering', () => {
+    it('renders a roving tab stop on the first trigger', () => {
+      renderToString(
+        <Menubar>
+          <Menu.Root>
+            <Menu.Trigger data-testid="trigger-1">File</Menu.Trigger>
+          </Menu.Root>
+          <Menu.Root>
+            <Menu.Trigger data-testid="trigger-2">Edit</Menu.Trigger>
+          </Menu.Root>
+        </Menubar>,
+      );
+
+      expect(screen.getByTestId('trigger-1')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('trigger-2')).toHaveAttribute('tabindex', '-1');
     });
   });
 });

--- a/packages/react/src/otp-field/input/OTPFieldInput.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.tsx
@@ -62,7 +62,7 @@ export const OTPFieldInput = React.forwardRef(function OTPFieldInput(
     value,
   } = useOTPFieldRootContext();
 
-  const { ref: listItemRef, index } = useCompositeListItem({ guess: true });
+  const { ref: listItemRef, index } = useCompositeListItem();
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   const direction = useDirection();
 

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -12,7 +12,7 @@ import { act, screen, fireEvent } from '@mui/internal-test-utils';
 import { describeConformance } from '../../test/describeConformance';
 
 describe('<RadioGroup />', () => {
-  const { render } = createRenderer();
+  const { render, renderToString } = createRenderer();
 
   describeConformance(<RadioGroup />, () => ({
     refInstanceof: window.HTMLDivElement,
@@ -863,6 +863,39 @@ describe('<RadioGroup />', () => {
 
     expect(radioA).not.toHaveAttribute('tabindex', '0');
     expect(radioB).toHaveAttribute('tabindex', '0');
+  });
+
+  describe('server-side rendering', () => {
+    it('renders a roving tab stop on the first radio', () => {
+      renderToString(
+        <RadioGroup>
+          <Radio.Root value="a" data-testid="radio-a" />
+          <Radio.Root value="b" data-testid="radio-b" />
+        </RadioGroup>,
+      );
+
+      expect(screen.getByTestId('radio-a')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('radio-b')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('moves the tab stop to the checked radio on hydration', () => {
+      const { hydrate } = renderToString(
+        <RadioGroup defaultValue="b">
+          <Radio.Root value="a" data-testid="radio-a" />
+          <Radio.Root value="b" data-testid="radio-b" />
+        </RadioGroup>,
+      );
+
+      // The server cannot know the checked index (it is resolved from the
+      // registered items after mount), so the tab stop starts on the first radio.
+      expect(screen.getByTestId('radio-a')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('radio-b')).toHaveAttribute('tabindex', '-1');
+
+      hydrate();
+
+      expect(screen.getByTestId('radio-a')).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByTestId('radio-b')).toHaveAttribute('tabindex', '0');
+    });
   });
 
   describe('with native <label>', () => {

--- a/packages/react/src/select/item/SelectItem.tsx
+++ b/packages/react/src/select/item/SelectItem.tsx
@@ -41,7 +41,6 @@ export const SelectItem = React.memo(
 
     const textRef = React.useRef<HTMLElement | null>(null);
     const listItem = useCompositeListItem({
-      guess: true,
       label,
       textRef,
     });

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -8,7 +8,7 @@ import { Tabs } from '@base-ui/react/tabs';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<Tabs.Root />', () => {
-  const { render } = createRenderer();
+  const { render, renderToString } = createRenderer();
 
   beforeEach(function beforeHook({ skip }) {
     const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
@@ -2593,6 +2593,22 @@ describe('<Tabs.Root />', () => {
       // Selection remains the externally-set tab since activateOnFocus=false
       expect(thirdTab).toHaveAttribute('aria-selected', 'true');
       expect(secondTab).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+
+  describe('server-side rendering', () => {
+    it('renders a roving tab stop on the first tab', () => {
+      renderToString(
+        <Tabs.Root defaultValue="one">
+          <Tabs.List>
+            <Tabs.Tab value="one" data-testid="tab-1" />
+            <Tabs.Tab value="two" data-testid="tab-2" />
+          </Tabs.List>
+        </Tabs.Root>,
+      );
+
+      expect(screen.getByTestId('tab-1')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('tab-2')).toHaveAttribute('tabindex', '-1');
     });
   });
 });

--- a/packages/react/src/toggle-group/ToggleGroup.test.tsx
+++ b/packages/react/src/toggle-group/ToggleGroup.test.tsx
@@ -8,7 +8,7 @@ import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { type Orientation } from '../internals/types';
 
 describe('<ToggleGroup />', () => {
-  const { render } = createRenderer();
+  const { render, renderToString } = createRenderer();
 
   describeConformance(<ToggleGroup />, () => ({
     refInstanceof: window.HTMLDivElement,
@@ -600,6 +600,20 @@ describe('<ToggleGroup />', () => {
         expect(onValueChange.mock.calls.length).toBe(2);
         expect(onValueChange.mock.calls[1][0]).toEqual(['two']);
       });
+    });
+  });
+
+  describe('server-side rendering', () => {
+    it('renders a roving tab stop on the first toggle', () => {
+      renderToString(
+        <ToggleGroup>
+          <Toggle value="one" data-testid="toggle-1" />
+          <Toggle value="two" data-testid="toggle-2" />
+        </ToggleGroup>,
+      );
+
+      expect(screen.getByTestId('toggle-1')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('toggle-2')).toHaveAttribute('tabindex', '-1');
     });
   });
 });

--- a/packages/react/src/toolbar/root/ToolbarRoot.test.tsx
+++ b/packages/react/src/toolbar/root/ToolbarRoot.test.tsx
@@ -7,7 +7,7 @@ import { type Orientation } from '../../internals/types';
 import { useToolbarRootContext } from './ToolbarRootContext';
 
 describe('<Toolbar.Root />', () => {
-  const { render } = createRenderer();
+  const { render, renderToString } = createRenderer();
 
   describeConformance(<Toolbar.Root />, () => ({
     refInstanceof: window.HTMLDivElement,
@@ -314,6 +314,20 @@ describe('<Toolbar.Root />', () => {
       await user.keyboard('[ArrowRight]');
       expect(input).not.toHaveFocus();
       expect(button2).toHaveFocus();
+    });
+  });
+
+  describe('server-side rendering', () => {
+    it('renders a roving tab stop on the first item', () => {
+      renderToString(
+        <Toolbar.Root>
+          <Toolbar.Button data-testid="button-1" />
+          <Toolbar.Button data-testid="button-2" />
+        </Toolbar.Root>,
+      );
+
+      expect(screen.getByTestId('button-1')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('button-2')).toHaveAttribute('tabindex', '-1');
     });
   });
 });


### PR DESCRIPTION
Closes #5597

Server-rendered composite items all had `tabindex="-1"`: the item index was only registered in a layout effect, so during SSR no item matched the initial highlight and the widget was unreachable by Tab until hydration.

## Changes

- `useCompositeListItem` now always guesses the index from render order, and the opt-in `guess` option (previously used by Menu, Select, Combobox, and OTP Field items) is removed. A wrong guess (grouped or out-of-order rendering) is still corrected by the commit flush before paint. An item rendered outside a `CompositeList` stays at `-1` so it doesn't consume from the default context's module-level counter.
- The server now emits `tabindex="0"` on the first item of every roving composite (radio group, tabs, toolbar, toggle group, menubar). When a later item is checked/selected, hydration moves the tab stop to it without a mismatch warning (checked on React 18 and 19, with and without Strict Mode). The server pass cannot know the active index, since it is resolved from the registered items after mount.
- Accordion items and tab panels render their real `data-index` in SSR markup instead of `-1`.
