### PR TITLE
[Slider] Commit keyboard inputs on key release instead of every step

### DIFF
--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -962,6 +962,92 @@ describe('<Slider.Root />', () => {
       expect(slider2).toHaveAttribute('aria-valuenow', '50');
     });
 
+    it('commits on key release rather than on every keydown', async () => {
+      const handleValueChange = vi.fn();
+      const handleValueCommitted = vi.fn();
+
+      await render(
+        <Slider.Root
+          defaultValue={0}
+          onValueChange={handleValueChange}
+          onValueCommitted={handleValueCommitted}
+        >
+          <Slider.Control>
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>,
+      );
+
+      const slider = screen.getByRole('slider');
+      await act(async () => {
+        slider.focus();
+      });
+
+      fireEvent.keyDown(slider, { key: ARROW_RIGHT });
+      fireEvent.keyDown(slider, { key: ARROW_RIGHT });
+
+      expect(handleValueChange).toHaveBeenCalledTimes(2);
+      expect(handleValueCommitted).not.toHaveBeenCalled();
+      expect(slider).toHaveAttribute('aria-valuenow', '2');
+
+      fireEvent.keyUp(slider, { key: ARROW_RIGHT });
+
+      expect(handleValueCommitted).toHaveBeenCalledTimes(1);
+      expect(handleValueCommitted.mock.calls[0][0]).toBe(2);
+      expect(handleValueCommitted.mock.calls[0][1].reason).toBe(REASONS.keyboard);
+    });
+
+    it('commits the pending keyboard value on blur when the key release is missed', async () => {
+      const handleValueCommitted = vi.fn();
+
+      await render(
+        <Slider.Root defaultValue={0} onValueCommitted={handleValueCommitted}>
+          <Slider.Control>
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>,
+      );
+
+      const slider = screen.getByRole('slider');
+      await act(async () => {
+        slider.focus();
+      });
+
+      fireEvent.keyDown(slider, { key: ARROW_RIGHT });
+      expect(handleValueCommitted).not.toHaveBeenCalled();
+
+      await act(async () => {
+        slider.blur();
+      });
+
+      expect(handleValueCommitted).toHaveBeenCalledTimes(1);
+      expect(handleValueCommitted.mock.calls[0][0]).toBe(1);
+      expect(handleValueCommitted.mock.calls[0][1].reason).toBe(REASONS.keyboard);
+    });
+
+    it('does not commit on key release when the value did not change', async () => {
+      const handleValueCommitted = vi.fn();
+
+      await render(
+        <Slider.Root defaultValue={100} onValueCommitted={handleValueCommitted}>
+          <Slider.Control>
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>,
+      );
+
+      const slider = screen.getByRole('slider');
+      await act(async () => {
+        slider.focus();
+      });
+
+      fireEvent.keyDown(slider, { key: ARROW_RIGHT });
+      fireEvent.keyUp(slider, { key: ARROW_RIGHT });
+
+      expect(handleValueCommitted).not.toHaveBeenCalled();
+      expect(slider).toHaveAttribute('aria-valuenow', '100');
+    });
+
     it.skipIf(isJSDOM)('does not commit when thumb press leaves the value unchanged', async () => {
       const handleValueChange = vi.fn();
       const handleValueCommitted = vi.fn();

--- a/packages/react/src/slider/root/SliderRoot.tsx
+++ b/packages/react/src/slider/root/SliderRoot.tsx
@@ -133,6 +133,8 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
   // The values when the current drag interaction started.
   const pressedValuesRef = React.useRef<readonly number[] | null>(null);
   const lastChangeReasonRef = React.useRef<SliderRoot.ChangeEventReason>(REASONS.none);
+  // The latest value applied through keyboard input that has not been committed yet.
+  const pendingKeyboardValueRef = React.useRef<number | number[] | null>(null);
 
   // We can't use the :active browser pseudo-classes.
   // - The active state isn't triggered when clicking on the rail.
@@ -230,7 +232,8 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
       const newValue = getSliderValue(valueInput, index, min, max, range, values);
 
       if (validateMinimumDistance(newValue, step, minStepsBetweenValues)) {
-        const reason = 'key' in event ? REASONS.keyboard : REASONS.inputChange;
+        const isKeyboard = 'key' in event;
+        const reason = isKeyboard ? REASONS.keyboard : REASONS.inputChange;
         const applied = setValue(
           newValue,
           createChangeEventDetails(reason, event.nativeEvent, undefined, {
@@ -240,11 +243,24 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
         setTouched(true);
 
         if (applied) {
-          onValueCommitted(newValue, createGenericEventDetails(reason, event.nativeEvent));
+          if (isKeyboard) {
+            pendingKeyboardValueRef.current = newValue;
+          } else {
+            onValueCommitted(newValue, createGenericEventDetails(reason, event.nativeEvent));
+          }
         }
       }
     },
   );
+
+  const commitKeyboardValue = useStableCallback((nativeEvent?: KeyboardEvent) => {
+    const pendingValue = pendingKeyboardValueRef.current;
+    if (pendingValue == null) {
+      return;
+    }
+    pendingKeyboardValueRef.current = null;
+    onValueCommitted(pendingValue, createGenericEventDetails(REASONS.keyboard, nativeEvent));
+  });
 
   /* istanbul ignore else -- `process.env.NODE_ENV` is a build-time constant under test */
   if (process.env.NODE_ENV !== 'production') {
@@ -301,6 +317,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
   const contextValue: SliderRootContext = React.useMemo(
     () => ({
       active,
+      commitKeyboardValue,
       controlRef,
       disabled,
       dragging,
@@ -342,6 +359,7 @@ export const SliderRoot = React.forwardRef(function SliderRoot<
     [
       active,
       ariaLabelledby,
+      commitKeyboardValue,
       defaultLabelId,
       disabled,
       dragging,

--- a/packages/react/src/slider/root/SliderRootContext.ts
+++ b/packages/react/src/slider/root/SliderRootContext.ts
@@ -15,6 +15,11 @@ export interface SliderRootContext {
    * The index of the most recently interacted thumb.
    */
   lastUsedThumbIndex: number;
+  /**
+   * Commits the value produced by the pending keyboard interaction, if any.
+   * Called when an arrow key is released or focus leaves the thumb.
+   */
+  commitKeyboardValue: (nativeEvent?: KeyboardEvent) => void;
   controlRef: React.RefObject<HTMLElement | null>;
   dragging: boolean;
   disabled: boolean;

--- a/packages/react/src/slider/thumb/SliderThumb.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.tsx
@@ -115,6 +115,7 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
 
   const {
     active: activeIndex,
+    commitKeyboardValue,
     lastUsedThumbIndex,
     controlRef,
     disabled: contextDisabled,
@@ -347,6 +348,10 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
 
         setActive(-1);
 
+        // Commit any value from an in-progress keyboard interaction whose `keyup`
+        // never reached this input.
+        commitKeyboardValue();
+
         // Keep field-level blur logic from running while focus moves to another thumb
         // of the same slider, so validation doesn't commit mid-interaction.
         if (thumbRefs.current.some((thumb) => contains(thumb, event.relatedTarget))) {
@@ -435,6 +440,13 @@ export const SliderThumb = React.forwardRef(function SliderThumb(
           handleInputChange(newValue, index, event);
           event.preventDefault();
         }
+      },
+      onKeyUp(event: React.KeyboardEvent) {
+        if (!ALL_KEYS.has(event.key)) {
+          return;
+        }
+
+        commitKeyboardValue(event.nativeEvent);
       },
       step,
       style: {


### PR DESCRIPTION
A slider can be adjusted two ways:

- `Dragging` fires `onValueChange` on every pointer move, but `onValueCommitted` only once the pointer is released.
- `Keyboard` fires `onValueCommitted` on every step, causing each step's value to be continuous committed until key is released.

The keyboard input values should only be committed once the user lets go, the same way dragging works. **Committing on every keyboard step causes unnecessary commit callbacks, potentially slowing down the UI on expensive operations**.

## Fix

Defer the keyboard commit until the key is released:

- **`SliderRoot`** — `handleInputChange` now stashes keyboard values in a `pendingKeyboardValueRef` instead of committing immediately. A new `commitKeyboardValue` callback fires `onValueCommitted` once with the pending value and clears the ref.
- **`SliderThumb`** — added an `onKeyUp` handler on the input that commits the pending value when a stepping key is released, plus a fallback in `onBlur` for the rare case where the `keyup` never reaches the input.
- **`SliderRootContext`** — exposes `commitKeyboardValue` so the thumb calls logic owned by the root.

## Tests

Added tests to `SliderRoot.test.tsx` to ensure keyboard input behavior is adhered.

Closes #5595