### PR TITLE
[accordion][collapsible] Apply the native disabled attribute to triggers

### DIFF
--- a/packages/react/src/accordion/trigger/AccordionTrigger.test.tsx
+++ b/packages/react/src/accordion/trigger/AccordionTrigger.test.tsx
@@ -18,6 +18,23 @@ describe('<Accordion.Trigger />', () => {
       ),
   }));
 
+  it('renders the disabled attribute when disabled', async () => {
+    await render(
+      <Accordion.Root>
+        <Accordion.Item disabled>
+          <Accordion.Header>
+            <Accordion.Trigger>Trigger</Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Panel>Panel</Accordion.Panel>
+        </Accordion.Item>
+      </Accordion.Root>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Trigger' });
+    expect(trigger).toBeDisabled();
+    expect(trigger).not.toHaveAttribute('aria-disabled');
+  });
+
   it('keeps a non-native trigger tabbable', async () => {
     await render(
       <Accordion.Root>

--- a/packages/react/src/accordion/trigger/AccordionTrigger.tsx
+++ b/packages/react/src/accordion/trigger/AccordionTrigger.tsx
@@ -36,7 +36,6 @@ export const AccordionTrigger = React.forwardRef(function AccordionTrigger(
 
   const { getButtonProps, buttonRef } = useButton({
     disabled,
-    focusableWhenDisabled: true,
     native: nativeButton,
   });
 

--- a/packages/react/src/collapsible/root/CollapsibleRoot.test.tsx
+++ b/packages/react/src/collapsible/root/CollapsibleRoot.test.tsx
@@ -358,7 +358,7 @@ describe('<Collapsible.Root />', () => {
         const trigger = screen.getByRole('button');
 
         await user.keyboard('[Tab]');
-        expect(trigger).toHaveFocus();
+        expect(trigger).not.toHaveFocus();
 
         await user.keyboard(`[${key}]`);
 

--- a/packages/react/src/collapsible/trigger/CollapsibleTrigger.test.tsx
+++ b/packages/react/src/collapsible/trigger/CollapsibleTrigger.test.tsx
@@ -29,6 +29,18 @@ describe('<Collapsible.Trigger />', () => {
     },
   }));
 
+  it('renders the disabled attribute when disabled', async () => {
+    await render(
+      <Collapsible.Root disabled>
+        <Collapsible.Trigger>Trigger</Collapsible.Trigger>
+      </Collapsible.Root>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Trigger' });
+    expect(trigger).toBeDisabled();
+    expect(trigger).not.toHaveAttribute('aria-disabled');
+  });
+
   it('forwards the id prop', async () => {
     await render(
       <Collapsible.Root>

--- a/packages/react/src/collapsible/trigger/CollapsibleTrigger.tsx
+++ b/packages/react/src/collapsible/trigger/CollapsibleTrigger.tsx
@@ -43,7 +43,6 @@ export const CollapsibleTrigger = React.forwardRef(function CollapsibleTrigger(
 
   const { getButtonProps, buttonRef } = useButton({
     disabled,
-    focusableWhenDisabled: true,
     native: nativeButton,
   });
 


### PR DESCRIPTION
Fixes #4114

Disabled Accordion and Collapsible triggers rendered `aria-disabled` and stayed in the tab order. The `focusableWhenDisabled: true` hardcode is a leftover from Accordion's composite days (arrow-key navigation was removed in #4965), so the triggers now match `Button` and the other plain triggers: when disabled, native triggers render the `disabled` attribute, while non-native triggers keep `aria-disabled="true"` and receive `tabindex="-1"`.

## Changes

- Removed the hardcoded `focusableWhenDisabled: true` from `Accordion.Trigger` and `Collapsible.Trigger`.
- Added regression coverage for native `disabled` attributes and non-native `aria-disabled` / `tabindex` attributes and Tab behavior; updated the disabled-trigger focus expectation.

## Changelog note

This changes observable output without touching any documented API: disabled triggers leave the tab order. For native triggers, `aria-disabled` is replaced by `disabled`, so `[aria-disabled]` CSS selectors stop matching. Non-native triggers keep `aria-disabled="true"` and receive `tabindex="-1"`, without a `disabled` attribute. The documented styling hook `data-disabled` is unchanged, so this stays within the semver contract, but the changelog should call it out. In particular, the `render={<Button />}` workaround posted in #4114 must be removed after upgrading: it computes `disabled` from `props['aria-disabled']`, which is no longer set, so leaving it in place renders an enabled-looking (though still inert) button.

