### PR TITLE
[code-infra] Import vitest globals in tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -156,9 +156,28 @@ export default defineConfig(
       // matching the pattern of the test runner
       `**/*${EXTENSION_TEST_FILE}`,
     ],
-    extends: createTestConfig({ useMocha: false }),
+    // `useVitest` enables the vitest rules ahead of the code-infra bump that
+    // enables them unconditionally (and drops both options).
+    extends: createTestConfig({ useMocha: false, useVitest: true }),
     rules: {
       'mui/add-undef-to-optional': 'off',
+      // These helpers assert internally (shared between multiple tests).
+      'vitest/expect-expect': [
+        'error',
+        {
+          assertFunctionNames: [
+            'expect',
+            'expect*',
+            'assert*',
+            'openAndCloseDialog',
+            'openAndClosePopover',
+            'takeScreenshot',
+            'waitForBubbleToOverlapActiveTab',
+          ],
+        },
+      ],
+      // Parameterized suites pass loop variables as titles.
+      'vitest/valid-title': ['error', { allowArguments: true }],
       'no-restricted-syntax': [
         'error',
         ...baseRestrictedSyntax,

--- a/packages/react/src/accordion/header/AccordionHeader.test.tsx
+++ b/packages/react/src/accordion/header/AccordionHeader.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Accordion } from '@base-ui/react/accordion';
 import { describeConformance, createRenderer } from '#test-utils';
 

--- a/packages/react/src/accordion/item/AccordionItem.test.tsx
+++ b/packages/react/src/accordion/item/AccordionItem.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { Accordion } from '@base-ui/react/accordion';
 import { describeConformance, createRenderer, isJSDOM } from '#test-utils';

--- a/packages/react/src/accordion/panel/AccordionPanel.test.tsx
+++ b/packages/react/src/accordion/panel/AccordionPanel.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { reactMajor, screen, waitFor } from '@mui/internal-test-utils';
 import * as React from 'react';
 import { Accordion } from '@base-ui/react/accordion';

--- a/packages/react/src/accordion/root/AccordionRoot.test.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Accordion } from '@base-ui/react/accordion';

--- a/packages/react/src/accordion/trigger/AccordionTrigger.test.tsx
+++ b/packages/react/src/accordion/trigger/AccordionTrigger.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Accordion } from '@base-ui/react/accordion';
 import { screen } from '@mui/internal-test-utils';
 import { describeConformance, createRenderer } from '#test-utils';

--- a/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
+++ b/packages/react/src/alert-dialog/root/AlertDialogRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import type { UserEvent } from '@testing-library/user-event';
 import { act, flushMicrotasks, screen, waitFor, within } from '@mui/internal-test-utils';

--- a/packages/react/src/autocomplete/item/AutocompleteItem.test.tsx
+++ b/packages/react/src/autocomplete/item/AutocompleteItem.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';
 import { Autocomplete } from '@base-ui/react/autocomplete';

--- a/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
+++ b/packages/react/src/autocomplete/root/AutocompleteRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, isJSDOM } from '#test-utils';

--- a/packages/react/src/autocomplete/value/AutocompleteValue.test.tsx
+++ b/packages/react/src/autocomplete/value/AutocompleteValue.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { Autocomplete } from '@base-ui/react/autocomplete';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/avatar/fallback/AvatarFallback.test.tsx
+++ b/packages/react/src/avatar/fallback/AvatarFallback.test.tsx
@@ -1,4 +1,4 @@
-import { Mock, vi, expect } from 'vitest';
+import { Mock, vi, expect, describe, beforeEach, afterEach, it } from 'vitest';
 import * as React from 'react';
 import { Avatar } from '@base-ui/react/avatar';
 import { waitFor, screen } from '@mui/internal-test-utils';

--- a/packages/react/src/avatar/image/AvatarImage.test.tsx
+++ b/packages/react/src/avatar/image/AvatarImage.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, afterEach, it } from 'vitest';
 import * as React from 'react';
 import { Avatar } from '@base-ui/react/avatar';
 import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/avatar/root/AvatarRoot.test.tsx
+++ b/packages/react/src/avatar/root/AvatarRoot.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Avatar } from '@base-ui/react/avatar';
 import { describeConformance, createRenderer } from '#test-utils';
 

--- a/packages/react/src/button/Button.test.tsx
+++ b/packages/react/src/button/Button.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Button } from '@base-ui/react/button';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
+++ b/packages/react/src/checkbox-group/CheckboxGroup.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
@@ -1924,8 +1924,7 @@ describe('<CheckboxGroup />', () => {
 
         await user.click(screen.getByText('Submit'));
 
-        expect(validate).toHaveBeenCalledOnce();
-        expect(validate).toHaveBeenCalledWith(['one'], { group: [] });
+        expect(validate).toHaveBeenCalledExactlyOnceWith(['one'], { group: [] });
       },
     );
 
