### PR TITLE
[popups] Remove duplicate options key from arrow middleware

### DIFF
--- a/packages/react/src/floating-ui-react/middleware/arrow.ts
+++ b/packages/react/src/floating-ui-react/middleware/arrow.ts
@@ -117,7 +117,11 @@ export const baseArrow = (options: ArrowOptions | Derivable<ArrowOptions>): Midd
 export const arrow = (
   options: ArrowOptions | Derivable<ArrowOptions>,
   deps?: React.DependencyList,
-): Middleware => ({
-  ...baseArrow(options),
-  options: [options, deps],
-});
+): Middleware => {
+  const { name, fn } = baseArrow(options);
+  return {
+    name,
+    fn,
+    options: [options, deps],
+  };
+};


### PR DESCRIPTION
Fixes #5594

The forked `arrow` wrapper spread `baseArrow(options)` and then re-set `options`. When a downstream minifier inlines the base call and flattens the spread, the emitted literal contains two `options` keys, and esbuild logs a `duplicate-object-key` warning on every build (seen in OpenNext/Wrangler deploys). Runtime behavior was unaffected since the last key wins.

## Changes

- Return `{ name, fn, options }` explicitly instead of spreading, matching the upstream fix in floating-ui/floating-ui#3444.

Only `arrow` is forked locally; `offset` and `inline` come from `@floating-ui/react-dom` 2.1.9, which already includes the upstream fix. The local Preview Card inline middleware and `adaptiveOrigin` are plain literals without `options`, so they cannot hit this.