@@ -1962,8 +1961,7 @@ describe('<CheckboxGroup />', () => {
 
         await user.click(screen.getByText('Submit'));
 
-        expect(validate).toHaveBeenCalledOnce();
-        expect(validate).toHaveBeenCalledWith(['one'], { group: [] });
+        expect(validate).toHaveBeenCalledExactlyOnceWith(['one'], { group: [] });
 
         await user.click(screen.getByText('Select two'));
 
@@ -1992,8 +1990,7 @@ describe('<CheckboxGroup />', () => {
 
       await user.click(screen.getByText('Select'));
 
-      expect(validate).toHaveBeenCalledOnce();
-      expect(validate).toHaveBeenCalledWith(['one'], { group: ['one'] });
+      expect(validate).toHaveBeenCalledExactlyOnceWith(['one'], { group: ['one'] });
     });
 
     it('validates an initially empty group through the imperative action', async () => {
@@ -2017,8 +2014,7 @@ describe('<CheckboxGroup />', () => {
 
       await user.click(screen.getByText('Validate'));
 
-      expect(validate).toHaveBeenCalledOnce();
-      expect(validate).toHaveBeenCalledWith([], { group: [] });
+      expect(validate).toHaveBeenCalledExactlyOnceWith([], { group: [] });
     });
 
     it('skips a disabled representative checkbox on a later focus attempt', async () => {

--- a/packages/react/src/checkbox-group/useCheckboxGroupParent.test.tsx
+++ b/packages/react/src/checkbox-group/useCheckboxGroupParent.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { CheckboxGroup } from '@base-ui/react/checkbox-group';
@@ -379,9 +379,7 @@ describe('useCheckboxGroupParent', () => {
     expect(parent).toHaveAttribute('aria-checked', 'mixed');
     expect(checkboxA).toHaveAttribute('aria-checked', 'true');
     checkboxes.forEach((checkbox) => {
-      if (checkbox !== checkboxA) {
-        expect(checkbox).toHaveAttribute('aria-checked', 'false');
-      }
+      expect(checkbox).toHaveAttribute('aria-checked', checkbox === checkboxA ? 'true' : 'false');
     });
   });
 

--- a/packages/react/src/checkbox/indicator/CheckboxIndicator.test.tsx
+++ b/packages/react/src/checkbox/indicator/CheckboxIndicator.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it, afterEach } from 'vitest';
 import * as React from 'react';
 import { Checkbox } from '@base-ui/react/checkbox';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/checkbox/root/CheckboxRoot.react17.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.react17.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe } from 'vitest';
 import * as React from 'react';
 import { Checkbox } from '@base-ui/react/checkbox';
 import { CheckboxGroup } from '@base-ui/react/checkbox-group';

--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Checkbox } from '@base-ui/react/checkbox';

--- a/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
+++ b/packages/react/src/collapsible/panel/CollapsiblePanel.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import {
   act,

--- a/packages/react/src/collapsible/root/CollapsibleRoot.test.tsx
+++ b/packages/react/src/collapsible/root/CollapsibleRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { screen } from '@mui/internal-test-utils';
 import { Collapsible } from '@base-ui/react/collapsible';

--- a/packages/react/src/collapsible/trigger/CollapsibleTrigger.test.tsx
+++ b/packages/react/src/collapsible/trigger/CollapsibleTrigger.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import { Collapsible } from '@base-ui/react/collapsible';
 import { describeConformance } from '../../../test/describeConformance';

--- a/packages/react/src/combobox/arrow/ComboboxArrow.test.tsx
+++ b/packages/react/src/combobox/arrow/ComboboxArrow.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/combobox/backdrop/ComboboxBackdrop.test.tsx
+++ b/packages/react/src/combobox/backdrop/ComboboxBackdrop.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/combobox/chip-remove/ComboboxChipRemove.test.tsx
+++ b/packages/react/src/combobox/chip-remove/ComboboxChipRemove.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
 import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/combobox/chip/ComboboxChip.test.tsx
+++ b/packages/react/src/combobox/chip/ComboboxChip.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
 import { DirectionProvider } from '@base-ui/react/direction-provider';

--- a/packages/react/src/combobox/chips/ComboboxChips.test.tsx
+++ b/packages/react/src/combobox/chips/ComboboxChips.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/combobox/clear/ComboboxClear.test.tsx
+++ b/packages/react/src/combobox/clear/ComboboxClear.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { Autocomplete } from '@base-ui/react/autocomplete';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/combobox/collection/ComboboxCollection.test.tsx
+++ b/packages/react/src/combobox/collection/ComboboxCollection.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer } from '#test-utils';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/combobox/empty/ComboboxEmpty.test.tsx
+++ b/packages/react/src/combobox/empty/ComboboxEmpty.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/combobox/group-label/ComboboxGroupLabel.test.tsx
+++ b/packages/react/src/combobox/group-label/ComboboxGroupLabel.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/combobox/group/ComboboxGroup.test.tsx
+++ b/packages/react/src/combobox/group/ComboboxGroup.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/combobox/group/ComboboxGroupContext.test.tsx
+++ b/packages/react/src/combobox/group/ComboboxGroupContext.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { createRenderer } from '#test-utils';
 import { useComboboxGroupContext } from './ComboboxGroupContext';
 

--- a/packages/react/src/combobox/icon/ComboboxIcon.test.tsx
+++ b/packages/react/src/combobox/icon/ComboboxIcon.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/combobox/input-group/ComboboxInputGroup.test.tsx
+++ b/packages/react/src/combobox/input-group/ComboboxInputGroup.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
 import { Field } from '@base-ui/react/field';

--- a/packages/react/src/combobox/input/ComboboxInput.android.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.android.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer } from '#test-utils';
 import { fireEvent, screen } from '@mui/internal-test-utils';

--- a/packages/react/src/combobox/input/ComboboxInput.gecko.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.gecko.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/combobox/input/ComboboxInput.test.tsx
+++ b/packages/react/src/combobox/input/ComboboxInput.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/combobox/item-indicator/ComboboxItemIndicator.test.tsx
+++ b/packages/react/src/combobox/item-indicator/ComboboxItemIndicator.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/combobox/item/ComboboxItem.test.tsx
+++ b/packages/react/src/combobox/item/ComboboxItem.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/combobox/item/ComboboxItemContext.test.tsx
+++ b/packages/react/src/combobox/item/ComboboxItemContext.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { createRenderer } from '#test-utils';
 import { useComboboxItemContext } from './ComboboxItemContext';
 

--- a/packages/react/src/combobox/items/createItems.test.tsx
+++ b/packages/react/src/combobox/items/createItems.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/combobox/label/ComboboxLabel.test.tsx
+++ b/packages/react/src/combobox/label/ComboboxLabel.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { SafeReact } from '@base-ui/utils/safeReact';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/combobox/list/ComboboxList.test.tsx
+++ b/packages/react/src/combobox/list/ComboboxList.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { Autocomplete } from '@base-ui/react/autocomplete';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/combobox/popup/ComboboxPopup.test.tsx
+++ b/packages/react/src/combobox/popup/ComboboxPopup.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/combobox/portal/ComboboxPortal.test.tsx
+++ b/packages/react/src/combobox/portal/ComboboxPortal.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/combobox/portal/ComboboxPortalContext.test.tsx
+++ b/packages/react/src/combobox/portal/ComboboxPortalContext.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { createRenderer } from '#test-utils';
 import { useComboboxPortalContext } from './ComboboxPortalContext';
 

--- a/packages/react/src/combobox/positioner/ComboboxPositioner.test.tsx
+++ b/packages/react/src/combobox/positioner/ComboboxPositioner.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
 import { screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/combobox/positioner/ComboboxPositionerContext.test.tsx
+++ b/packages/react/src/combobox/positioner/ComboboxPositionerContext.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { createRenderer } from '#test-utils';
 import { useComboboxPositionerContext } from './ComboboxPositionerContext';
 

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import {
@@ -741,6 +741,8 @@ describe('<Combobox.Root />', () => {
         </Combobox.Portal>
       </Combobox.Root>,
     );
+
+    expect(screen.getByRole('combobox')).not.toBe(null);
   });
 
   it('hides the trigger when popup is open with input outside the popup', async () => {
@@ -3703,9 +3705,10 @@ describe('<Combobox.Root />', () => {
         .find((el) => el.getAttribute('name') === 'test') as HTMLInputElement;
       expect(hiddenInput).not.toBeUndefined();
 
-      if (withField) {
-        expect(screen.getByTestId('error')).toHaveTextContent('test');
-      }
+      // Only the Field wrapper renders an error.
+      const expectedError = withField ? 'test' : undefined;
+
+      expect(screen.queryByTestId('error')?.textContent).toBe(expectedError);
 
       fireEvent.change(hiddenInput, { target: { value: 'b' } });
       await flushMicrotasks();
@@ -3715,9 +3718,7 @@ describe('<Combobox.Root />', () => {
       expect(visibleInput.value).toBe('');
       expect(hiddenInput.value).toBe('');
 
-      if (withField) {
-        expect(screen.getByTestId('error')).toHaveTextContent('test');
-      }
+      expect(screen.queryByTestId('error')?.textContent).toBe(expectedError);
     },
   );
 

--- a/packages/react/src/combobox/root/ComboboxRootContext.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRootContext.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { createRenderer } from '#test-utils';
 import {
   useComboboxDerivedItemsContext,

--- a/packages/react/src/combobox/root/utils/index.test.ts
+++ b/packages/react/src/combobox/root/utils/index.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { getFilter } from '../../../internals/filter';
 import {
   createCollatorItemFilter,

--- a/packages/react/src/combobox/root/utils/useFilter.test.tsx
+++ b/packages/react/src/combobox/root/utils/useFilter.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { createRenderer } from '#test-utils';
 import { screen } from '@mui/internal-test-utils';
 import { useComboboxFilter } from './useFilter';

--- a/packages/react/src/combobox/status/ComboboxStatus.iOS.test.tsx
+++ b/packages/react/src/combobox/status/ComboboxStatus.iOS.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/combobox/status/ComboboxStatus.test.tsx
+++ b/packages/react/src/combobox/status/ComboboxStatus.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Combobox } from '@base-ui/react/combobox';
 import { createRenderer, describeConformance } from '#test-utils';
 import { screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/combobox/store.test.tsx
+++ b/packages/react/src/combobox/store.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
+++ b/packages/react/src/combobox/trigger/ComboboxTrigger.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Combobox } from '@base-ui/react/combobox';
 import { Autocomplete } from '@base-ui/react/autocomplete';

--- a/packages/react/src/combobox/utils/handleInputPress.test.ts
+++ b/packages/react/src/combobox/utils/handleInputPress.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import type * as React from 'react';
 import { handleInputPress } from './handleInputPress';
 import type { ComboboxStore } from '../store';

--- a/packages/react/src/combobox/utils/parts.test.ts
+++ b/packages/react/src/combobox/utils/parts.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { clickHighlightedItem, getIndexAfterChipRemoval } from './parts';
 import type { ComboboxStore } from '../store';
 

--- a/packages/react/src/combobox/utils/useInitialLiveRegionTextMutation.test.tsx
+++ b/packages/react/src/combobox/utils/useInitialLiveRegionTextMutation.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { createRenderer } from '#test-utils';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/combobox/value/ComboboxValue.test.tsx
+++ b/packages/react/src/combobox/value/ComboboxValue.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { screen } from '@mui/internal-test-utils';
 import { Combobox } from '@base-ui/react/combobox';

--- a/packages/react/src/context-menu/root/ContextMenuRoot.non-mac.test.tsx
+++ b/packages/react/src/context-menu/root/ContextMenuRoot.non-mac.test.tsx
@@ -1,4 +1,4 @@
-import { vi, expect } from 'vitest';
+import { vi, expect, describe, beforeEach, it } from 'vitest';
 import {
   fireEvent,
   ignoreActWarnings,

--- a/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
+++ b/packages/react/src/context-menu/root/ContextMenuRoot.test.tsx
@@ -1,4 +1,4 @@
-import { vi, expect } from 'vitest';
+import { vi, expect, describe, beforeEach, it } from 'vitest';
 import {
   fireEvent,
   flushMicrotasks,

--- a/packages/react/src/context-menu/trigger/ContextMenuTrigger.test.tsx
+++ b/packages/react/src/context-menu/trigger/ContextMenuTrigger.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { ContextMenu } from '@base-ui/react/context-menu';

--- a/packages/react/src/csp-provider/CSPProvider.test.tsx
+++ b/packages/react/src/csp-provider/CSPProvider.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import { Select } from '@base-ui/react/select';
 import { CSPProvider } from '@base-ui/react/csp-provider';

--- a/packages/react/src/dialog/backdrop/DialogBackdrop.test.tsx
+++ b/packages/react/src/dialog/backdrop/DialogBackdrop.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { Dialog } from '@base-ui/react/dialog';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/dialog/close/DialogClose.test.tsx
+++ b/packages/react/src/dialog/close/DialogClose.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Dialog } from '@base-ui/react/dialog';
 import { fireEvent, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/dialog/description/DialogDescription.test.tsx
+++ b/packages/react/src/dialog/description/DialogDescription.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Dialog } from '@base-ui/react/dialog';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/dialog/popup/DialogPopup.test.tsx
+++ b/packages/react/src/dialog/popup/DialogPopup.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Dialog } from '@base-ui/react/dialog';
 import { AlertDialog } from '@base-ui/react/alert-dialog';
@@ -32,12 +32,21 @@ describe('<Dialog.Popup />', () => {
   });
 
   describe('prop: keepMounted', () => {
-    [
-      [true, true],
-      [false, false],
-      [undefined, false],
-    ].forEach(([keepMounted, expectedIsMounted]) => {
-      it(`should ${!expectedIsMounted ? 'not ' : ''}keep the dialog mounted when keepMounted=${keepMounted}`, async () => {
+    it('should keep the dialog mounted when keepMounted=true', async () => {
+      await render(
+        <Dialog.Root open={false} modal={false}>
+          <Dialog.Portal keepMounted>
+            <Dialog.Popup />
+          </Dialog.Portal>
+        </Dialog.Root>,
+      );
+
+      const dialog = screen.getByRole('dialog', { hidden: true });
+      expect(dialog).toBeInaccessible();
+    });
+
+    [false, undefined].forEach((keepMounted) => {
+      it(`should not keep the dialog mounted when keepMounted=${keepMounted}`, async () => {
         await render(
           <Dialog.Root open={false} modal={false}>
             <Dialog.Portal keepMounted={keepMounted}>
@@ -46,13 +55,7 @@ describe('<Dialog.Popup />', () => {
           </Dialog.Root>,
         );
 
-        const dialog = screen.queryByRole('dialog', { hidden: true });
-        if (expectedIsMounted) {
-          expect(dialog).not.toBe(null);
-          expect(dialog).toBeInaccessible();
-        } else {
-          expect(dialog).toBe(null);
-        }
+        expect(screen.queryByRole('dialog', { hidden: true })).toBe(null);
       });
     });
   });

--- a/packages/react/src/dialog/portal/DialogPortal.test.tsx
+++ b/packages/react/src/dialog/portal/DialogPortal.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Dialog } from '@base-ui/react/dialog';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.detached-triggers.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import type { UserEvent } from '@testing-library/user-event';
 import { act, fireEvent, screen, waitFor, within } from '@mui/internal-test-utils';

--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it, afterEach } from 'vitest';
 import type { CDPSession } from '@vitest/browser-playwright';
 import * as React from 'react';
 import { act, fireEvent, screen, waitFor, flushMicrotasks } from '@mui/internal-test-utils';
@@ -611,20 +611,6 @@ describe('<Dialog.Root />', () => {
       });
     });
 
-    describe('prop: modal', () => {
-      it('makes other interactive elements on the page inert when a modal dialog is open', async () => {
-        await render(<TestDialog rootProps={{ defaultOpen: true, modal: true }} />);
-
-        expect(screen.getByRole('presentation', { hidden: true })).not.toBe(null);
-      });
-
-      it('does not make other interactive elements on the page inert when a non-modal dialog is open', async () => {
-        await render(<TestDialog rootProps={{ defaultOpen: true, modal: false }} />);
-
-        expect(screen.queryByRole('presentation')).toBe(null);
-      });
-    });
-
     describe('prop: disablePointerDismissal', () => {
       (
         [
@@ -654,12 +640,7 @@ describe('<Dialog.Root />', () => {
           fireEvent.mouseDown(outside);
           fireEvent.click(outside);
           expect(handleOpenChange.mock.calls.length === 1).toBe(expectDismissed);
-
-          if (expectDismissed) {
-            expect(screen.queryByRole('dialog')).toBe(null);
-          } else {
-            expect(screen.queryByRole('dialog')).not.toBe(null);
-          }
+          expect(screen.queryByRole('dialog') === null).toBe(expectDismissed);
         });
       });
     });
@@ -881,6 +862,18 @@ describe('<Dialog.Root />', () => {
     });
 
     describe('prop: modal', () => {
+      it('makes other interactive elements on the page inert when a modal dialog is open', async () => {
+        await render(<TestDialog rootProps={{ defaultOpen: true, modal: true }} />);
+
+        expect(screen.getByRole('presentation', { hidden: true })).not.toBe(null);
+      });
+
+      it('does not make other interactive elements on the page inert when a non-modal dialog is open', async () => {
+        await render(<TestDialog rootProps={{ defaultOpen: true, modal: false }} />);
+
+        expect(screen.queryByRole('presentation')).toBe(null);
+      });
+
       it('should render an internal backdrop when `true`', async () => {
         const { user } = await render(
           <div>

--- a/packages/react/src/dialog/title/DialogTitle.test.tsx
+++ b/packages/react/src/dialog/title/DialogTitle.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Dialog } from '@base-ui/react/dialog';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/dialog/trigger/DialogTrigger.test.tsx
+++ b/packages/react/src/dialog/trigger/DialogTrigger.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Dialog } from '@base-ui/react/dialog';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/dialog/viewport/DialogViewport.test.tsx
+++ b/packages/react/src/dialog/viewport/DialogViewport.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { Dialog } from '@base-ui/react/dialog';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/direction-provider/DirectionProvider.test.tsx
+++ b/packages/react/src/direction-provider/DirectionProvider.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import {
   DirectionProvider,

--- a/packages/react/src/drawer/indent-background/DrawerIndentBackground.test.tsx
+++ b/packages/react/src/drawer/indent-background/DrawerIndentBackground.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Drawer } from '@base-ui/react/drawer';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/drawer/root/DrawerSnapPoints.test.tsx
+++ b/packages/react/src/drawer/root/DrawerSnapPoints.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { Drawer } from '@base-ui/react/drawer';
 import { screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/drawer/root/useDrawerSnapPoints.test.ts
+++ b/packages/react/src/drawer/root/useDrawerSnapPoints.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { closestSnapPointIndex, getSnapPointSwipeMovement } from './useDrawerSnapPoints';
 
 describe('getSnapPointSwipeMovement', () => {

--- a/packages/react/src/field/control/FieldControl.test.tsx
+++ b/packages/react/src/field/control/FieldControl.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import {
   act,
   createRenderer,

--- a/packages/react/src/field/description/FieldDescription.test.tsx
+++ b/packages/react/src/field/description/FieldDescription.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Field } from '@base-ui/react/field';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import { describeConformance } from '../../../test/describeConformance';

--- a/packages/react/src/field/error/FieldError.test.tsx
+++ b/packages/react/src/field/error/FieldError.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it, afterEach } from 'vitest';
 import * as React from 'react';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';

--- a/packages/react/src/field/item/FieldItem.test.tsx
+++ b/packages/react/src/field/item/FieldItem.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Field } from '@base-ui/react/field';
 import { Checkbox } from '@base-ui/react/checkbox';

--- a/packages/react/src/field/label/FieldLabel.test.tsx
+++ b/packages/react/src/field/label/FieldLabel.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { Field } from '@base-ui/react/field';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/field/root/FieldRoot.react17.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.react17.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { Field } from '@base-ui/react/field';

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -1,4 +1,4 @@
-import { vi, expect } from 'vitest';
+import { vi, expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { Form } from '@base-ui/react/form';
 import { NumberField } from '@base-ui/react/number-field';

--- a/packages/react/src/field/validity/FieldValidity.test.tsx
+++ b/packages/react/src/field/validity/FieldValidity.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { act, createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';

--- a/packages/react/src/fieldset/legend/FieldsetLegend.test.tsx
+++ b/packages/react/src/fieldset/legend/FieldsetLegend.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { createRenderer, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Fieldset } from '@base-ui/react/fieldset';

--- a/packages/react/src/fieldset/root/FieldsetRoot.test.tsx
+++ b/packages/react/src/fieldset/root/FieldsetRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { createRenderer, fireEvent, screen } from '@mui/internal-test-utils';
 import { Checkbox } from '@base-ui/react/checkbox';

--- a/packages/react/src/floating-ui-react/components/FloatingDelayGroup.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingDelayGroup.test.tsx
@@ -1,4 +1,4 @@
-import { vi, expect } from 'vitest';
+import { vi, expect, beforeEach, test, it } from 'vitest';
 
 /* eslint-disable react/jsx-fragments */
 import * as React from 'react';

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -1,4 +1,4 @@
-import { test, vi, expect } from 'vitest';
+import { test, vi, expect, beforeEach, describe } from 'vitest';
 /* eslint-disable jsx-a11y/role-has-required-aria-props */
 /* eslint-disable no-promise-executor-return */
 /* eslint-disable react/function-component-definition */
@@ -2065,7 +2065,7 @@ describe('FloatingFocusManager', () => {
     });
   });
 
-  describe.skipIf(!isJSDOM)('JSDOM-only coverage', () => {
+  describe.skipIf(!isJSDOM)('JSDOM-only combobox and focus return coverage', () => {
     test('trapped combobox prevents focus moving outside floating element', async () => {
       function App() {
         const [isOpen, setIsOpen] = React.useState(false);

--- a/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingPortal.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, test } from 'vitest';
 import * as React from 'react';
 import { fireEvent, flushMicrotasks, render, screen } from '@mui/internal-test-utils';
 import { isJSDOM } from '#test-utils';

--- a/packages/react/src/floating-ui-react/hooks/useClick.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useClick.test.tsx
@@ -1,4 +1,4 @@
-import { vi, expect } from 'vitest';
+import { vi, expect, beforeEach, afterEach, test } from 'vitest';
 import { act, fireEvent, flushMicrotasks, render, screen } from '@mui/internal-test-utils';
 import * as React from 'react';
 import { isJSDOM, useTestInteractions } from '#test-utils';

--- a/packages/react/src/floating-ui-react/hooks/useDismiss.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useDismiss.test.tsx
@@ -1,4 +1,4 @@
-import { vi, expect } from 'vitest';
+import { vi, expect, beforeEach, describe, test } from 'vitest';
 
 import { act, fireEvent, flushMicrotasks, render, screen, waitFor } from '@mui/internal-test-utils';
 import userEvent from '@testing-library/user-event';

--- a/packages/react/src/floating-ui-react/hooks/useFocus.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useFocus.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, beforeEach, afterEach, it } from 'vitest';
 import { act, fireEvent, render, screen } from '@mui/internal-test-utils';
 import * as React from 'react';
 import { isJSDOM, useTestInteractions } from '#test-utils';

--- a/packages/react/src/floating-ui-react/hooks/useHover.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useHover.test.tsx
@@ -1,4 +1,4 @@
-import { vi, test, expect } from 'vitest';
+import { vi, test, expect, beforeEach, describe } from 'vitest';
 
 import { act, fireEvent, flushMicrotasks, render, screen, waitFor } from '@mui/internal-test-utils';
 import * as React from 'react';
@@ -170,7 +170,7 @@ describe.skipIf(!isJSDOM)('useHover', () => {
     spy.mockRestore();
   });
 
-  test.skip('restMs is always 0 for touch input', async () => {
+  test.todo('restMs is always 0 for touch input', async () => {
     render(<App restMs={100} />);
 
     fireEvent.pointerDown(screen.getByRole('button'), { pointerType: 'touch' });

--- a/packages/react/src/floating-ui-react/hooks/useHoverReferenceInteraction.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useHoverReferenceInteraction.test.tsx
@@ -1,4 +1,4 @@
-import { vi, expect } from 'vitest';
+import { vi, expect, it } from 'vitest';
 import { act, fireEvent, flushMicrotasks, render, screen } from '@mui/internal-test-utils';
 import * as React from 'react';
 import { isJSDOM } from '#test-utils';

--- a/packages/react/src/floating-ui-react/hooks/useTypeahead.test.tsx
+++ b/packages/react/src/floating-ui-react/hooks/useTypeahead.test.tsx
@@ -1,4 +1,4 @@
-import { vi, expect } from 'vitest';
+import { vi, expect, beforeEach, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/react/src/floating-ui-react/safePolygon.test.ts
+++ b/packages/react/src/floating-ui-react/safePolygon.test.ts
@@ -1,4 +1,4 @@
-import { vi, expect } from 'vitest';
+import { vi, expect, describe, beforeEach, afterEach, it } from 'vitest';
 import { act } from '@mui/internal-test-utils';
 import { FloatingTreeStore } from './components/FloatingTreeStore';
 import type { HandleCloseContext } from './hooks/useHoverShared';

--- a/packages/react/src/floating-ui-react/utils/composite.test.ts
+++ b/packages/react/src/floating-ui-react/utils/composite.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, it, expect } from 'vitest';
 import { isElementVisible, isHiddenByStyles, isListIndexDisabled } from './composite';
 
 afterEach(() => {

--- a/packages/react/src/floating-ui-react/utils/markOthers.test.ts
+++ b/packages/react/src/floating-ui-react/utils/markOthers.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, afterEach, test } from 'vitest';
 import { markOthers } from './markOthers';
 
 afterEach(() => {
@@ -280,6 +280,9 @@ test('does not recurse infinitely with target inside anchor in shadow root', () 
   shadowRoot.appendChild(anchor);
 
   const cleanup = markOthers([target], { ariaHidden: true });
+
+  // The host contains the target, so it must not have been hidden.
+  expect(host).not.toHaveAttribute('aria-hidden');
 
   cleanup();
 });

--- a/packages/react/src/floating-ui-react/utils/nodes.test.ts
+++ b/packages/react/src/floating-ui-react/utils/nodes.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, test } from 'vitest';
 import type { FloatingContext } from '../types';
 import { getNodeAncestors, getNodeChildren } from './nodes';
 

--- a/packages/react/src/floating-ui-react/utils/tabbable.test.ts
+++ b/packages/react/src/floating-ui-react/utils/tabbable.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, it, expect } from 'vitest';
 import { isJSDOM } from '#test-utils';
 import { visuallyHidden, visuallyHiddenInput } from '@base-ui/utils/visuallyHidden';
 import { isTabbable, tabbable } from './tabbable';

--- a/packages/react/src/form/Form.test.tsx
+++ b/packages/react/src/form/Form.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Form } from '@base-ui/react/form';

--- a/packages/react/src/input/Input.test.tsx
+++ b/packages/react/src/input/Input.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Input } from '@base-ui/react/input';
 import { createRenderer } from '@mui/internal-test-utils';
 import { describeConformance } from '../../test/describeConformance';

--- a/packages/react/src/internals/RequestQueue.test.ts
+++ b/packages/react/src/internals/RequestQueue.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { RequestQueue } from './RequestQueue';
 
 function createDeferred() {

--- a/packages/react/src/internals/TimeoutManager.test.ts
+++ b/packages/react/src/internals/TimeoutManager.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, afterEach, it } from 'vitest';
 import { TimeoutManager } from './TimeoutManager';
 
 describe('TimeoutManager', () => {

--- a/packages/react/src/internals/composite/composite.test.ts
+++ b/packages/react/src/internals/composite/composite.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { scrollIntoViewIfNeeded } from './composite';
 
 describe('Composite', () => {

--- a/packages/react/src/internals/composite/list/CompositeList.test.tsx
+++ b/packages/react/src/internals/composite/list/CompositeList.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { act, screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import {
   act,

--- a/packages/react/src/internals/filter.test.ts
+++ b/packages/react/src/internals/filter.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { getFilter } from './filter';
 
 describe('getFilter', () => {

--- a/packages/react/src/internals/getStateAttributesProps.test.ts
+++ b/packages/react/src/internals/getStateAttributesProps.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { getStateAttributesProps } from './getStateAttributesProps';
 
 describe('getStateAttributesProps', () => {

--- a/packages/react/src/internals/resolveValueLabel.test.ts
+++ b/packages/react/src/internals/resolveValueLabel.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { hasNullItemLabel, isGroupedItems, resolveSelectedLabel } from './resolveValueLabel';
 
 describe('resolveValueLabel', () => {

--- a/packages/react/src/internals/stateAttributesMapping.test.ts
+++ b/packages/react/src/internals/stateAttributesMapping.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { transitionStatusMapping } from './stateAttributesMapping';
 import { fieldValidityMapping } from './field-constants/constants';
 

--- a/packages/react/src/internals/temporal-adapter-date-fns/TemporalAdapterDateFns.test.ts
+++ b/packages/react/src/internals/temporal-adapter-date-fns/TemporalAdapterDateFns.test.ts
@@ -1,3 +1,4 @@
+import { describe, afterEach, it, expect } from 'vitest';
 import { fr } from 'date-fns/locale/fr';
 import { describeGregorianAdapter } from '#test-utils';
 import { TemporalAdapterDateFns } from './TemporalAdapterDateFns';

--- a/packages/react/src/internals/temporal-adapter-luxon/TemporalAdapterLuxon.test.ts
+++ b/packages/react/src/internals/temporal-adapter-luxon/TemporalAdapterLuxon.test.ts
@@ -1,5 +1,6 @@
 // TODO: Remove if temporal adapters are supported
 // @ts-nocheck No types available
+import { describe } from 'vitest';
 import { DateTime, Settings } from 'luxon';
 import { describeGregorianAdapter } from '#test-utils';
 import { TemporalAdapterLuxon } from './TemporalAdapterLuxon';

--- a/packages/react/src/internals/use-button/useButton.test.tsx
+++ b/packages/react/src/internals/use-button/useButton.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import { useMergedRefs } from '@base-ui/utils/useMergedRefs';

--- a/packages/react/src/internals/useAnchorPositioning.test.tsx
+++ b/packages/react/src/internals/useAnchorPositioning.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import { createRenderer } from '#test-utils';
 import { useFloating } from '../floating-ui-react';

--- a/packages/react/src/internals/useAnimationsFinished.test.tsx
+++ b/packages/react/src/internals/useAnimationsFinished.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';

--- a/packages/react/src/internals/useRenderElement.test.tsx
+++ b/packages/react/src/internals/useRenderElement.test.tsx
@@ -1,4 +1,4 @@
-import { vi, expect } from 'vitest';
+import { vi, expect, describe, it } from 'vitest';
 /* eslint-disable testing-library/render-result-naming-convention */
 import * as React from 'react';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/internals/useValueChanged.test.tsx
+++ b/packages/react/src/internals/useValueChanged.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe } from 'vitest';
 import { render } from '@testing-library/react';
 import * as React from 'react';
 import { useValueChanged } from './useValueChanged';

--- a/packages/react/src/menu/arrow/MenuArrow.test.tsx
+++ b/packages/react/src/menu/arrow/MenuArrow.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/menu/backdrop/MenuBackdrop.test.tsx
+++ b/packages/react/src/menu/backdrop/MenuBackdrop.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance } from '#test-utils';
 import { screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.test.tsx
+++ b/packages/react/src/menu/checkbox-item-indicator/MenuCheckboxItemIndicator.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/menu/checkbox-item/MenuCheckboxItem.test.tsx
+++ b/packages/react/src/menu/checkbox-item/MenuCheckboxItem.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { fireEvent, act, waitFor, screen } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';

--- a/packages/react/src/menu/group-label/MenuGroupLabel.test.tsx
+++ b/packages/react/src/menu/group-label/MenuGroupLabel.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, expect, vi } from 'vitest';
+import { afterEach, expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, screen } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';

--- a/packages/react/src/menu/group/MenuGroup.test.tsx
+++ b/packages/react/src/menu/group/MenuGroup.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/menu/item/MenuItem.test.tsx
+++ b/packages/react/src/menu/item/MenuItem.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';

--- a/packages/react/src/menu/link-item/MenuLinkItem.test.tsx
+++ b/packages/react/src/menu/link-item/MenuLinkItem.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe } from 'vitest';
 import * as React from 'react';
 import { MemoryRouter, Route, Routes, Link, useLocation } from 'react-router';
 import { act, screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/menu/popup/MenuPopup.test.tsx
+++ b/packages/react/src/menu/popup/MenuPopup.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/menu/popup/MenuPopupEnterTransition.test.tsx
+++ b/packages/react/src/menu/popup/MenuPopupEnterTransition.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, afterEach, it } from 'vitest';
 import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 import { act, screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/menu/portal/MenuPortal.test.tsx
+++ b/packages/react/src/menu/portal/MenuPortal.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import * as React from 'react';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/menu/positioner/MenuPositioner.test.tsx
+++ b/packages/react/src/menu/positioner/MenuPositioner.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, expect, vi } from 'vitest';
+import { afterEach, beforeEach, expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 import { act, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
@@ -381,6 +381,7 @@ describe('<Menu.Positioner />', () => {
       }
 
       await render(<TestComponent />);
+      expect(screen.getByTestId('positioner')).not.toBe(null);
     });
 
     it('should react to the anchor changing from a ref to undefined and back', async () => {

--- a/packages/react/src/menu/radio-group/MenuRadioGroup.test.tsx
+++ b/packages/react/src/menu/radio-group/MenuRadioGroup.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.test.tsx
+++ b/packages/react/src/menu/radio-item-indicator/MenuRadioItemIndicator.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Menu } from '@base-ui/react/menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/menu/radio-item/MenuRadioItem.test.tsx
+++ b/packages/react/src/menu/radio-item/MenuRadioItem.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { fireEvent, act, waitFor, screen } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';

--- a/packages/react/src/menu/root/MenuRoot.detached-triggers.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.detached-triggers.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, ignoreActWarnings, screen, waitFor } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it, afterEach } from 'vitest';
 import type { CDPSession } from '@vitest/browser-playwright';
 import * as React from 'react';
 import {
@@ -1691,7 +1691,7 @@ describe('<Menu.Root />', () => {
       });
     });
 
-    describe('controlled open', () => {
+    describe('controlled open interactions', () => {
       it('does not close after hovering out of a popup opened externally', async () => {
         function App() {
           const [open, setOpen] = React.useState(false);

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.talkBack.test.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.talkBack.test.tsx
@@ -89,7 +89,7 @@ describe.skipIf(isJSDOM)('<Menu.SubmenuTrigger /> with TalkBack', () => {
     fireTalkBackPress(submenuTrigger);
 
     // The mousedown open path defers through a rAF.
-    await screen.findByTestId('submenu');
+    expect(await screen.findByTestId('submenu')).not.toBe(null);
   });
 
   it('keeps the submenu open on a TalkBack press with `openOnHover={false}`', async () => {

--- a/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
+++ b/packages/react/src/menu/submenu-trigger/MenuSubmenuTrigger.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, vi, expect } from 'vitest';
+import { afterEach, beforeEach, vi, expect, describe, it } from 'vitest';
 import { act, fireEvent, waitFor, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
@@ -151,11 +151,7 @@ describe('<Menu.SubmenuTrigger />', () => {
       });
 
       submenuItems.forEach((item) => {
-        if (item === submenuItem1) {
-          expect(item).toHaveAttribute('data-highlighted');
-        } else {
-          expect(item).not.toHaveAttribute('data-highlighted');
-        }
+        expect(item.hasAttribute('data-highlighted')).toBe(item === submenuItem1);
       });
 
       // Check that parent menu items are not active

--- a/packages/react/src/menu/trigger/MenuTrigger.test.tsx
+++ b/packages/react/src/menu/trigger/MenuTrigger.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { Menu } from '@base-ui/react/menu';

--- a/packages/react/src/menu/viewport/MenuViewport.test.tsx
+++ b/packages/react/src/menu/viewport/MenuViewport.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it, beforeEach, afterEach } from 'vitest';
 import * as React from 'react';
 import { Menu } from '@base-ui/react/menu';
 import { screen, waitFor } from '@mui/internal-test-utils';
@@ -397,14 +397,9 @@ describe('<Menu.Viewport />', () => {
       });
 
       const direction = viewport.getAttribute('data-activation-direction');
+      const directionTokens = (direction ?? '').split(' ').filter(Boolean);
 
-      if (expectedDirection.length === 0) {
-        expect(direction?.trim()).toBe('');
-      } else {
-        expectedDirection.forEach((dir) => {
-          expect(direction).toContain(dir);
-        });
-      }
+      expect(directionTokens.sort()).toEqual([...expectedDirection].sort());
     });
   });
 });

--- a/packages/react/src/menubar/Menubar.test.tsx
+++ b/packages/react/src/menubar/Menubar.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, expect, vi } from 'vitest';
+import { afterEach, expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import {

--- a/packages/react/src/merge-props/mergeProps.test.ts
+++ b/packages/react/src/merge-props/mergeProps.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { mergeProps, mergePropsN } from '@base-ui/react/merge-props';
 import type { BaseUIEvent } from '../internals/types';
 

--- a/packages/react/src/meter/indicator/MeterIndicator.test.tsx
+++ b/packages/react/src/meter/indicator/MeterIndicator.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { Meter } from '@base-ui/react/meter';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/meter/label/MeterLabel.test.tsx
+++ b/packages/react/src/meter/label/MeterLabel.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Meter } from '@base-ui/react/meter';
 import { fireEvent, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/meter/root/MeterRoot.test.tsx
+++ b/packages/react/src/meter/root/MeterRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Meter } from '@base-ui/react/meter';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/meter/track/MeterTrack.test.tsx
+++ b/packages/react/src/meter/track/MeterTrack.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Meter } from '@base-ui/react/meter';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/meter/value/MeterValue.test.tsx
+++ b/packages/react/src/meter/value/MeterValue.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { Meter } from '@base-ui/react/meter';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/navigation-menu/arrow/NavigationMenuArrow.test.tsx
+++ b/packages/react/src/navigation-menu/arrow/NavigationMenuArrow.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/navigation-menu/backdrop/NavigationMenuBackdrop.test.tsx
+++ b/packages/react/src/navigation-menu/backdrop/NavigationMenuBackdrop.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/navigation-menu/content/NavigationMenuContent.test.tsx
+++ b/packages/react/src/navigation-menu/content/NavigationMenuContent.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { fireEvent, screen, flushMicrotasks, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/navigation-menu/icon/NavigationMenuIcon.test.tsx
+++ b/packages/react/src/navigation-menu/icon/NavigationMenuIcon.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/navigation-menu/item/NavigationMenuItem.test.tsx
+++ b/packages/react/src/navigation-menu/item/NavigationMenuItem.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/navigation-menu/link/NavigationMenuLink.test.tsx
+++ b/packages/react/src/navigation-menu/link/NavigationMenuLink.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/navigation-menu/list/NavigationMenuList.test.tsx
+++ b/packages/react/src/navigation-menu/list/NavigationMenuList.test.tsx
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';

--- a/packages/react/src/navigation-menu/popup/NavigationMenuPopup.test.tsx
+++ b/packages/react/src/navigation-menu/popup/NavigationMenuPopup.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/navigation-menu/portal/NavigationMenuPortal.test.tsx
+++ b/packages/react/src/navigation-menu/portal/NavigationMenuPortal.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import * as React from 'react';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.test.tsx
+++ b/packages/react/src/navigation-menu/positioner/NavigationMenuPositioner.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, expect, vi } from 'vitest';
+import { beforeEach, expect, vi, describe, it } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { fireEvent, screen, flushMicrotasks, act, within, waitFor } from '@mui/internal-test-utils';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';

--- a/packages/react/src/navigation-menu/root/NavigationMenuRoot.webkit.test.tsx
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRoot.webkit.test.tsx
@@ -1,4 +1,4 @@
-import { vi, expect } from 'vitest';
+import { vi, expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';

--- a/packages/react/src/navigation-menu/root/NavigationMenuRootContext.test.ts
+++ b/packages/react/src/navigation-menu/root/NavigationMenuRootContext.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, vi } from 'vitest';
+import { afterEach, expect, vi, describe, it } from 'vitest';
 import { isJSDOM } from '#test-utils';
 
 describe('NavigationMenuRootContext', () => {

--- a/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
+++ b/packages/react/src/navigation-menu/trigger/NavigationMenuTrigger.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/navigation-menu/viewport/NavigationMenuViewport.test.tsx
+++ b/packages/react/src/navigation-menu/viewport/NavigationMenuViewport.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/number-field/decrement/NumberFieldDecrement.test.tsx
+++ b/packages/react/src/number-field/decrement/NumberFieldDecrement.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { screen, fireEvent, act } from '@mui/internal-test-utils';
 import { NumberField } from '@base-ui/react/number-field';

--- a/packages/react/src/number-field/group/NumberFieldGroup.test.tsx
+++ b/packages/react/src/number-field/group/NumberFieldGroup.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { NumberField } from '@base-ui/react/number-field';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/number-field/increment/NumberFieldIncrement.test.tsx
+++ b/packages/react/src/number-field/increment/NumberFieldIncrement.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { screen, fireEvent, act } from '@mui/internal-test-utils';
 import { NumberField } from '@base-ui/react/number-field';

--- a/packages/react/src/number-field/input/NumberFieldInput.test.tsx
+++ b/packages/react/src/number-field/input/NumberFieldInput.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, screen, fireEvent } from '@mui/internal-test-utils';
 import { NumberField } from '@base-ui/react/number-field';

--- a/packages/react/src/number-field/root/NumberFieldRoot.iOS.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.iOS.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { NumberField } from '@base-ui/react/number-field';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, screen, fireEvent } from '@mui/internal-test-utils';
 import { NumberField as NumberFieldBase } from '@base-ui/react/number-field';
@@ -1865,23 +1865,20 @@ describe('<NumberField />', () => {
 
         expect(hiddenInput).not.toBe(null);
 
-        if (withField) {
-          expect(screen.getByTestId('error')).toHaveTextContent('test');
-          if (lockState === 'disabled') {
-            expect(input).not.toHaveAttribute('aria-invalid');
-          } else {
-            expect(input).toHaveAttribute('aria-invalid', 'true');
-          }
-        }
+        // Only the Field wrapper renders an error and marks the input invalid,
+        // unless the field is disabled.
+        const expectedError = withField ? 'test' : undefined;
+        const expectedAriaInvalid = withField && lockState !== 'disabled' ? 'true' : null;
+
+        expect(screen.queryByTestId('error')?.textContent).toBe(expectedError);
+        expect(input.getAttribute('aria-invalid')).toBe(expectedAriaInvalid);
 
         fireEvent.change(hiddenInput, { target: { value: '42' } });
 
         expect(onValueChange).not.toHaveBeenCalled();
         expect(input).toHaveValue('1');
 
-        if (withField) {
-          expect(screen.getByTestId('error')).toHaveTextContent('test');
-        }
+        expect(screen.queryByTestId('error')?.textContent).toBe(expectedError);
       },
     );
   });

--- a/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.test.tsx
+++ b/packages/react/src/number-field/scrub-area-cursor/NumberFieldScrubAreaCursor.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, it } from 'vitest';
 import * as React from 'react';
 import { screen, act } from '@mui/internal-test-utils';
 import { NumberField } from '@base-ui/react/number-field';

--- a/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.gecko.test.tsx
+++ b/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.gecko.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, it } from 'vitest';
 import { screen, act } from '@mui/internal-test-utils';
 import { NumberField } from '@base-ui/react/number-field';
 import { createRenderer, isJSDOM } from '#test-utils';

--- a/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.test.tsx
+++ b/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { screen, act, fireEvent, reactMajor } from '@mui/internal-test-utils';
 import { NumberField } from '@base-ui/react/number-field';

--- a/packages/react/src/number-field/utils/getViewportRect.test.ts
+++ b/packages/react/src/number-field/utils/getViewportRect.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, afterEach, it } from 'vitest';
 import { isJSDOM } from '#test-utils';
 import { getViewportRect } from './getViewportRect';
 

--- a/packages/react/src/number-field/utils/parse.test.ts
+++ b/packages/react/src/number-field/utils/parse.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { isJSDOM } from '#test-utils';
 import { getNumberLocaleDetails, isNumeralChar, parseNumber } from './parse';
 

--- a/packages/react/src/number-field/utils/validate.test.ts
+++ b/packages/react/src/number-field/utils/validate.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { toValidatedNumber as toValidatedNumberImpl, removeFloatingPointErrors } from './validate';
 
 const min = Number.MIN_SAFE_INTEGER;

--- a/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
+++ b/packages/react/src/otp-field/input/OTPFieldInput.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 import { SafeReact } from '@base-ui/utils/safeReact';

--- a/packages/react/src/otp-field/root/OTPFieldRoot.react17.test.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.react17.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { OTPField } from '@base-ui/react/otp-field';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
+++ b/packages/react/src/otp-field/root/OTPFieldRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { SafeReact } from '@base-ui/utils/safeReact';
 import { act, fireEvent, screen } from '@mui/internal-test-utils';
@@ -1186,17 +1186,15 @@ describe('<OTPField.Root />', () => {
 
         expect(hiddenInput).not.toBeNull();
 
-        if (withField) {
-          expect(screen.getByTestId('error')).toHaveTextContent('test');
-          const inputs = screen.getAllByRole('textbox');
-          inputs.forEach((input) => {
-            if (lockState === 'disabled') {
-              expect(input).not.toHaveAttribute('aria-invalid');
-            } else {
-              expect(input).toHaveAttribute('aria-invalid', 'true');
-            }
-          });
-        }
+        // Only the Field wrapper renders an error and marks the inputs invalid,
+        // unless the field is disabled.
+        const expectedError = withField ? 'test' : undefined;
+        const expectedAriaInvalid = withField && lockState !== 'disabled' ? 'true' : null;
+
+        expect(screen.queryByTestId('error')?.textContent).toBe(expectedError);
+        screen.getAllByRole('textbox').forEach((input) => {
+          expect(input.getAttribute('aria-invalid')).toBe(expectedAriaInvalid);
+        });
 
         fireEvent.change(hiddenInput!, { target: { value: '12a34b56' } });
 
@@ -1205,9 +1203,7 @@ describe('<OTPField.Root />', () => {
         expect(onValueInvalid).not.toHaveBeenCalled();
         expect(onValueComplete).not.toHaveBeenCalled();
 
-        if (withField) {
-          expect(screen.getByTestId('error')).toHaveTextContent('test');
-        }
+        expect(screen.queryByTestId('error')?.textContent).toBe(expectedError);
       },
     );
 

--- a/packages/react/src/popover/arrow/PopoverArrow.test.tsx
+++ b/packages/react/src/popover/arrow/PopoverArrow.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Popover } from '@base-ui/react/popover';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/popover/backdrop/PopoverBackdrop.test.tsx
+++ b/packages/react/src/popover/backdrop/PopoverBackdrop.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Popover } from '@base-ui/react/popover';
 import { createRenderer, describeConformance } from '#test-utils';
 import { screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/popover/close/PopoverClose.test.tsx
+++ b/packages/react/src/popover/close/PopoverClose.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Popover } from '@base-ui/react/popover';
 import { Tooltip } from '@base-ui/react/tooltip';

--- a/packages/react/src/popover/description/PopoverDescription.test.tsx
+++ b/packages/react/src/popover/description/PopoverDescription.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Popover } from '@base-ui/react/popover';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/popover/popup/PopoverPopup.test.tsx
+++ b/packages/react/src/popover/popup/PopoverPopup.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Popover } from '@base-ui/react/popover';
 import { Toolbar } from '@base-ui/react/toolbar';

--- a/packages/react/src/popover/portal/PopoverPortal.test.tsx
+++ b/packages/react/src/popover/portal/PopoverPortal.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import * as React from 'react';
 import { Popover } from '@base-ui/react/popover';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
+++ b/packages/react/src/popover/positioner/PopoverPositioner.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Popover } from '@base-ui/react/popover';

--- a/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.detached-triggers.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import type { UserEvent } from '@testing-library/user-event';
 import { createRenderer, isJSDOM } from '#test-utils';

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import { Popover } from '@base-ui/react/popover';
 import { Combobox } from '@base-ui/react/combobox';

--- a/packages/react/src/popover/title/PopoverTitle.test.tsx
+++ b/packages/react/src/popover/title/PopoverTitle.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Popover } from '@base-ui/react/popover';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
+++ b/packages/react/src/popover/trigger/PopoverTrigger.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import { Popover } from '@base-ui/react/popover';
 import {

--- a/packages/react/src/popover/viewport/PopoverViewport.test.tsx
+++ b/packages/react/src/popover/viewport/PopoverViewport.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it, beforeEach, afterEach } from 'vitest';
 import * as React from 'react';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { Popover } from '@base-ui/react/popover';
@@ -590,14 +590,9 @@ describe('<Popover.Viewport />', () => {
       });
 
       const direction = viewport.getAttribute('data-activation-direction');
+      const directionTokens = (direction ?? '').split(' ').filter(Boolean);
 
-      if (expectedDirection.length === 0) {
-        expect(direction?.trim()).toBe('');
-      } else {
-        expectedDirection.forEach((dir) => {
-          expect(direction).toContain(dir);
-        });
-      }
+      expect(directionTokens.sort()).toEqual([...expectedDirection].sort());
     });
   });
 });

--- a/packages/react/src/preview-card/arrow/PreviewCardArrow.test.tsx
+++ b/packages/react/src/preview-card/arrow/PreviewCardArrow.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/preview-card/backdrop/PreviewCardBackdrop.test.tsx
+++ b/packages/react/src/preview-card/backdrop/PreviewCardBackdrop.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/preview-card/popup/PreviewCardPopup.test.tsx
+++ b/packages/react/src/preview-card/popup/PreviewCardPopup.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/preview-card/portal/PreviewCardPortal.test.tsx
+++ b/packages/react/src/preview-card/portal/PreviewCardPortal.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import * as React from 'react';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
+++ b/packages/react/src/preview-card/positioner/PreviewCardPositioner.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, expect, vi } from 'vitest';
+import { afterEach, expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
@@ -1092,44 +1092,5 @@ describe('<PreviewCard.Positioner />', () => {
         expectWithin(positioner.getBoundingClientRect().y, expectedY);
       });
     });
-  });
-
-  it.skipIf(isJSDOM)('uses transform positioning without Viewport', async () => {
-    const { unmount } = await render(
-      <PreviewCard.Root open>
-        <Trigger style={triggerStyle}>Trigger</Trigger>
-        <PreviewCard.Portal>
-          <PreviewCard.Positioner data-testid="positioner">
-            <PreviewCard.Popup style={popupStyle}>Popup</PreviewCard.Popup>
-          </PreviewCard.Positioner>
-        </PreviewCard.Portal>
-      </PreviewCard.Root>,
-    );
-
-    const positioner = screen.getByTestId('positioner');
-    await waitFor(() => {
-      expect(positioner.style.transform).not.toBe('');
-    });
-    unmount();
-  });
-
-  it.skipIf(isJSDOM)('uses top/left positioning with Viewport', async () => {
-    const { unmount } = await render(
-      <PreviewCard.Root open>
-        <Trigger style={triggerStyle}>Trigger</Trigger>
-        <PreviewCard.Portal>
-          <PreviewCard.Positioner data-testid="positioner">
-            <PreviewCard.Popup style={popupStyle}>
-              <PreviewCard.Viewport>Popup</PreviewCard.Viewport>
-            </PreviewCard.Popup>
-          </PreviewCard.Positioner>
-        </PreviewCard.Portal>
-      </PreviewCard.Root>,
-    );
-
-    const positioner = screen.getByTestId('positioner');
-    await waitForPositioned(positioner);
-    expect(positioner.style.transform).toBe('');
-    unmount();
   });
 });

--- a/packages/react/src/preview-card/root/PreviewCardRoot.detached-triggers.test.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.detached-triggers.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
 import { createRenderer, isJSDOM, resetBrowserPointer } from '#test-utils';

--- a/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
+++ b/packages/react/src/preview-card/root/PreviewCardRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { act, fireEvent, screen, flushMicrotasks, waitFor } from '@mui/internal-test-utils';
@@ -545,91 +545,6 @@ describe('<PreviewCard.Root />', () => {
           false,
           expect.objectContaining({ reason: REASONS.imperativeAction }),
         );
-      });
-    });
-
-    describe.skipIf(isJSDOM)('prop: onOpenChangeComplete', () => {
-      it('is called on close when there is no exit animation defined', async () => {
-        const onOpenChangeComplete = vi.fn();
-
-        function Test() {
-          const [open, setOpen] = React.useState(true);
-          return (
-            <div>
-              <button onClick={() => setOpen(false)}>Close</button>
-              <TestPreviewCard
-                rootProps={{
-                  open,
-                  onOpenChangeComplete,
-                }}
-              />
-            </div>
-          );
-        }
-
-        const { user } = await render(<Test />);
-
-        const closeButton = screen.getByText('Close');
-        await user.click(closeButton);
-
-        await waitFor(() => {
-          expect(screen.queryByTestId('popup')).toBe(null);
-        });
-
-        expect(onOpenChangeComplete.mock.calls[0][0]).toBe(true);
-        expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
-      });
-
-      it('is called on close when the exit animation finishes', async () => {
-        globalThis.BASE_UI_ANIMATIONS_DISABLED = false;
-
-        const onOpenChangeComplete = vi.fn();
-
-        function Test() {
-          const style = `
-          @keyframes test-anim {
-            to {
-              opacity: 0;
-            }
-          }
-
-          .animation-test-indicator[data-ending-style] {
-            animation: test-anim 1ms;
-          }
-        `;
-
-          const [open, setOpen] = React.useState(true);
-
-          return (
-            <div>
-              {/* eslint-disable-next-line react/no-danger */}
-              <style dangerouslySetInnerHTML={{ __html: style }} />
-              <button onClick={() => setOpen(false)}>Close</button>
-              <TestPreviewCard
-                rootProps={{
-                  open,
-                  onOpenChangeComplete,
-                }}
-                popupProps={{
-                  className: 'animation-test-indicator',
-                }}
-              />
-            </div>
-          );
-        }
-
-        const { user } = await render(<Test />);
-
-        expect(screen.getByTestId('popup')).not.toBe(null);
-
-        const closeButton = screen.getByText('Close');
-        await user.click(closeButton);
-
-        await waitFor(() => {
-          expect(screen.queryByTestId('popup')).toBe(null);
-        });
-
-        expect(onOpenChangeComplete.mock.lastCall?.[0]).toBe(false);
       });
     });
 

--- a/packages/react/src/preview-card/trigger/PreviewCardTrigger.test.tsx
+++ b/packages/react/src/preview-card/trigger/PreviewCardTrigger.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/preview-card/viewport/PreviewCardViewport.test.tsx
+++ b/packages/react/src/preview-card/viewport/PreviewCardViewport.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it, beforeEach, afterEach } from 'vitest';
 import * as React from 'react';
 import { PreviewCard } from '@base-ui/react/preview-card';
 import { act, ignoreActWarnings, screen, waitFor } from '@mui/internal-test-utils';
@@ -431,14 +431,9 @@ describe('<PreviewCard.Viewport />', () => {
       });
 
       const direction = viewport.getAttribute('data-activation-direction');
+      const directionTokens = (direction ?? '').split(' ').filter(Boolean);
 
-      if (expectedDirection.length === 0) {
-        expect(direction?.trim()).toBe('');
-      } else {
-        expectedDirection.forEach((dir) => {
-          expect(direction).toContain(dir);
-        });
-      }
+      expect(directionTokens.sort()).toEqual([...expectedDirection].sort());
     });
   });
 });

--- a/packages/react/src/progress/indicator/ProgressIndicator.test.tsx
+++ b/packages/react/src/progress/indicator/ProgressIndicator.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { Progress } from '@base-ui/react/progress';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/progress/label/ProgressLabel.test.tsx
+++ b/packages/react/src/progress/label/ProgressLabel.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Progress } from '@base-ui/react/progress';
 import { fireEvent, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/progress/root/ProgressRoot.test.tsx
+++ b/packages/react/src/progress/root/ProgressRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { Progress } from '@base-ui/react/progress';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/progress/track/ProgressTrack.test.tsx
+++ b/packages/react/src/progress/track/ProgressTrack.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Progress } from '@base-ui/react/progress';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/progress/value/ProgressValue.test.tsx
+++ b/packages/react/src/progress/value/ProgressValue.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { Progress } from '@base-ui/react/progress';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { RadioGroup } from '@base-ui/react/radio-group';

--- a/packages/react/src/radio/indicator/RadioIndicator.test.tsx
+++ b/packages/react/src/radio/indicator/RadioIndicator.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, beforeEach, it, afterEach } from 'vitest';
 import * as React from 'react';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/radio/root/RadioRoot.test.tsx
+++ b/packages/react/src/radio/root/RadioRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Radio } from '@base-ui/react/radio';
 import { RadioGroup } from '@base-ui/react/radio-group';

--- a/packages/react/src/scroll-area/content/ScrollAreaContent.test.tsx
+++ b/packages/react/src/scroll-area/content/ScrollAreaContent.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import { createRenderer, isJSDOM } from '#test-utils';
 import { screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/scroll-area/corner/ScrollAreaCorner.test.tsx
+++ b/packages/react/src/scroll-area/corner/ScrollAreaCorner.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, isJSDOM } from '#test-utils';

--- a/packages/react/src/scroll-area/root/ScrollAreaRoot.test.tsx
+++ b/packages/react/src/scroll-area/root/ScrollAreaRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
@@ -13,7 +13,7 @@ const SCROLLABLE_CONTENT_SIZE = 1000;
 const SCROLLBAR_WIDTH = 10;
 const SCROLLBAR_HEIGHT = 10;
 
-async function withMockResizeObserver(test: (notifyResizeObserver: () => void) => Promise<void>) {
+async function withMockResizeObserver(run: (notifyResizeObserver: () => void) => Promise<void>) {
   const originalResizeObserver = window.ResizeObserver;
   const observers = new Set<ResizeObserverMock>();
 
@@ -42,7 +42,7 @@ async function withMockResizeObserver(test: (notifyResizeObserver: () => void) =
   window.ResizeObserver = ResizeObserverMock;
 
   try {
-    await test(() => {
+    await run(() => {
       expect(observers.size).toBeGreaterThan(0);
       observers.forEach((observer) => observer.callback([], observer));
     });

--- a/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
+++ b/packages/react/src/scroll-area/scrollbar/ScrollAreaScrollbar.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import { screen, fireEvent, flushMicrotasks, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
+++ b/packages/react/src/scroll-area/thumb/ScrollAreaThumb.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { createRenderer, isJSDOM } from '#test-utils';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/scroll-area/viewport/ScrollAreaViewport.test.tsx
+++ b/packages/react/src/scroll-area/viewport/ScrollAreaViewport.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { ScrollArea } from '@base-ui/react/scroll-area';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { createRenderer, isJSDOM, describeConformance } from '#test-utils';

--- a/packages/react/src/select/arrow/SelectArrow.test.tsx
+++ b/packages/react/src/select/arrow/SelectArrow.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/select/backdrop/SelectBackdrop.test.tsx
+++ b/packages/react/src/select/backdrop/SelectBackdrop.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/select/group-label/SelectGroupLabel.test.tsx
+++ b/packages/react/src/select/group-label/SelectGroupLabel.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/select/group/SelectGroup.test.tsx
+++ b/packages/react/src/select/group/SelectGroup.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance } from '#test-utils';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/select/icon/SelectIcon.test.tsx
+++ b/packages/react/src/select/icon/SelectIcon.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/select/item-indicator/SelectItemIndicator.test.tsx
+++ b/packages/react/src/select/item-indicator/SelectItemIndicator.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/select/item-text/SelectItemText.test.tsx
+++ b/packages/react/src/select/item-text/SelectItemText.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/select/item/SelectItem.test.tsx
+++ b/packages/react/src/select/item/SelectItem.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Select } from '@base-ui/react/select';
 import {
@@ -408,8 +408,7 @@ describe('<Select.Item />', () => {
     fireEvent.click(option);
     await flushMicrotasks();
 
-    expect(onValueChange).toHaveBeenCalledOnce();
-    expect(onValueChange).toHaveBeenCalledWith('two', expect.anything());
+    expect(onValueChange).toHaveBeenCalledExactlyOnceWith('two', expect.anything());
     await waitFor(() => {
       expect(screen.getByTestId('value').textContent).toBe('two');
     });

--- a/packages/react/src/select/label/SelectLabel.test.tsx
+++ b/packages/react/src/select/label/SelectLabel.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/select/list/SelectList.test.tsx
+++ b/packages/react/src/select/list/SelectList.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/select/popup/SelectPopup.test.tsx
+++ b/packages/react/src/select/popup/SelectPopup.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it, afterEach } from 'vitest';
 import * as React from 'react';
 import { Select } from '@base-ui/react/select';
 import { Toolbar } from '@base-ui/react/toolbar';

--- a/packages/react/src/select/portal/SelectPortal.test.tsx
+++ b/packages/react/src/select/portal/SelectPortal.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import * as React from 'react';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/select/positioner/SelectPositioner.test.tsx
+++ b/packages/react/src/select/positioner/SelectPositioner.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { Select } from '@base-ui/react/select';
 import { screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Select } from '@base-ui/react/select';
@@ -1305,9 +1305,10 @@ describe('<Select.Root />', () => {
       const selectInput = screen.getByRole<HTMLInputElement>('textbox', { hidden: true });
       expect(selectInput).toHaveAttribute('name', 'select');
 
-      if (withField) {
-        expect(screen.getByTestId('error')).toHaveTextContent('test');
-      }
+      // Only the Field wrapper renders an error.
+      const expectedError = withField ? 'test' : undefined;
+
+      expect(screen.queryByTestId('error')?.textContent).toBe(expectedError);
 
       fireEvent.change(selectInput, { target: { value: 'b' } });
       await flushMicrotasks();
@@ -1315,9 +1316,7 @@ describe('<Select.Root />', () => {
       expect(onValueChange).not.toHaveBeenCalled();
       expect(selectInput.value).toBe('');
 
-      if (withField) {
-        expect(screen.getByTestId('error')).toHaveTextContent('test');
-      }
+      expect(screen.queryByTestId('error')?.textContent).toBe(expectedError);
     },
   );
 
@@ -2771,7 +2770,7 @@ describe('<Select.Root />', () => {
 
       await user.keyboard('[Tab]');
 
-      expect(expect(document.activeElement)).not.toBe(trigger);
+      expect(document.activeElement).not.toBe(trigger);
 
       await user.click(trigger);
       expect(handleOpenChange.mock.calls.length).toBe(0);
@@ -2808,7 +2807,7 @@ describe('<Select.Root />', () => {
 
       await user.keyboard('[Tab]');
 
-      expect(expect(document.activeElement)).not.toBe(trigger);
+      expect(document.activeElement).not.toBe(trigger);
 
       await user.click(trigger);
       expect(handleOpenChange.mock.calls.length).toBe(0);

--- a/packages/react/src/select/scroll-arrow/SelectScrollArrow.test.tsx
+++ b/packages/react/src/select/scroll-arrow/SelectScrollArrow.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/select/scroll-down-arrow/SelectScrollDownArrow.test.tsx
+++ b/packages/react/src/select/scroll-down-arrow/SelectScrollDownArrow.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/select/scroll-up-arrow/SelectScrollUpArrow.test.tsx
+++ b/packages/react/src/select/scroll-up-arrow/SelectScrollUpArrow.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { act, fireEvent, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/select/store.test.tsx
+++ b/packages/react/src/select/store.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/select/trigger/SelectTrigger.test.tsx
+++ b/packages/react/src/select/trigger/SelectTrigger.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Select } from '@base-ui/react/select';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { fireEvent, ignoreActWarnings, screen, waitFor } from '@mui/internal-test-utils';
@@ -124,7 +124,7 @@ describe('<Select.Trigger />', () => {
 
       await user.keyboard('[Tab]');
 
-      expect(expect(document.activeElement)).not.toBe(trigger);
+      expect(document.activeElement).not.toBe(trigger);
     });
 
     it('does not toggle the popup when disabled', async () => {

--- a/packages/react/src/select/value/SelectValue.test.tsx
+++ b/packages/react/src/select/value/SelectValue.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Select } from '@base-ui/react/select';
 import { fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';

--- a/packages/react/src/separator/Separator.test.tsx
+++ b/packages/react/src/separator/Separator.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { Separator } from '@base-ui/react/separator';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/slider/control/SliderControl.test.tsx
+++ b/packages/react/src/slider/control/SliderControl.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Slider } from '@base-ui/react/slider';

--- a/packages/react/src/slider/indicator/SliderIndicator.test.tsx
+++ b/packages/react/src/slider/indicator/SliderIndicator.test.tsx
@@ -1,3 +1,4 @@
+import { describe, expect } from 'vitest';
 import * as React from 'react';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
@@ -68,10 +69,8 @@ describe('<Slider.Indicator />', () => {
       });
       expect(indicator.style[startSide]).toBe(expectedStartSide);
       expect(indicator.style[sizeSide]).toBe(expectedSizeSide);
-      if (edge) {
-        expect(indicator.style.getPropertyValue('--start-position')).toBe(start);
-        expect(indicator.style.getPropertyValue('--relative-size')).toBe(range ? size : '');
-      }
+      expect(indicator.style.getPropertyValue('--start-position')).toBe(edge ? start : '');
+      expect(indicator.style.getPropertyValue('--relative-size')).toBe(edge && range ? size : '');
 
       const input = screen.getAllByRole('slider')[0];
       let incrementKey = 'ArrowRight';

--- a/packages/react/src/slider/label/SliderLabel.test.tsx
+++ b/packages/react/src/slider/label/SliderLabel.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { Slider } from '@base-ui/react/slider';
 import { Field } from '@base-ui/react/field';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, expect as expectVitest, vi } from 'vitest';
+import { expect, vi, describe, beforeAll, it } from 'vitest';
 import * as React from 'react';
 import { act, flushMicrotasks, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
@@ -89,6 +89,8 @@ describe('<Slider.Root />', () => {
   }));
 
   it('warns when max is not greater than min', async () => {
+    // `toWarnDev` requires a callback, so the wrapper is not unneeded.
+    // eslint-disable-next-line vitest/no-unneeded-async-expect-function
     await expect(async () => {
       await render(<TestSlider defaultValue={10} min={10} max={10} />);
     }).toWarnDev('Base UI: Slider `max` must be greater than `min`.');
@@ -136,11 +138,13 @@ describe('<Slider.Root />', () => {
         document.body,
         createTouches([{ identifier: 1, clientX: 20, clientY: 0 }]),
       );
+
+      expect(screen.getAllByRole('slider')).toHaveLength(2);
     },
   );
 
   describe('ARIA attributes', () => {
-    it('it has the correct aria attributes', async () => {
+    it('has the correct aria attributes', async () => {
       await render(
         <Slider.Root defaultValue={30} aria-labelledby="labelId" data-testid="root">
           <Slider.Value />
@@ -2102,7 +2106,7 @@ describe('<Slider.Root />', () => {
             slider.focus();
           });
 
-          expectVitest(() => {
+          expect(() => {
             fireEvent.change(slider, {
               target: {
                 value: 4,
@@ -2110,7 +2114,7 @@ describe('<Slider.Root />', () => {
             });
           }).not.toThrow();
 
-          expectVitest(handleValueChange).toHaveBeenCalledTimes(1);
+          expect(handleValueChange).toHaveBeenCalledTimes(1);
         } finally {
           if (hadGlobalEvent && previousDescriptor) {
             Object.defineProperty(globalThis, 'event', previousDescriptor);
@@ -2136,7 +2140,7 @@ describe('<Slider.Root />', () => {
         });
 
         const slider = shadowRoot.querySelector('input[type="range"]');
-        expectVitest(slider).toBeTruthy();
+        expect(slider).toBeTruthy();
 
         if (!slider) {
           return;
@@ -2150,7 +2154,7 @@ describe('<Slider.Root />', () => {
           slider.dispatchEvent(new KeyboardEvent('keydown', { key: ARROW_RIGHT, bubbles: true }));
         });
 
-        expectVitest(handleValueChange).toHaveBeenCalledTimes(1);
+        expect(handleValueChange).toHaveBeenCalledTimes(1);
       } finally {
         await act(async () => {
           host.remove();
@@ -2215,7 +2219,7 @@ describe('<Slider.Root />', () => {
         incrementKeys: string[],
       ];
 
-      describe(String(direction), () => {
+      describe(direction, () => {
         describe(`orientation: ${orientation}`, () => {
           decrementKeys.forEach((key) => {
             it(`key: ${key} decrements the value`, async () => {

--- a/packages/react/src/slider/thumb/SliderThumb.test.tsx
+++ b/packages/react/src/slider/thumb/SliderThumb.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Slider } from '@base-ui/react/slider';

--- a/packages/react/src/slider/track/SliderTrack.test.tsx
+++ b/packages/react/src/slider/track/SliderTrack.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import { Slider } from '@base-ui/react/slider';
 import { createRenderer, describeConformance } from '#test-utils';
 

--- a/packages/react/src/slider/utils/getPushedThumbValues.test.ts
+++ b/packages/react/src/slider/utils/getPushedThumbValues.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { getPushedThumbValues } from './getPushedThumbValues';
 
 describe('getPushedThumbValues', () => {

--- a/packages/react/src/slider/utils/resolveThumbCollision.test.ts
+++ b/packages/react/src/slider/utils/resolveThumbCollision.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { resolveThumbCollision } from './resolveThumbCollision';
 
 describe('resolveThumbCollision', () => {

--- a/packages/react/src/slider/value/SliderValue.test.tsx
+++ b/packages/react/src/slider/value/SliderValue.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { Slider } from '@base-ui/react/slider';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/switch/root/SwitchRoot.test.tsx
+++ b/packages/react/src/switch/root/SwitchRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
 import { Switch } from '@base-ui/react/switch';

--- a/packages/react/src/switch/thumb/SwitchThumb.test.tsx
+++ b/packages/react/src/switch/thumb/SwitchThumb.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Switch } from '@base-ui/react/switch';
 import { createRenderer, describeConformance } from '#test-utils';
 import { SwitchRootContext } from '../root/SwitchRootContext';

--- a/packages/react/src/tabs/indicator/TabsIndicator.test.tsx
+++ b/packages/react/src/tabs/indicator/TabsIndicator.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, expect, vi } from 'vitest';
+import { afterEach, expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Tabs } from '@base-ui/react/tabs';
 import { CSPProvider } from '@base-ui/react/csp-provider';

--- a/packages/react/src/tabs/list/TabsList.test.tsx
+++ b/packages/react/src/tabs/list/TabsList.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';
 import { Tabs } from '@base-ui/react/tabs';

--- a/packages/react/src/tabs/panel/TabsPanel.test.tsx
+++ b/packages/react/src/tabs/panel/TabsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, expect, vi } from 'vitest';
+import { afterEach, expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Tabs } from '@base-ui/react/tabs';
 import { act, reactMajor, screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import { act, flushMicrotasks, fireEvent, screen, waitFor, within } from '@mui/internal-test-utils';
 import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
@@ -42,7 +42,8 @@ describe('<Tabs.Root />', () => {
     });
 
     it('should support empty children', async () => {
-      await render(<Tabs.Root value={1} />);
+      const { container } = await render(<Tabs.Root value={1} />);
+      expect(container.firstElementChild).not.toBe(null);
     });
 
     it('puts the selected child in tab order', async () => {
@@ -386,6 +387,8 @@ describe('<Tabs.Root />', () => {
       const tabs = screen.getAllByRole('tab');
       expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
 
+      // `toErrorDev` requires a callback, so the wrapper is not unneeded.
+      // eslint-disable-next-line vitest/no-unneeded-async-expect-function
       await expect(async () => {
         await setProps({ defaultValue: 1 });
       }).toErrorDev(
@@ -1282,7 +1285,7 @@ describe('<Tabs.Root />', () => {
       describe.skipIf(isJSDOM && direction === 'rtl')(
         `when focus is on a tab element in a ${orientation} ${direction ?? ''} tablist`,
         () => {
-          describe(previousItemKey ?? '', () => {
+          describe(`${previousItemKey}`, () => {
             describe('with `activateOnFocus = false`', () => {
               it('moves focus to the last tab without activating it if focus is on the first tab', async () => {
                 const handleChange = vi.fn();
@@ -1485,7 +1488,7 @@ describe('<Tabs.Root />', () => {
             });
           });
 
-          describe(nextItemKey ?? '', () => {
+          describe(`${nextItemKey}`, () => {
             describe('with `activateOnFocus = false`', () => {
               it('moves focus to the first tab without activating it if focus is on the last tab', async () => {
                 const handleChange = vi.fn();
@@ -2516,8 +2519,9 @@ describe('<Tabs.Root />', () => {
         await user.keyboard('{ArrowRight}');
         expect(thirdTab).toHaveFocus();
 
+        expect(onValueChange.mock.calls.length === 0).toBe(!activateOnFocus);
+
         if (!activateOnFocus) {
-          expect(onValueChange).not.toHaveBeenCalled();
           await user.keyboard('{Enter}');
         }
 

--- a/packages/react/src/tabs/tab/TabsTab.test.tsx
+++ b/packages/react/src/tabs/tab/TabsTab.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Link, MemoryRouter } from 'react-router';
 import { act, fireEvent, screen } from '@mui/internal-test-utils';

--- a/packages/react/src/toast/action/ToastAction.test.tsx
+++ b/packages/react/src/toast/action/ToastAction.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Toast } from '@base-ui/react/toast';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/toast/arrow/ToastArrow.test.tsx
+++ b/packages/react/src/toast/arrow/ToastArrow.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Toast } from '@base-ui/react/toast';
 import { screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/toast/close/ToastClose.test.tsx
+++ b/packages/react/src/toast/close/ToastClose.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Toast } from '@base-ui/react/toast';
 import { act, screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/toast/content/ToastContent.test.tsx
+++ b/packages/react/src/toast/content/ToastContent.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { Toast } from '@base-ui/react/toast';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/toast/createToastManager.test.tsx
+++ b/packages/react/src/toast/createToastManager.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Toast } from '@base-ui/react/toast';
 import { fireEvent, flushMicrotasks, screen } from '@mui/internal-test-utils';

--- a/packages/react/src/toast/description/ToastDescription.test.tsx
+++ b/packages/react/src/toast/description/ToastDescription.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Toast } from '@base-ui/react/toast';
 import { createRenderer, describeConformance } from '#test-utils';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/toast/portal/ToastPortal.test.tsx
+++ b/packages/react/src/toast/portal/ToastPortal.test.tsx
@@ -1,3 +1,4 @@
+import { describe } from 'vitest';
 import * as React from 'react';
 import { Toast } from '@base-ui/react/toast';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/toast/positioner/ToastPositioner.test.tsx
+++ b/packages/react/src/toast/positioner/ToastPositioner.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Toast } from '@base-ui/react/toast';
 import { act, screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/toast/provider/ToastProvider.test.tsx
+++ b/packages/react/src/toast/provider/ToastProvider.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Toast } from '@base-ui/react/toast';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';

--- a/packages/react/src/toast/root/ToastRoot.test.tsx
+++ b/packages/react/src/toast/root/ToastRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Toast } from '@base-ui/react/toast';

--- a/packages/react/src/toast/title/ToastTitle.test.tsx
+++ b/packages/react/src/toast/title/ToastTitle.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Toast } from '@base-ui/react/toast';
 import { createRenderer, describeConformance } from '#test-utils';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/toast/useToastManager.test.tsx
+++ b/packages/react/src/toast/useToastManager.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Toast } from '@base-ui/react/toast';
 import { Dialog } from '@base-ui/react/dialog';

--- a/packages/react/src/toast/utils/isRenderableNode.test.ts
+++ b/packages/react/src/toast/utils/isRenderableNode.test.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { hasRenderableChildren, isRenderableNode } from './isRenderableNode';
 
 describe('isRenderableNode', () => {

--- a/packages/react/src/toast/viewport/ToastViewport.test.tsx
+++ b/packages/react/src/toast/viewport/ToastViewport.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Toast } from '@base-ui/react/toast';

--- a/packages/react/src/toggle-group/ToggleGroup.test.tsx
+++ b/packages/react/src/toggle-group/ToggleGroup.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { act, screen } from '@mui/internal-test-utils';
 import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
 import { ToggleGroup } from '@base-ui/react/toggle-group';

--- a/packages/react/src/toggle/Toggle.test.tsx
+++ b/packages/react/src/toggle/Toggle.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, screen } from '@mui/internal-test-utils';
 import { Toggle } from '@base-ui/react/toggle';

--- a/packages/react/src/toolbar/button/ToolbarButton.test.tsx
+++ b/packages/react/src/toolbar/button/ToolbarButton.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Toolbar } from '@base-ui/react/toolbar';
 import { Switch } from '@base-ui/react/switch';
 import { Menu } from '@base-ui/react/menu';

--- a/packages/react/src/toolbar/group/ToolbarGroup.test.tsx
+++ b/packages/react/src/toolbar/group/ToolbarGroup.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Toolbar } from '@base-ui/react/toolbar';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/toolbar/input/ToolbarInput.test.tsx
+++ b/packages/react/src/toolbar/input/ToolbarInput.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Toolbar } from '@base-ui/react/toolbar';
 import { NumberField } from '@base-ui/react/number-field';
 import { DirectionProvider } from '@base-ui/react/direction-provider';

--- a/packages/react/src/toolbar/link/ToolbarLink.test.tsx
+++ b/packages/react/src/toolbar/link/ToolbarLink.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Toolbar } from '@base-ui/react/toolbar';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/toolbar/root/ToolbarRoot.test.tsx
+++ b/packages/react/src/toolbar/root/ToolbarRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Toolbar } from '@base-ui/react/toolbar';
 import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/toolbar/separator/ToolbarSeparator.test.tsx
+++ b/packages/react/src/toolbar/separator/ToolbarSeparator.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Toolbar } from '@base-ui/react/toolbar';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/tooltip/arrow/TooltipArrow.test.tsx
+++ b/packages/react/src/tooltip/arrow/TooltipArrow.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';

--- a/packages/react/src/tooltip/popup/TooltipPopup.test.tsx
+++ b/packages/react/src/tooltip/popup/TooltipPopup.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, describeConformance } from '#test-utils';

--- a/packages/react/src/tooltip/portal/TooltipPortal.test.tsx
+++ b/packages/react/src/tooltip/portal/TooltipPortal.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { screen } from '@mui/internal-test-utils';

--- a/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
+++ b/packages/react/src/tooltip/positioner/TooltipPositioner.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
+++ b/packages/react/src/tooltip/provider/TooltipProvider.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, beforeEach, it } from 'vitest';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { screen, fireEvent, flushMicrotasks } from '@mui/internal-test-utils';
 import { advanceReactClock, createRenderer, resetBrowserPointer } from '#test-utils';

--- a/packages/react/src/tooltip/root/TooltipRoot.detached-triggers.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.detached-triggers.test.tsx
@@ -1,4 +1,4 @@
-import { vi, expect } from 'vitest';
+import { vi, expect, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import * as ReactDOMClient from 'react-dom/client';
 import * as ReactDOMServer from 'react-dom/server';
@@ -25,10 +25,12 @@ describe('<Tooltip.Root />', () => {
       document.body.click();
     });
 
-    // Wait for all tooltips to unmount
+    // Wait for all tooltips to unmount (`expect` is not allowed outside test blocks)
     await waitFor(() => {
       const tooltips = document.querySelectorAll('[data-open]');
-      expect(tooltips.length).toBe(0);
+      if (tooltips.length > 0) {
+        throw new Error(`${tooltips.length} tooltips still mounted`);
+      }
     });
   });
 

--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, afterEach, it } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';

--- a/packages/react/src/tooltip/trigger/TooltipTrigger.test.tsx
+++ b/packages/react/src/tooltip/trigger/TooltipTrigger.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { Toolbar } from '@base-ui/react/toolbar';

--- a/packages/react/src/tooltip/viewport/TooltipViewport.test.tsx
+++ b/packages/react/src/tooltip/viewport/TooltipViewport.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it, beforeEach, afterEach } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { act, ignoreActWarnings, screen, waitFor } from '@mui/internal-test-utils';
@@ -595,14 +595,9 @@ describe('<Tooltip.Viewport />', () => {
       });
 
       const direction = viewport.getAttribute('data-activation-direction');
+      const directionTokens = (direction ?? '').split(' ').filter(Boolean);
 
-      if (expectedDirection.length === 0) {
-        expect(direction?.trim()).toBe('');
-      } else {
-        expectedDirection.forEach((dir) => {
-          expect(direction).toContain(dir);
-        });
-      }
+      expect(directionTokens.sort()).toEqual([...expectedDirection].sort());
     });
   });
 });

--- a/packages/react/src/use-render/useRender.test.tsx
+++ b/packages/react/src/use-render/useRender.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 /* eslint-disable testing-library/render-result-naming-convention */
 import * as React from 'react';
 import { useRender } from '@base-ui/react/use-render';
@@ -221,12 +221,8 @@ describe('useRender', () => {
 
       expect(span).toHaveAttribute('class', 'test-class');
 
-      const attributes = span?.attributes;
-      if (attributes) {
-        for (let i = 0; i < attributes.length; i += 1) {
-          expect(attributes[i].name).not.toMatch(/^data-/);
-        }
-      }
+      const attributeNames = Array.from(span?.attributes ?? [], (attr) => attr.name);
+      expect(attributeNames.filter((name) => name.startsWith('data-'))).toEqual([]);
     });
 
     it('handles undefined state', async () => {

--- a/packages/react/src/utils/hideMiddleware.test.ts
+++ b/packages/react/src/utils/hideMiddleware.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import {
   hide as nativeHide,
   type MiddlewareState,

--- a/packages/react/src/utils/listbox-separator/ListboxSeparator.test.tsx
+++ b/packages/react/src/utils/listbox-separator/ListboxSeparator.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { Autocomplete } from '@base-ui/react/autocomplete';
 import { Combobox } from '@base-ui/react/combobox';
 import { Select } from '@base-ui/react/select';

--- a/packages/react/src/utils/popupStateMapping.test.ts
+++ b/packages/react/src/utils/popupStateMapping.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import {
   popupStateMapping,
   pressableTriggerOpenStateMapping,

--- a/packages/react/src/utils/useIsHydrating.test.tsx
+++ b/packages/react/src/utils/useIsHydrating.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { screen, waitFor } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';

--- a/packages/react/src/utils/useRegisteredLabelId.test.tsx
+++ b/packages/react/src/utils/useRegisteredLabelId.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer } from '#test-utils';
 import { useRegisteredLabelId } from './useRegisteredLabelId';

--- a/packages/react/test/pointer.test.tsx
+++ b/packages/react/test/pointer.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { screen } from '@mui/internal-test-utils';
 import { createRenderer, firePointer } from '#test-utils';

--- a/packages/react/test/useTestInteractions.test.tsx
+++ b/packages/react/test/useTestInteractions.test.tsx
@@ -1,4 +1,4 @@
-import { vi, expect } from 'vitest';
+import { vi, expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { useTestInteractions } from './useTestInteractions';
@@ -129,6 +129,8 @@ describe('useTestInteractions', () => {
   });
 
   it('prop getters are memoized', () => {
+    const effectRuns = vi.fn();
+
     function App() {
       const [, setCount] = React.useState(0);
       const propsList = React.useMemo(
@@ -143,6 +145,7 @@ describe('useTestInteractions', () => {
       const { getReferenceProps, getFloatingProps, getItemProps } = useTestInteractions(propsList);
 
       React.useEffect(() => {
+        effectRuns();
         setCount((count) => count + 1);
       }, [getReferenceProps, getFloatingProps, getItemProps]);
 
@@ -150,5 +153,8 @@ describe('useTestInteractions', () => {
     }
 
     render(<App />);
+
+    // The getters must be stable across the re-render forced by the effect.
+    expect(effectRuns).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/utils/src/addEventListener.test.ts
+++ b/packages/utils/src/addEventListener.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { addEventListener } from './addEventListener';
 
 describe('addEventListener', () => {

--- a/packages/utils/src/areArraysEqual.test.ts
+++ b/packages/utils/src/areArraysEqual.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { areArraysEqual } from './areArraysEqual';
 
 describe('areArraysEqual', () => {

--- a/packages/utils/src/clamp.test.ts
+++ b/packages/utils/src/clamp.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { clamp } from './clamp';
 
 describe('clamp', () => {

--- a/packages/utils/src/createLogOnce.test.ts
+++ b/packages/utils/src/createLogOnce.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, afterEach, it } from 'vitest';
 import { createLogOnce, reset } from './createLogOnce';
 
 describe('createLogOnce', () => {

--- a/packages/utils/src/formatErrorMessage.test.ts
+++ b/packages/utils/src/formatErrorMessage.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import formatErrorMessage, { createFormatErrorMessage } from './formatErrorMessage';
 
 describe('formatErrorMessage', () => {

--- a/packages/utils/src/formatNumber.test.ts
+++ b/packages/utils/src/formatNumber.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { formatNumber, getFormatter } from './formatNumber';
 
 const getOptions = (): Intl.NumberFormatOptions => ({

--- a/packages/utils/src/getDefaultFormSubmitter.test.ts
+++ b/packages/utils/src/getDefaultFormSubmitter.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, afterEach, it } from 'vitest';
 import { getDefaultFormSubmitter } from './getDefaultFormSubmitter';
 
 describe('getDefaultFormSubmitter', () => {

--- a/packages/utils/src/getReactElementRef.test.tsx
+++ b/packages/utils/src/getReactElementRef.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { getReactElementRef } from './getReactElementRef';
 

--- a/packages/utils/src/mergeCleanups.test.ts
+++ b/packages/utils/src/mergeCleanups.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it } from 'vitest';
 import { mergeCleanups } from './mergeCleanups';
 
 describe('mergeCleanups', () => {

--- a/packages/utils/src/shadowDom.test.ts
+++ b/packages/utils/src/shadowDom.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { getTarget } from './shadowDom';
 
 describe('getTarget', () => {

--- a/packages/utils/src/store/ReactStore.test.tsx
+++ b/packages/utils/src/store/ReactStore.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi, type MockInstance } from 'vitest';
+import { expect, vi, type MockInstance, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, createRenderer, screen } from '@mui/internal-test-utils';
 import { ReactStore } from './ReactStore';

--- a/packages/utils/src/stringifyLocale.test.ts
+++ b/packages/utils/src/stringifyLocale.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { stringifyLocale } from './stringifyLocale';
 
 describe('stringifyLocale', () => {

--- a/packages/utils/src/useAnimationFrame.test.ts
+++ b/packages/utils/src/useAnimationFrame.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, beforeEach, afterEach, it } from 'vitest';
 import { AnimationFrame, resetAnimationFrameScheduler } from './useAnimationFrame';
 
 describe('AnimationFrame', () => {

--- a/packages/utils/src/useControlled.test.tsx
+++ b/packages/utils/src/useControlled.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { renderHook } from '@testing-library/react';
 import { act, createRenderer } from '@mui/internal-test-utils';

--- a/packages/utils/src/useId.test.tsx
+++ b/packages/utils/src/useId.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { createRenderer, screen } from '@mui/internal-test-utils';
 import { useId } from '@base-ui/utils/useId';

--- a/packages/utils/src/useIdleCallback.fallback.test.ts
+++ b/packages/utils/src/useIdleCallback.fallback.test.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, beforeAll, afterAll, describe, it } from 'vitest';
 
 type IdleCallbackModule = typeof import('./useIdleCallback');
 

--- a/packages/utils/src/useIdleCallback.test.tsx
+++ b/packages/utils/src/useIdleCallback.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createRenderer } from '@mui/internal-test-utils';
-import { expect, vi } from 'vitest';
+import { expect, vi, beforeAll, beforeEach, afterAll, describe, it } from 'vitest';
 
 type IdleCallbackModule = typeof import('./useIdleCallback');
 

--- a/packages/utils/src/useMergedRefs.test.tsx
+++ b/packages/utils/src/useMergedRefs.test.tsx
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest';
+import { expect, vi, describe, it, test } from 'vitest';
 import * as React from 'react';
 import { createRenderer, MuiRenderResult, screen } from '@mui/internal-test-utils';
 import { getReactElementRef } from './getReactElementRef';

--- a/packages/utils/src/usePreviousValue.test.tsx
+++ b/packages/utils/src/usePreviousValue.test.tsx
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import * as React from 'react';
 import { act, createRenderer } from '@mui/internal-test-utils';
 import { usePreviousValue } from './usePreviousValue';

--- a/test/regressions/index.test.ts
+++ b/test/regressions/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, it, beforeEach, afterAll } from 'vitest';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import { chromium, Locator } from '@playwright/test';


### PR DESCRIPTION
Prepares for the next `@mui/internal-code-infra` bump. mui/mui-public#1798 changes the shared eslint test config to require importing vitest globals (`vitest/prefer-importing-vitest-globals`) and enables the vitest recommended rules, which breaks lint on master (measured in #5603).

Changes, without bumping code-infra:

- Import vitest globals in all test files (mechanical `eslint --fix`).
- Enable the same vitest rules today via `createTestConfig({ useVitest: true })`.
- Register shared assertion helpers with `vitest/expect-expect`; allow variable titles with `vitest/valid-title`.
- Restructure conditional `expect` calls.
- Deduplicate test titles; remove two verbatim-duplicated test blocks.
- Fix always-passing `expect(expect(...))` assertions.