### PR TITLE
[toast] Replace custom data wholesale and accept a function to derive it

### DIFF
--- a/docs/src/app/(docs)/react/components/toast/page.mdx
+++ b/docs/src/app/(docs)/react/components/toast/page.mdx
@@ -380,11 +380,11 @@ toastManager.update(toastId, {
 });
 ```
 
-Custom `data` is replaced as a whole. To change part of it, pass a function that receives the current value and returns the next one:
+Custom `data` is replaced as a whole. To change part of it, pass a function that receives the current value, or `undefined` when the toast has no data yet, and returns the next one:
 
 ```jsx title="Partial data update"
 toastManager.update(toastId, {
-  data: (prevData) => ({ ...prevData, progress: 100 }),
+  data: (prevData) => prevData && { ...prevData, progress: 100 },
 });
 ```
 

--- a/docs/src/app/(docs)/react/components/toast/page.mdx
+++ b/docs/src/app/(docs)/react/components/toast/page.mdx
@@ -252,6 +252,7 @@ import { DemoToastPromise } from './demos/promise';
 
 A toast with custom data can be created by passing any typed object interface to the `data` option.
 This enables you to pass any data (including functions) you need to the toast and access it in the toast's rendering logic.
+When updating a toast, `data` replaces the whole value, while `dataPatch` shallow merges a partial value into existing plain object data.
 
 import { DemoToastCustom } from './demos/custom';
 

--- a/docs/src/app/(docs)/react/components/toast/page.mdx
+++ b/docs/src/app/(docs)/react/components/toast/page.mdx
@@ -252,7 +252,6 @@ import { DemoToastPromise } from './demos/promise';
 
 A toast with custom data can be created by passing any typed object interface to the `data` option.
 This enables you to pass any data (including functions) you need to the toast and access it in the toast's rendering logic.
-When updating a toast, `data` replaces the whole value, while `dataPatch` shallow merges a partial value into existing plain object data.
 
 import { DemoToastCustom } from './demos/custom';
 
@@ -381,11 +380,11 @@ toastManager.update(toastId, {
 });
 ```
 
-Custom `data` is replaced as a whole. To change part of it, pass `dataPatch` instead, which shallow merges into existing plain object data:
+Custom `data` is replaced as a whole. To change part of it, pass a function that receives the current value and returns the next one:
 
 ```jsx title="Partial data update"
 toastManager.update(toastId, {
-  dataPatch: { progress: 100 },
+  data: (prevData) => ({ ...prevData, progress: 100 }),
 });
 ```
 

--- a/docs/src/app/(docs)/react/components/toast/page.mdx
+++ b/docs/src/app/(docs)/react/components/toast/page.mdx
@@ -381,6 +381,14 @@ toastManager.update(toastId, {
 });
 ```
 
+Custom `data` is replaced as a whole. To change part of it, pass `dataPatch` instead, which shallow merges into existing plain object data:
+
+```jsx title="Partial data update"
+toastManager.update(toastId, {
+  dataPatch: { progress: 100 },
+});
+```
+
 ### `close` method
 
 Closes the toast, removing it from the toast list after any animations complete.

--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -598,8 +598,7 @@ type ToastManager<Data extends {} = any> = {
 type ToastManagerAddOptions<Data extends {}> = {
   /**
    * The unique identifier for the toast. Adding a toast with an existing ID
-   * updates it in place and refreshes its auto-dismiss timer. `data` given
-   * here replaces the existing data instead of being merged into it.
+   * updates it in place and refreshes its auto-dismiss timer.
    */
   id?: string;
   /** The title of the toast. */
@@ -824,13 +823,13 @@ type ToastManagerPromiseOptions<Value, Data extends {}> = {
 ```typescript
 type ToastManagerUpdateOptions<Data extends {}> = {
   /**
-   * Custom data for the toast.
-   * Shallow merged into the existing data only when the stored value and the
-   * given value are both plain objects. In every other case—arrays, `Map`,
-   * `Set`, `Date`, class instances, and a toast that has no data yet—the given
-   * value replaces the existing data. Passing `undefined` clears it.
+   * A partial value shallow merged into the toast's custom data.
+   * Only a plain object can be patched, so when the toast has no data yet, or its
+   * data is an array, a `Map`, a `Set`, a `Date`, or a class instance, the patch
+   * is ignored. Use `data` to replace the value instead. When both are given,
+   * `data` is stored first and the patch is merged into it.
    */
-  data?: Partial<Data>;
+  dataPatch?: Partial<Data>;
   /** The title of the toast. */
   title?: React.ReactNode;
   /**
@@ -864,6 +863,8 @@ type ToastManagerUpdateOptions<Data extends {}> = {
   >;
   /** The props forwarded to the toast positioner element when rendering anchored toasts. */
   positionerProps?: ToastManagerPositionerProps;
+  /** Custom data for the toast. */
+  data?: Data;
 };
 ```
 

--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -806,11 +806,7 @@ type ToastManagerPositionerProps = {
 
 ```typescript
 type ToastManagerPromiseOptions<Value, Data extends {}> = {
-  /**
-   * Options for the toast while the promise is pending. It is a new toast, so
-   * `dataPatch` is not accepted; pass `data` instead.
-   */
-  loading: string | Omit<ToastManagerUpdateOptions<Data>, 'dataPatch'>;
+  loading: string | ToastManagerUpdateOptions<Data>;
   success:
     | string
     | ToastManagerUpdateOptions<Data>
@@ -828,18 +824,9 @@ type ToastManagerPromiseOptions<Value, Data extends {}> = {
 type ToastManagerUpdateOptions<Data extends {}> = {
   /**
    * Custom data for the toast.
-   * Replaces the stored value. Use `dataPatch` to shallow merge into it instead.
+   * Replaces the stored value. Pass a function to derive the next value from the current one.
    */
-  data?: Data;
-  /**
-   * A partial value shallow merged into the toast's custom data.
-   * Both the stored data and the patch must be plain objects, so the patch is ignored
-   * when the toast has no data yet, or when either value is an array, a `Map`, a `Set`,
-   * a `Date`, a class instance, or an object with a `null` prototype.
-   * Use `data` to replace the value instead. When both are given, `data` is stored
-   * first and the patch is merged into it.
-   */
-  dataPatch?: Partial<Data>;
+  data?: Data | ((prevData?: Data) => Data);
   /** The title of the toast. */
   title?: React.ReactNode;
   /**

--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -827,7 +827,7 @@ type ToastManagerUpdateOptions<Data extends {}> = {
    * Replaces the stored value. Pass a function to derive the next value from the
    * current one; it receives `undefined` when the toast has no data yet and may
    * return `undefined` to clear the value. A function is always called as an
-   * updater, never stored as the value.
+   * updater, never stored as the value; to store a function, return it from one.
    */
   data?: Data | ((prevData?: Data) => Data | undefined);
   /** The title of the toast. */

--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -806,7 +806,11 @@ type ToastManagerPositionerProps = {
 
 ```typescript
 type ToastManagerPromiseOptions<Value, Data extends {}> = {
-  loading: string | ToastManagerUpdateOptions<Data>;
+  /**
+   * Options for the toast while the promise is pending. It is a new toast, so
+   * `dataPatch` is not accepted; pass `data` instead.
+   */
+  loading: string | Omit<ToastManagerUpdateOptions<Data>, 'dataPatch'>;
   success:
     | string
     | ToastManagerUpdateOptions<Data>
@@ -823,11 +827,17 @@ type ToastManagerPromiseOptions<Value, Data extends {}> = {
 ```typescript
 type ToastManagerUpdateOptions<Data extends {}> = {
   /**
+   * Custom data for the toast.
+   * Replaces the stored value. Use `dataPatch` to shallow merge into it instead.
+   */
+  data?: Data;
+  /**
    * A partial value shallow merged into the toast's custom data.
-   * Only a plain object can be patched, so when the toast has no data yet, or its
-   * data is an array, a `Map`, a `Set`, a `Date`, or a class instance, the patch
-   * is ignored. Use `data` to replace the value instead. When both are given,
-   * `data` is stored first and the patch is merged into it.
+   * Both the stored data and the patch must be plain objects, so the patch is ignored
+   * when the toast has no data yet, or when either value is an array, a `Map`, a `Set`,
+   * a `Date`, a class instance, or an object with a `null` prototype.
+   * Use `data` to replace the value instead. When both are given, `data` is stored
+   * first and the patch is merged into it.
    */
   dataPatch?: Partial<Data>;
   /** The title of the toast. */
@@ -863,8 +873,6 @@ type ToastManagerUpdateOptions<Data extends {}> = {
   >;
   /** The props forwarded to the toast positioner element when rendering anchored toasts. */
   positionerProps?: ToastManagerPositionerProps;
-  /** Custom data for the toast. */
-  data?: Data;
 };
 ```
 

--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -824,9 +824,11 @@ type ToastManagerPromiseOptions<Value, Data extends {}> = {
 type ToastManagerUpdateOptions<Data extends {}> = {
   /**
    * Custom data for the toast.
-   * Replaces the stored value. Pass a function to derive the next value from the current one.
+   * Replaces the stored value. Pass a function to derive the next value from the
+   * current one; it receives `undefined` when the toast has no data yet and may
+   * return `undefined` to clear the value.
    */
-  data?: Data | ((prevData?: Data) => Data);
+  data?: Data | ((prevData?: Data) => Data | undefined);
   /** The title of the toast. */
   title?: React.ReactNode;
   /**

--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -826,7 +826,8 @@ type ToastManagerUpdateOptions<Data extends {}> = {
    * Custom data for the toast.
    * Replaces the stored value. Pass a function to derive the next value from the
    * current one; it receives `undefined` when the toast has no data yet and may
-   * return `undefined` to clear the value.
+   * return `undefined` to clear the value. A function is always called as an
+   * updater, never stored as the value.
    */
   data?: Data | ((prevData?: Data) => Data | undefined);
   /** The title of the toast. */

--- a/docs/src/app/(docs)/react/components/toast/types.md
+++ b/docs/src/app/(docs)/react/components/toast/types.md
@@ -598,7 +598,8 @@ type ToastManager<Data extends {} = any> = {
 type ToastManagerAddOptions<Data extends {}> = {
   /**
    * The unique identifier for the toast. Adding a toast with an existing ID
-   * updates it in place and refreshes its auto-dismiss timer.
+   * updates it in place and refreshes its auto-dismiss timer. `data` given
+   * here replaces the existing data instead of being merged into it.
    */
   id?: string;
   /** The title of the toast. */
@@ -822,7 +823,13 @@ type ToastManagerPromiseOptions<Value, Data extends {}> = {
 
 ```typescript
 type ToastManagerUpdateOptions<Data extends {}> = {
-  /** Custom data for the toast. */
+  /**
+   * Custom data for the toast.
+   * Shallow merged into the existing data only when the stored value and the
+   * given value are both plain objects. In every other case—arrays, `Map`,
+   * `Set`, `Date`, class instances, and a toast that has no data yet—the given
+   * value replaces the existing data. Passing `undefined` clears it.
+   */
   data?: Partial<Data>;
   /** The title of the toast. */
   title?: React.ReactNode;

--- a/packages/react/src/toast/createToastManager.spec.tsx
+++ b/packages/react/src/toast/createToastManager.spec.tsx
@@ -73,6 +73,16 @@ typedManager.promise(Promise.resolve(2), {
   error: 'error',
 });
 
+typedManager.promise(Promise.resolve(2), {
+  loading: {
+    title: 'loading',
+    // @ts-expect-error - dataPatch cannot merge into a new loading toast
+    dataPatch: { count: 1 },
+  },
+  success: 'success',
+  error: 'error',
+});
+
 const legacyManager = createToastManager();
 
 const legacyAddId = legacyManager.add<ToastPayload>({

--- a/packages/react/src/toast/createToastManager.spec.tsx
+++ b/packages/react/src/toast/createToastManager.spec.tsx
@@ -34,6 +34,12 @@ typedManager.add({
   },
 });
 
+typedManager.add({
+  title: 'updater',
+  // @ts-expect-error - add takes a value, not an updater function
+  data: () => ({ id: 'typed', count: 1 }),
+});
+
 typedManager.update('typed', {
   data: {
     id: 'typed-update',

--- a/packages/react/src/toast/createToastManager.spec.tsx
+++ b/packages/react/src/toast/createToastManager.spec.tsx
@@ -111,3 +111,33 @@ legacyManager.promise<number, ToastPayload>(Promise.resolve(5), {
   }),
   error: 'error',
 });
+
+type CallableData = () => string;
+const callableManager = createToastManager<CallableData>();
+
+callableManager.add({ data: () => 'initial' });
+
+callableManager.update('callable', {
+  // @ts-expect-error - a function is always an updater, so a callable value must be wrapped
+  data: () => 'replacement',
+});
+
+callableManager.update('callable', {
+  data: () => () => 'replacement',
+});
+
+callableManager.update('callable', {
+  data: (prevData) => {
+    expectType<CallableData | undefined, typeof prevData>(prevData);
+    return prevData;
+  },
+});
+
+callableManager.promise(Promise.resolve(1), {
+  loading: {
+    // @ts-expect-error - a function is always an updater, so a callable value must be wrapped
+    data: () => 'loading',
+  },
+  success: { data: () => () => 'done' },
+  error: 'failed',
+});

--- a/packages/react/src/toast/createToastManager.spec.tsx
+++ b/packages/react/src/toast/createToastManager.spec.tsx
@@ -42,8 +42,22 @@ typedManager.update('typed', {
 });
 
 typedManager.update('typed', {
+  // @ts-expect-error - id is a missing property, `data` replaces the whole value
   data: {
     count: 2,
+  },
+});
+
+typedManager.update('typed', {
+  dataPatch: {
+    count: 2,
+  },
+});
+
+typedManager.update('typed', {
+  dataPatch: {
+    // @ts-expect-error - message is not a valid property
+    message: 'not a number',
   },
 });
 
@@ -73,6 +87,12 @@ expectType<string, typeof legacyAddId>(legacyAddId);
 legacyManager.update<ToastPayload>('legacy', {
   data: {
     id: 'legacy-update',
+    count: 4,
+  },
+});
+
+legacyManager.update<ToastPayload>('legacy', {
+  dataPatch: {
     count: 4,
   },
 });

--- a/packages/react/src/toast/createToastManager.spec.tsx
+++ b/packages/react/src/toast/createToastManager.spec.tsx
@@ -49,16 +49,15 @@ typedManager.update('typed', {
 });
 
 typedManager.update('typed', {
-  dataPatch: {
-    count: 2,
+  data: (prevData) => {
+    expectType<ToastPayload | undefined, typeof prevData>(prevData);
+    return { id: 'typed-update', count: 2 };
   },
 });
 
 typedManager.update('typed', {
-  dataPatch: {
-    // @ts-expect-error - message is not a valid property
-    message: 'not a number',
-  },
+  // @ts-expect-error - count is a missing property, the updater returns the whole value
+  data: () => ({ id: 'typed-update' }),
 });
 
 typedManager.promise(Promise.resolve(2), {
@@ -70,16 +69,6 @@ typedManager.promise(Promise.resolve(2), {
       count: value,
     },
   }),
-  error: 'error',
-});
-
-typedManager.promise(Promise.resolve(2), {
-  loading: {
-    title: 'loading',
-    // @ts-expect-error - dataPatch cannot merge into a new loading toast
-    dataPatch: { count: 1 },
-  },
-  success: 'success',
   error: 'error',
 });
 
@@ -102,9 +91,7 @@ legacyManager.update<ToastPayload>('legacy', {
 });
 
 legacyManager.update<ToastPayload>('legacy', {
-  dataPatch: {
-    count: 4,
-  },
+  data: (prevData) => ({ id: 'legacy', count: (prevData?.count ?? 0) + 1 }),
 });
 
 legacyManager.promise<number, ToastPayload>(Promise.resolve(5), {

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { reset as resetWarnings } from '@base-ui/utils/warn';
 import { ToastStore, selectors } from './store';
 import type { ToastObject } from './useToastManager';
 
@@ -110,171 +109,59 @@ describe('ToastStore', () => {
     expect(selectors.toast(store.state, 'a')?.data).toBe(undefined);
   });
 
-  it('shallow merges a data patch into plain object custom data', () => {
-    const store = createStore([
-      { id: 'a', data: { name: 'Draft', count: 1, nested: { keep: 1 } } },
-    ]);
+  it('derives custom data from the current value when given a function', () => {
+    const store = createStore([{ id: 'a', data: { name: 'Draft', count: 1 } }]);
 
-    store.updateToast('a', { dataPatch: { count: 2, nested: { drop: 2 } } });
+    store.updateToast('a', { data: (prevData) => ({ ...prevData, count: 2 }) });
     const toast = selectors.toast(store.state, 'a');
-    // Nested values are replaced rather than merged into.
-    expect(toast?.data).toEqual({ name: 'Draft', count: 2, nested: { drop: 2 } });
-    expect(toast).not.toHaveProperty('dataPatch');
+    expect(toast?.data).toEqual({ name: 'Draft', count: 2 });
     expect(toast?.updateKey).toBe(1);
   });
 
-  it('merges a data patch into the data given in the same update', () => {
-    const store = createStore([{ id: 'a', data: { name: 'Draft', stale: true } }]);
+  it('passes undefined to the data updater when the toast has no custom data', () => {
+    const store = createStore([{ id: 'a' }]);
+    const updater = vi.fn(() => ({ name: 'Draft' }));
 
-    store.updateToast<{ name: string; count?: number }>('a', {
-      data: { name: 'Saved' },
-      dataPatch: { count: 1 },
-    });
-    expect(selectors.toast(store.state, 'a')?.data).toEqual({ name: 'Saved', count: 1 });
+    store.updateToast('a', { data: updater });
+    expect(updater).toHaveBeenCalledWith(undefined);
+    expect(selectors.toast(store.state, 'a')?.data).toEqual({ name: 'Draft' });
   });
 
-  it('ignores a data patch when the toast has no custom data', () => {
-    resetWarnings();
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      const store = createStore([{ id: 'a' }]);
-
-      store.updateToast('a', { title: 'Saved', dataPatch: { name: 'Draft' } });
-      const toast = selectors.toast(store.state, 'a');
-      expect(toast?.title).toBe('Saved');
-      expect(toast?.data).toBe(undefined);
-      expect(toast).not.toHaveProperty('dataPatch');
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(warnSpy.mock.calls[0]?.[0]).toContain('The `dataPatch` option was ignored');
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
-  it('ignores a data patch when the custom data is not a plain object', () => {
-    class Model {
-      name: string;
-
-      constructor(name: string) {
-        this.name = name;
-      }
-    }
-    class NullBasedModel {
-      name: string;
-
-      constructor(name: string) {
-        this.name = name;
-      }
-    }
-    // Its instances are now "one hop from `null`" like an object literal, but they are
-    // still class instances.
-    Object.setPrototypeOf(NullBasedModel.prototype, null);
-
-    // Patching any of these key by key would strip the prototype (arrays, `Map`, class
-    // instances) or swap a deliberately null prototype for `Object.prototype`.
-    const values = [
-      ['x', 'y'],
-      new Map([['k', 1]]),
-      new Model('a'),
-      new NullBasedModel('a'),
-      Object.assign(Object.create(null), { name: 'a' }),
-    ];
-    const store = createStore(values.map((data, index) => ({ id: `${index}`, data })));
-
-    resetWarnings();
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      values.forEach((data, index) => {
-        store.updateToast(`${index}`, { dataPatch: { name: 'b' } });
-        expect(selectors.toast(store.state, `${index}`)?.data).toBe(data);
-      });
-      // The warning is logged once per message.
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
-  it('ignores a data patch that is not itself a plain object', () => {
-    resetWarnings();
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      const data = { name: 'Draft' };
-      const store = createStore([{ id: 'a', data }]);
-
-      store.updateToast('a', { dataPatch: ['x'] as any });
-      expect(selectors.toast(store.state, 'a')?.data).toBe(data);
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
-  it('keeps an own __proto__ key in a data patch as an own key', () => {
-    const store = createStore([{ id: 'a', data: { name: 'Draft' } }]);
-
-    // `Object.assign` writes through the inherited `__proto__` setter, which would swap
-    // the merged object's prototype and drop the key instead of copying it.
-    const injected = JSON.parse('{"__proto__":{"injected":true}}');
-    store.updateToast('a', { dataPatch: injected });
-    const data = selectors.toast(store.state, 'a')?.data;
-    expect(Object.getPrototypeOf(data)).toBe(Object.prototype);
-    expect(Object.hasOwn(data, '__proto__')).toBe(true);
-    expect('injected' in data).toBe(false);
-
-    // The merged value is still a plain object, so a later patch still merges.
-    store.updateToast('a', { dataPatch: { count: 1 } });
-    expect(selectors.toast(store.state, 'a')?.data).toMatchObject({ name: 'Draft', count: 1 });
-  });
-
-  it('does not read a data patch when updating a missing or ending toast', () => {
+  it('does not call the data updater for a missing or ending toast', () => {
     const store = createStore([{ id: 'a', data: { name: 'Draft' } }]);
     store.closeToast('a');
     expect(selectors.toast(store.state, 'a')?.transitionStatus).toBe('ending');
 
-    const dataPatch = {
-      get name(): string {
-        throw new Error('data was read');
-      },
-    };
-    expect(() => store.updateToast('a', { dataPatch })).not.toThrow();
+    const updater = vi.fn();
+    store.updateToast('a', { data: updater });
+    store.updateToast('missing', { data: updater });
+    expect(updater).not.toHaveBeenCalled();
     expect(selectors.toast(store.state, 'a')?.data).toEqual({ name: 'Draft' });
-
-    expect(() => store.updateToast('missing', { dataPatch })).not.toThrow();
   });
 
   it('replaces custom data when re-adding a toast under an existing id', () => {
     const store = createStore([]);
 
-    // `add` takes a complete `Data`, so keys the caller leaves out must not survive from
-    // the previous value.
     store.addToast({ id: 'a', data: { status: 'error', errorCode: 42 } });
     store.addToast({ id: 'a', data: { status: 'ok' } });
     expect(selectors.toast(store.state, 'a')?.data).toEqual({ status: 'ok' });
 
-    // Only the data actually given is replaced; omitting it leaves the stored value alone.
     store.addToast({ id: 'a', title: 'Still uploading' });
     expect(selectors.toast(store.state, 'a')?.data).toEqual({ status: 'ok' });
   });
 
-  it('patches the loading data of a promise toast on settlement', async () => {
-    resetWarnings();
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      const store = createStore([]);
+  it('resolves data updaters on a promise toast', async () => {
+    const store = createStore([]);
 
-      await store.promiseToast(Promise.resolve('done'), {
-        loading: { title: 'Saving', data: { step: 'save', progress: 0 } },
-        success: { title: 'Saved', dataPatch: { progress: 100 } },
-        error: 'Failed',
-      });
-      const toast = store.state.toasts[0];
-      expect(toast?.data).toEqual({ step: 'save', progress: 100 });
-      expect(toast).not.toHaveProperty('dataPatch');
-      expect(warnSpy).not.toHaveBeenCalled();
-    } finally {
-      warnSpy.mockRestore();
-    }
+    await store.promiseToast(Promise.resolve('done'), {
+      loading: {
+        title: 'Saving',
+        data: (prevData) => ({ ...prevData, step: 'save', progress: 0 }),
+      },
+      success: { title: 'Saved', data: (prevData) => ({ ...prevData, progress: 100 }) },
+      error: 'Failed',
+    });
+    expect(store.state.toasts[0]?.data).toEqual({ step: 'save', progress: 100 });
   });
 
   it('does not invoke onRemove for a toast that is no longer in the store', () => {

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -146,6 +146,43 @@ describe('ToastStore', () => {
     expect(selectors.toast(store.state, 'a')?.data).toEqual({ name: 'Draft' });
   });
 
+  it('keeps a toast added from inside a data updater', () => {
+    const store = createStore([{ id: 'a', data: { count: 1 } }]);
+
+    store.updateToast('a', {
+      data: () => {
+        store.addToast({ id: 'b' });
+        return { count: 2 };
+      },
+    });
+    expect(store.state.toasts.map((toast) => toast.id)).toEqual(['b', 'a']);
+    expect(selectors.toast(store.state, 'a')?.data).toEqual({ count: 2 });
+    expectToastMetadataToMatchToasts(store);
+  });
+
+  it('keeps a toast closed from inside its data updater closed', () => {
+    const store = createStore([{ id: 'a', data: { count: 1 } }]);
+
+    store.updateToast('a', {
+      data: () => {
+        store.closeToast('a');
+        return { count: 2 };
+      },
+    });
+    expect(selectors.toast(store.state, 'a')?.transitionStatus).toBe('ending');
+    expect(selectors.toast(store.state, 'a')?.data).toEqual({ count: 1 });
+  });
+
+  it('stores a function as the value when re-adding a toast under an existing id', () => {
+    const store = createStore([]);
+    const value = () => 'first';
+    const nextValue = () => 'second';
+
+    store.addToast({ id: 'a', data: value });
+    store.addToast({ id: 'a', data: nextValue });
+    expect(selectors.toast(store.state, 'a')?.data).toBe(nextValue);
+  });
+
   it('replaces custom data when re-adding a toast under an existing id', () => {
     const store = createStore([]);
 

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -118,6 +118,13 @@ describe('ToastStore', () => {
     expect(toast?.updateKey).toBe(1);
   });
 
+  it('clears custom data when the data updater returns undefined', () => {
+    const store = createStore([{ id: 'a', data: { name: 'Draft' } }]);
+
+    store.updateToast('a', { data: () => undefined });
+    expect(selectors.toast(store.state, 'a')?.data).toBe(undefined);
+  });
+
   it('passes undefined to the data updater when the toast has no custom data', () => {
     const store = createStore([{ id: 'a' }]);
     const updater = vi.fn(() => ({ name: 'Draft' }));

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -108,6 +108,128 @@ describe('ToastStore', () => {
     expect(selectors.toast(store.state, 'a')?.data).toBe(undefined);
   });
 
+  it('replaces nested values in custom data rather than merging into them', () => {
+    const store = createStore([{ id: 'a', data: { nested: { keep: 1, drop: 2 } } }]);
+
+    store.updateToast('a', { data: { nested: { keep: 9 } } });
+    expect(selectors.toast(store.state, 'a')?.data).toEqual({ nested: { keep: 9 } });
+  });
+
+  it('replaces array custom data instead of merging it index-wise', () => {
+    const store = createStore([{ id: 'a', data: ['x', 'y'] }]);
+
+    // Spreading an array merges it index-wise, which turns it into a plain object
+    // and leaves the stale trailing entry behind.
+    const nextData = ['z'];
+    store.updateToast('a', { data: nextData });
+    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
+  });
+
+  it('replaces class instance custom data so its prototype survives', () => {
+    class Model {
+      name: string;
+
+      constructor(name: string) {
+        this.name = name;
+      }
+
+      greet() {
+        return `hi ${this.name}`;
+      }
+    }
+
+    const store = createStore([{ id: 'a', data: new Model('a') }]);
+
+    // Spreading a class instance drops its prototype along with its methods.
+    store.updateToast('a', { data: new Model('b') });
+    const data = selectors.toast(store.state, 'a')?.data;
+    expect(data).toBeInstanceOf(Model);
+    expect(data.greet()).toBe('hi b');
+  });
+
+  it('replaces Map custom data instead of flattening it to an empty object', () => {
+    const store = createStore([{ id: 'a', data: new Map([['k', 1]]) }]);
+
+    // A `Map` keeps its entries off its own enumerable properties, so spreading one
+    // yields an empty object and loses every entry.
+    const nextData = new Map([['j', 2]]);
+    store.updateToast('a', { data: nextData });
+    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
+  });
+
+  it('merges plain object custom data that does not use this realm’s Object.prototype', () => {
+    // A record built in another realm — an iframe, say — has a prototype one hop from
+    // `null` that is not this realm's `Object.prototype`. It is still a plain record, so it
+    // merges, and the merge must not swap its prototype for the local one.
+    const foreignObjectPrototype = Object.create(null);
+    const store = createStore([
+      {
+        id: 'a',
+        data: Object.assign(Object.create(foreignObjectPrototype), { name: 'Draft', count: 1 }),
+      },
+    ]);
+
+    store.updateToast('a', { data: { count: 2 } });
+    const data = selectors.toast(store.state, 'a')?.data;
+    expect({ ...data }).toEqual({ name: 'Draft', count: 2 });
+    expect(Object.getPrototypeOf(data)).toBe(foreignObjectPrototype);
+  });
+
+  it('replaces null prototype custom data so the null prototype survives', () => {
+    const store = createStore([
+      { id: 'a', data: Object.assign(Object.create(null), { name: 'Draft' }) },
+    ]);
+
+    // Merging would spread the dictionary into an object literal and hand back
+    // `Object.prototype`, which is exactly what a null prototype guards against.
+    const nextData = Object.assign(Object.create(null), { name: 'Saved' });
+    store.updateToast('a', { data: nextData });
+    const data = selectors.toast(store.state, 'a')?.data;
+    expect(data).toBe(nextData);
+    expect(Object.getPrototypeOf(data)).toBe(null);
+  });
+
+  it('replaces custom data when only one side is a plain object', () => {
+    const store = createStore([
+      { id: 'record', data: { name: 'Draft' } },
+      { id: 'array', data: ['x'] },
+    ]);
+
+    const nextArray = ['z'];
+    store.updateToast('record', { data: nextArray });
+    expect(selectors.toast(store.state, 'record')?.data).toBe(nextArray);
+
+    const nextRecord = { name: 'Saved' };
+    store.updateToast('array', { data: nextRecord });
+    expect(selectors.toast(store.state, 'array')?.data).toBe(nextRecord);
+  });
+
+  it('stores the given custom data as-is when the toast has none yet', () => {
+    const store = createStore([{ id: 'a' }]);
+
+    const nextData = { name: 'Draft' };
+    store.updateToast('a', { data: nextData });
+    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
+  });
+
+  it('replaces custom data when re-adding a toast under an existing id', () => {
+    const store = createStore([]);
+
+    // `add` takes a complete `Data`, not a patch, so keys the caller leaves out must
+    // not survive from the previous value.
+    store.addToast({ id: 'a', data: { status: 'error', errorCode: 42 } });
+    store.addToast({ id: 'a', data: { status: 'ok' } });
+    expect(selectors.toast(store.state, 'a')?.data).toEqual({ status: 'ok' });
+
+    const nextData = new Map([['j', 2]]);
+    store.addToast({ id: 'a', data: nextData });
+    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
+
+    // Only the data actually given is replaced; omitting it leaves the stored value alone.
+    store.addToast({ id: 'a', title: 'Still uploading' });
+    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
+  });
+
   it('does not invoke onRemove for a toast that is no longer in the store', () => {
     const onRemove = vi.fn();
     const store = createStore([{ id: 'a', onRemove }]);

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -272,21 +272,6 @@ describe('ToastStore', () => {
       expect(toast?.data).toEqual({ step: 'save', progress: 100 });
       expect(toast).not.toHaveProperty('dataPatch');
       expect(warnSpy).not.toHaveBeenCalled();
-
-      // A loading toast is brand new, so it has no data for a patch to merge into.
-      await store.promiseToast(Promise.resolve('done'), {
-        loading: {
-          title: 'Saving',
-          // @ts-expect-error - the `loading` type omits `dataPatch`; a JavaScript caller can still pass one
-          dataPatch: { progress: 0 },
-        },
-        success: 'Saved',
-        error: 'Failed',
-      });
-      const loadingToast = store.state.toasts[0];
-      expect(loadingToast?.data).toBe(undefined);
-      expect(loadingToast).not.toHaveProperty('dataPatch');
-      expect(warnSpy).toHaveBeenCalledTimes(1);
     } finally {
       warnSpy.mockRestore();
     }

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { reset as resetWarnings } from '@base-ui/utils/warn';
 import { ToastStore, selectors } from './store';
 import type { ToastObject } from './useToastManager';
 
@@ -95,69 +96,121 @@ describe('ToastStore', () => {
     expect(selectors.toast(store.state, 'a')?.transitionStatus).toBe(undefined);
   });
 
-  it('shallow merges custom data when updating a toast', () => {
+  it('replaces custom data wholesale when updating a toast', () => {
     const store = createStore([{ id: 'a', data: { name: 'Draft', count: 1 } }]);
 
-    store.updateToast('a', { data: { count: 2 } });
-    expect(selectors.toast(store.state, 'a')?.data).toEqual({ name: 'Draft', count: 2 });
+    const nextData = { count: 2 };
+    store.updateToast('a', { data: nextData });
+    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
 
     store.updateToast('a', { title: 'Saved' });
-    expect(selectors.toast(store.state, 'a')?.data).toEqual({ name: 'Draft', count: 2 });
+    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
 
     store.updateToast('a', { data: undefined });
     expect(selectors.toast(store.state, 'a')?.data).toBe(undefined);
   });
 
-  it('replaces nested values in custom data rather than merging into them', () => {
-    const store = createStore([{ id: 'a', data: { nested: { keep: 1, drop: 2 } } }]);
+  it('shallow merges a data patch into plain object custom data', () => {
+    const store = createStore([
+      { id: 'a', data: { name: 'Draft', count: 1, nested: { keep: 1 } } },
+    ]);
 
-    store.updateToast('a', { data: { nested: { keep: 9 } } });
-    expect(selectors.toast(store.state, 'a')?.data).toEqual({ nested: { keep: 9 } });
+    store.updateToast('a', { dataPatch: { count: 2, nested: { drop: 2 } } });
+    const toast = selectors.toast(store.state, 'a');
+    // Nested values are replaced rather than merged into.
+    expect(toast?.data).toEqual({ name: 'Draft', count: 2, nested: { drop: 2 } });
+    expect(toast).not.toHaveProperty('dataPatch');
+    expect(toast?.updateKey).toBe(1);
   });
 
-  it('replaces array custom data instead of merging it index-wise', () => {
-    const store = createStore([{ id: 'a', data: ['x', 'y'] }]);
+  it('merges a data patch into the data given in the same update', () => {
+    const store = createStore([{ id: 'a', data: { name: 'Draft', stale: true } }]);
 
-    // Spreading an array merges it index-wise, which turns it into a plain object
-    // and leaves the stale trailing entry behind.
-    const nextData = ['z'];
-    store.updateToast('a', { data: nextData });
-    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
+    store.updateToast<{ name: string; count?: number }>('a', {
+      data: { name: 'Saved' },
+      dataPatch: { count: 1 },
+    });
+    expect(selectors.toast(store.state, 'a')?.data).toEqual({ name: 'Saved', count: 1 });
   });
 
-  it('replaces class instance custom data so its prototype survives', () => {
+  it('ignores a data patch when the toast has no custom data', () => {
+    resetWarnings();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const store = createStore([{ id: 'a' }]);
+
+      store.updateToast('a', { title: 'Saved', dataPatch: { name: 'Draft' } });
+      const toast = selectors.toast(store.state, 'a');
+      expect(toast?.title).toBe('Saved');
+      expect(toast?.data).toBe(undefined);
+      expect(toast).not.toHaveProperty('dataPatch');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain('The `dataPatch` option was ignored');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('ignores a data patch when the custom data is not a plain object', () => {
     class Model {
       name: string;
 
       constructor(name: string) {
         this.name = name;
       }
+    }
+    class NullBasedModel {
+      name: string;
 
-      greet() {
-        return `hi ${this.name}`;
+      constructor(name: string) {
+        this.name = name;
       }
     }
+    // Its instances are now "one hop from `null`" like an object literal, but they are
+    // still class instances.
+    Object.setPrototypeOf(NullBasedModel.prototype, null);
 
-    const store = createStore([{ id: 'a', data: new Model('a') }]);
+    // Patching any of these key by key would strip the prototype (arrays, `Map`, class
+    // instances) or swap a deliberately null prototype for `Object.prototype`.
+    const values = [
+      ['x', 'y'],
+      new Map([['k', 1]]),
+      new Model('a'),
+      new NullBasedModel('a'),
+      Object.assign(Object.create(null), { name: 'a' }),
+    ];
+    const store = createStore(values.map((data, index) => ({ id: `${index}`, data })));
 
-    // Spreading a class instance drops its prototype along with its methods.
-    store.updateToast('a', { data: new Model('b') });
-    const data = selectors.toast(store.state, 'a')?.data;
-    expect(data).toBeInstanceOf(Model);
-    expect(data.greet()).toBe('hi b');
+    resetWarnings();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      values.forEach((data, index) => {
+        store.updateToast(`${index}`, { dataPatch: { name: 'b' } });
+        expect(selectors.toast(store.state, `${index}`)?.data).toBe(data);
+      });
+      // The warning is logged once per message.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
-  it('replaces Map custom data instead of flattening it to an empty object', () => {
-    const store = createStore([{ id: 'a', data: new Map([['k', 1]]) }]);
+  it('ignores a data patch that is not itself a plain object', () => {
+    resetWarnings();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const data = { name: 'Draft' };
+      const store = createStore([{ id: 'a', data }]);
 
-    // A `Map` keeps its entries off its own enumerable properties, so spreading one
-    // yields an empty object and loses every entry.
-    const nextData = new Map([['j', 2]]);
-    store.updateToast('a', { data: nextData });
-    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
+      store.updateToast('a', { dataPatch: ['x'] as any });
+      expect(selectors.toast(store.state, 'a')?.data).toBe(data);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
-  it('merges plain object custom data that does not use this realm’s Object.prototype', () => {
+  it('merges a data patch into plain object custom data from another realm', () => {
     // A record built in another realm — an iframe — has that realm's `Object.prototype`,
     // which is not this realm's. It is still a plain record, so it merges, and the merge
     // must not swap its prototype for the local one.
@@ -172,7 +225,7 @@ describe('ToastStore', () => {
         { id: 'a', data: Object.assign(new ForeignObject(), { name: 'Draft', count: 1 }) },
       ]);
 
-      store.updateToast('a', { data: { count: 2 } });
+      store.updateToast('a', { dataPatch: { count: 2 } });
       const data = selectors.toast(store.state, 'a')?.data;
       expect({ ...data }).toEqual({ name: 'Draft', count: 2 });
       expect(Object.getPrototypeOf(data)).toBe(foreignObjectPrototype);
@@ -181,46 +234,24 @@ describe('ToastStore', () => {
     }
   });
 
-  it('replaces class instance custom data whose prototype chain ends at the class', () => {
-    class Model {
-      name: string;
-
-      stale?: boolean;
-
-      constructor(name: string, stale?: boolean) {
-        this.name = name;
-        this.stale = stale;
-      }
-    }
-    // Its instances are now "one hop from `null`" like an object literal, but they are
-    // still class instances, so they must be replaced rather than merged.
-    Object.setPrototypeOf(Model.prototype, null);
-
-    const store = createStore([{ id: 'a', data: new Model('a', true) }]);
-
-    const nextData = new Model('b');
-    store.updateToast('a', { data: nextData });
-    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
-  });
-
-  it('keeps an own __proto__ key in custom data as an own key', () => {
+  it('keeps an own __proto__ key in a data patch as an own key', () => {
     const store = createStore([{ id: 'a', data: { name: 'Draft' } }]);
 
     // `Object.assign` writes through the inherited `__proto__` setter, which would swap
     // the merged object's prototype and drop the key instead of copying it.
     const injected = JSON.parse('{"__proto__":{"injected":true}}');
-    store.updateToast('a', { data: injected });
+    store.updateToast('a', { dataPatch: injected });
     const data = selectors.toast(store.state, 'a')?.data;
     expect(Object.getPrototypeOf(data)).toBe(Object.prototype);
     expect(Object.hasOwn(data, '__proto__')).toBe(true);
     expect('injected' in data).toBe(false);
 
     // The merged value is still a plain object, so a later patch still merges.
-    store.updateToast('a', { data: { count: 1 } });
+    store.updateToast('a', { dataPatch: { count: 1 } });
     expect(selectors.toast(store.state, 'a')?.data).toMatchObject({ name: 'Draft', count: 1 });
   });
 
-  it('defines merged custom data as own properties instead of calling inherited setters', () => {
+  it('defines patched custom data as own properties instead of calling inherited setters', () => {
     // The setter lives on another realm's `Object.prototype`, so it is inherited by a plain
     // record from that realm without leaking into this realm's objects.
     const iframe = document.createElement('iframe');
@@ -233,7 +264,7 @@ describe('ToastStore', () => {
         { id: 'a', data: Object.assign(new ForeignObject(), { name: 'Draft' }) },
       ]);
 
-      store.updateToast('a', { data: { count: 2 } });
+      store.updateToast('a', { dataPatch: { count: 2 } });
       const data = selectors.toast(store.state, 'a')?.data;
       expect(setter).not.toHaveBeenCalled();
       expect(Object.hasOwn(data, 'count')).toBe(true);
@@ -244,75 +275,65 @@ describe('ToastStore', () => {
     }
   });
 
-  it('does not read custom data when updating a missing or ending toast', () => {
+  it('does not read a data patch when updating a missing or ending toast', () => {
     const store = createStore([{ id: 'a', data: { name: 'Draft' } }]);
     store.closeToast('a');
     expect(selectors.toast(store.state, 'a')?.transitionStatus).toBe('ending');
 
-    const data = {
+    const dataPatch = {
       get name(): string {
         throw new Error('data was read');
       },
     };
-    expect(() => store.updateToast('a', { data })).not.toThrow();
+    expect(() => store.updateToast('a', { dataPatch })).not.toThrow();
     expect(selectors.toast(store.state, 'a')?.data).toEqual({ name: 'Draft' });
 
-    expect(() => store.updateToast('missing', { data })).not.toThrow();
-  });
-
-  it('replaces null prototype custom data so the null prototype survives', () => {
-    const store = createStore([
-      { id: 'a', data: Object.assign(Object.create(null), { name: 'Draft' }) },
-    ]);
-
-    // Merging would spread the dictionary into an object literal and hand back
-    // `Object.prototype`, which is exactly what a null prototype guards against.
-    const nextData = Object.assign(Object.create(null), { name: 'Saved' });
-    store.updateToast('a', { data: nextData });
-    const data = selectors.toast(store.state, 'a')?.data;
-    expect(data).toBe(nextData);
-    expect(Object.getPrototypeOf(data)).toBe(null);
-  });
-
-  it('replaces custom data when only one side is a plain object', () => {
-    const store = createStore([
-      { id: 'record', data: { name: 'Draft' } },
-      { id: 'array', data: ['x'] },
-    ]);
-
-    const nextArray = ['z'];
-    store.updateToast('record', { data: nextArray });
-    expect(selectors.toast(store.state, 'record')?.data).toBe(nextArray);
-
-    const nextRecord = { name: 'Saved' };
-    store.updateToast('array', { data: nextRecord });
-    expect(selectors.toast(store.state, 'array')?.data).toBe(nextRecord);
-  });
-
-  it('stores the given custom data as-is when the toast has none yet', () => {
-    const store = createStore([{ id: 'a' }]);
-
-    const nextData = { name: 'Draft' };
-    store.updateToast('a', { data: nextData });
-    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
+    expect(() => store.updateToast('missing', { dataPatch })).not.toThrow();
   });
 
   it('replaces custom data when re-adding a toast under an existing id', () => {
     const store = createStore([]);
 
-    // `add` takes a complete `Data`, not a patch, so keys the caller leaves out must
-    // not survive from the previous value.
+    // `add` takes a complete `Data`, so keys the caller leaves out must not survive from
+    // the previous value.
     store.addToast({ id: 'a', data: { status: 'error', errorCode: 42 } });
     store.addToast({ id: 'a', data: { status: 'ok' } });
     expect(selectors.toast(store.state, 'a')?.data).toEqual({ status: 'ok' });
 
-    const nextData = new Map([['j', 2]]);
-    store.addToast({ id: 'a', data: nextData });
-    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
-
     // Only the data actually given is replaced; omitting it leaves the stored value alone.
     store.addToast({ id: 'a', title: 'Still uploading' });
-    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
+    expect(selectors.toast(store.state, 'a')?.data).toEqual({ status: 'ok' });
+  });
+
+  it('patches the loading data of a promise toast on settlement', async () => {
+    resetWarnings();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const store = createStore([]);
+
+      await store.promiseToast(Promise.resolve('done'), {
+        loading: { title: 'Saving', data: { step: 'save', progress: 0 } },
+        success: { title: 'Saved', dataPatch: { progress: 100 } },
+        error: 'Failed',
+      });
+      const toast = store.state.toasts[0];
+      expect(toast?.data).toEqual({ step: 'save', progress: 100 });
+      expect(toast).not.toHaveProperty('dataPatch');
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      // A loading toast is brand new, so it has no data for a patch to merge into.
+      await store.promiseToast(Promise.resolve('done'), {
+        loading: { title: 'Saving', dataPatch: { progress: 0 } },
+        success: 'Saved',
+        error: 'Failed',
+      });
+      const loadingToast = store.state.toasts[0];
+      expect(loadingToast?.data).toBe(undefined);
+      expect(loadingToast).not.toHaveProperty('dataPatch');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('does not invoke onRemove for a toast that is no longer in the store', () => {

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -158,21 +158,49 @@ describe('ToastStore', () => {
   });
 
   it('merges plain object custom data that does not use this realm’s Object.prototype', () => {
-    // A record built in another realm — an iframe, say — has a prototype one hop from
-    // `null` that is not this realm's `Object.prototype`. It is still a plain record, so it
-    // merges, and the merge must not swap its prototype for the local one.
-    const foreignObjectPrototype = Object.create(null);
-    const store = createStore([
-      {
-        id: 'a',
-        data: Object.assign(Object.create(foreignObjectPrototype), { name: 'Draft', count: 1 }),
-      },
-    ]);
+    // A record built in another realm — an iframe — has that realm's `Object.prototype`,
+    // which is not this realm's. It is still a plain record, so it merges, and the merge
+    // must not swap its prototype for the local one.
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    try {
+      const ForeignObject = (iframe.contentWindow as Window & typeof globalThis).Object;
+      const foreignObjectPrototype = ForeignObject.prototype;
+      expect(foreignObjectPrototype).not.toBe(Object.prototype);
 
-    store.updateToast('a', { data: { count: 2 } });
-    const data = selectors.toast(store.state, 'a')?.data;
-    expect({ ...data }).toEqual({ name: 'Draft', count: 2 });
-    expect(Object.getPrototypeOf(data)).toBe(foreignObjectPrototype);
+      const store = createStore([
+        { id: 'a', data: Object.assign(new ForeignObject(), { name: 'Draft', count: 1 }) },
+      ]);
+
+      store.updateToast('a', { data: { count: 2 } });
+      const data = selectors.toast(store.state, 'a')?.data;
+      expect({ ...data }).toEqual({ name: 'Draft', count: 2 });
+      expect(Object.getPrototypeOf(data)).toBe(foreignObjectPrototype);
+    } finally {
+      iframe.remove();
+    }
+  });
+
+  it('replaces class instance custom data whose prototype chain ends at the class', () => {
+    class Model {
+      name: string;
+
+      stale?: boolean;
+
+      constructor(name: string, stale?: boolean) {
+        this.name = name;
+        this.stale = stale;
+      }
+    }
+    // Its instances are now "one hop from `null`" like an object literal, but they are
+    // still class instances, so they must be replaced rather than merged.
+    Object.setPrototypeOf(Model.prototype, null);
+
+    const store = createStore([{ id: 'a', data: new Model('a', true) }]);
+
+    const nextData = new Model('b');
+    store.updateToast('a', { data: nextData });
+    expect(selectors.toast(store.state, 'a')?.data).toBe(nextData);
   });
 
   it('keeps an own __proto__ key in custom data as an own key', () => {
@@ -193,19 +221,27 @@ describe('ToastStore', () => {
   });
 
   it('defines merged custom data as own properties instead of calling inherited setters', () => {
-    const setter = vi.fn();
-    const prototype = Object.create(null);
-    Object.defineProperty(prototype, 'count', { set: setter });
-    const store = createStore([
-      { id: 'a', data: Object.assign(Object.create(prototype), { name: 'Draft' }) },
-    ]);
+    // The setter lives on another realm's `Object.prototype`, so it is inherited by a plain
+    // record from that realm without leaking into this realm's objects.
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    try {
+      const ForeignObject = (iframe.contentWindow as Window & typeof globalThis).Object;
+      const setter = vi.fn();
+      Object.defineProperty(ForeignObject.prototype, 'count', { set: setter, configurable: true });
+      const store = createStore([
+        { id: 'a', data: Object.assign(new ForeignObject(), { name: 'Draft' }) },
+      ]);
 
-    store.updateToast('a', { data: { count: 2 } });
-    const data = selectors.toast(store.state, 'a')?.data;
-    expect(setter).not.toHaveBeenCalled();
-    expect(Object.hasOwn(data, 'count')).toBe(true);
-    expect({ ...data }).toEqual({ name: 'Draft', count: 2 });
-    expect(Object.getPrototypeOf(data)).toBe(prototype);
+      store.updateToast('a', { data: { count: 2 } });
+      const data = selectors.toast(store.state, 'a')?.data;
+      expect(setter).not.toHaveBeenCalled();
+      expect(Object.hasOwn(data, 'count')).toBe(true);
+      expect({ ...data }).toEqual({ name: 'Draft', count: 2 });
+      expect(Object.getPrototypeOf(data)).toBe(ForeignObject.prototype);
+    } finally {
+      iframe.remove();
+    }
   });
 
   it('does not read custom data when updating a missing or ending toast', () => {

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -175,6 +175,55 @@ describe('ToastStore', () => {
     expect(Object.getPrototypeOf(data)).toBe(foreignObjectPrototype);
   });
 
+  it('keeps an own __proto__ key in custom data as an own key', () => {
+    const store = createStore([{ id: 'a', data: { name: 'Draft' } }]);
+
+    // `Object.assign` writes through the inherited `__proto__` setter, which would swap
+    // the merged object's prototype and drop the key instead of copying it.
+    const injected = JSON.parse('{"__proto__":{"injected":true}}');
+    store.updateToast('a', { data: injected });
+    const data = selectors.toast(store.state, 'a')?.data;
+    expect(Object.getPrototypeOf(data)).toBe(Object.prototype);
+    expect(Object.hasOwn(data, '__proto__')).toBe(true);
+    expect('injected' in data).toBe(false);
+
+    // The merged value is still a plain object, so a later patch still merges.
+    store.updateToast('a', { data: { count: 1 } });
+    expect(selectors.toast(store.state, 'a')?.data).toMatchObject({ name: 'Draft', count: 1 });
+  });
+
+  it('defines merged custom data as own properties instead of calling inherited setters', () => {
+    const setter = vi.fn();
+    const prototype = Object.create(null);
+    Object.defineProperty(prototype, 'count', { set: setter });
+    const store = createStore([
+      { id: 'a', data: Object.assign(Object.create(prototype), { name: 'Draft' }) },
+    ]);
+
+    store.updateToast('a', { data: { count: 2 } });
+    const data = selectors.toast(store.state, 'a')?.data;
+    expect(setter).not.toHaveBeenCalled();
+    expect(Object.hasOwn(data, 'count')).toBe(true);
+    expect({ ...data }).toEqual({ name: 'Draft', count: 2 });
+    expect(Object.getPrototypeOf(data)).toBe(prototype);
+  });
+
+  it('does not read custom data when updating a missing or ending toast', () => {
+    const store = createStore([{ id: 'a', data: { name: 'Draft' } }]);
+    store.closeToast('a');
+    expect(selectors.toast(store.state, 'a')?.transitionStatus).toBe('ending');
+
+    const data = {
+      get name(): string {
+        throw new Error('data was read');
+      },
+    };
+    expect(() => store.updateToast('a', { data })).not.toThrow();
+    expect(selectors.toast(store.state, 'a')?.data).toEqual({ name: 'Draft' });
+
+    expect(() => store.updateToast('missing', { data })).not.toThrow();
+  });
+
   it('replaces null prototype custom data so the null prototype survives', () => {
     const store = createStore([
       { id: 'a', data: Object.assign(Object.create(null), { name: 'Draft' }) },

--- a/packages/react/src/toast/store.test.ts
+++ b/packages/react/src/toast/store.test.ts
@@ -210,30 +210,6 @@ describe('ToastStore', () => {
     }
   });
 
-  it('merges a data patch into plain object custom data from another realm', () => {
-    // A record built in another realm — an iframe — has that realm's `Object.prototype`,
-    // which is not this realm's. It is still a plain record, so it merges, and the merge
-    // must not swap its prototype for the local one.
-    const iframe = document.createElement('iframe');
-    document.body.appendChild(iframe);
-    try {
-      const ForeignObject = (iframe.contentWindow as Window & typeof globalThis).Object;
-      const foreignObjectPrototype = ForeignObject.prototype;
-      expect(foreignObjectPrototype).not.toBe(Object.prototype);
-
-      const store = createStore([
-        { id: 'a', data: Object.assign(new ForeignObject(), { name: 'Draft', count: 1 }) },
-      ]);
-
-      store.updateToast('a', { dataPatch: { count: 2 } });
-      const data = selectors.toast(store.state, 'a')?.data;
-      expect({ ...data }).toEqual({ name: 'Draft', count: 2 });
-      expect(Object.getPrototypeOf(data)).toBe(foreignObjectPrototype);
-    } finally {
-      iframe.remove();
-    }
-  });
-
   it('keeps an own __proto__ key in a data patch as an own key', () => {
     const store = createStore([{ id: 'a', data: { name: 'Draft' } }]);
 
@@ -249,30 +225,6 @@ describe('ToastStore', () => {
     // The merged value is still a plain object, so a later patch still merges.
     store.updateToast('a', { dataPatch: { count: 1 } });
     expect(selectors.toast(store.state, 'a')?.data).toMatchObject({ name: 'Draft', count: 1 });
-  });
-
-  it('defines patched custom data as own properties instead of calling inherited setters', () => {
-    // The setter lives on another realm's `Object.prototype`, so it is inherited by a plain
-    // record from that realm without leaking into this realm's objects.
-    const iframe = document.createElement('iframe');
-    document.body.appendChild(iframe);
-    try {
-      const ForeignObject = (iframe.contentWindow as Window & typeof globalThis).Object;
-      const setter = vi.fn();
-      Object.defineProperty(ForeignObject.prototype, 'count', { set: setter, configurable: true });
-      const store = createStore([
-        { id: 'a', data: Object.assign(new ForeignObject(), { name: 'Draft' }) },
-      ]);
-
-      store.updateToast('a', { dataPatch: { count: 2 } });
-      const data = selectors.toast(store.state, 'a')?.data;
-      expect(setter).not.toHaveBeenCalled();
-      expect(Object.hasOwn(data, 'count')).toBe(true);
-      expect({ ...data }).toEqual({ name: 'Draft', count: 2 });
-      expect(Object.getPrototypeOf(data)).toBe(ForeignObject.prototype);
-    } finally {
-      iframe.remove();
-    }
   });
 
   it('does not read a data patch when updating a missing or ending toast', () => {
@@ -323,7 +275,11 @@ describe('ToastStore', () => {
 
       // A loading toast is brand new, so it has no data for a patch to merge into.
       await store.promiseToast(Promise.resolve('done'), {
-        loading: { title: 'Saving', dataPatch: { progress: 0 } },
+        loading: {
+          title: 'Saving',
+          // @ts-expect-error - the `loading` type omits `dataPatch`; a JavaScript caller can still pass one
+          dataPatch: { progress: 0 },
+        },
         success: 'Saved',
         error: 'Failed',
       });

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -45,17 +45,33 @@ type ToastMetadata = {
 
 type InitialState = Omit<State, 'toastMetadata'>;
 
+const nativeObjectSource = Function.prototype.toString.call(Object);
+
 // Whether `value` is a record that can be copied key by key without losing anything, which
-// is true when its prototype is one hop from `null`. That accepts object literals from any
-// realm, so a record built inside an iframe still merges, and rejects the values a copy
-// would silently reshape: arrays, `Map`, `Set`, `Date`, class instances, and
-// `Object.create(null)` dictionaries, whose null prototype is the point of them.
+// is true when its prototype is some realm's `Object.prototype`. That accepts object
+// literals built inside an iframe, and rejects the values a copy would silently reshape:
+// arrays, `Map`, `Set`, `Date`, class instances (even those whose prototype chain ends
+// right after the class, so "one hop from `null`" is not enough), and `Object.create(null)`
+// dictionaries, whose null prototype is the point of them.
 function isPlainObject(value: unknown): value is object {
   if (value === null || typeof value !== 'object') {
     return false;
   }
   const proto = Object.getPrototypeOf(value);
-  return proto !== null && Object.getPrototypeOf(proto) === null;
+  if (proto === null) {
+    return false;
+  }
+  if (proto === Object.prototype) {
+    return true;
+  }
+  // Another realm's `Object.prototype` is recognized through its own `constructor`: that
+  // realm's native `Object`, whose prototype is `proto` itself.
+  const Ctor = Object.hasOwn(proto, 'constructor') ? proto.constructor : undefined;
+  return (
+    typeof Ctor === 'function' &&
+    Ctor.prototype === proto &&
+    Function.prototype.toString.call(Ctor) === nativeObjectSource
+  );
 }
 
 // Copies `updates` over `prev` while keeping `prev`'s prototype, which an object literal

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -2,6 +2,7 @@ import { ReactStore } from '@base-ui/utils/store';
 import { generateId } from '@base-ui/utils/generateId';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { Timeout } from '@base-ui/utils/useTimeout';
+import { warn } from '@base-ui/utils/warn';
 import {
   ToastManagerAddOptions,
   ToastManagerPromiseOptions,
@@ -13,10 +14,8 @@ import { activeElement, contains, getTarget } from '../floating-ui-react/utils';
 import { isFocusVisible } from './utils/focusVisible';
 
 type ToastInternalUpdateOptions<Data extends object> = Partial<
-  Omit<ToastObject<Data>, 'id' | 'updateKey' | 'data'>
-> & {
-  data?: Partial<Data> | undefined;
-};
+  Omit<ToastObject<Data>, 'id' | 'updateKey'>
+>;
 
 /**
  * A toast once it lives in the store. `addToast` is the only way in and it always
@@ -47,7 +46,7 @@ type InitialState = Omit<State, 'toastMetadata'>;
 
 const nativeObjectSource = Function.prototype.toString.call(Object);
 
-// Whether `value` is a record that can be copied key by key without losing anything, which
+// Whether `value` is a record that can be patched key by key without losing anything, which
 // is true when its prototype is some realm's `Object.prototype`. That accepts object
 // literals built inside an iframe, and rejects the values a copy would silently reshape:
 // arrays, `Map`, `Set`, `Date`, class instances (even those whose prototype chain ends
@@ -74,17 +73,45 @@ function isPlainObject(value: unknown): value is object {
   );
 }
 
-// Copies `updates` over `prev` while keeping `prev`'s prototype, which an object literal
+// Copies `patch` over `prev` while keeping `prev`'s prototype, which an object literal
 // would replace with this realm's `Object.prototype`. Spread defines own data properties,
 // unlike `Object.assign`, which writes through inherited setters, so an own `__proto__`
 // key (as `JSON.parse` produces) stays an own key instead of swapping the prototype.
-function mergeData<Data extends object>(prev: Data, updates: Partial<Data>): Data {
-  const merged = { ...prev, ...updates };
+function mergeData<Data extends object>(prev: Data, patch: Partial<Data>): Data {
+  const merged = { ...prev, ...patch };
   const prevPrototype = Object.getPrototypeOf(prev);
   if (prevPrototype !== Object.prototype) {
     Object.setPrototypeOf(merged, prevPrototype);
   }
   return merged;
+}
+
+// Folds `dataPatch` into `data`, patching the `data` given alongside it when there is one
+// and the toast's current data otherwise. Only a plain object can be patched by a plain
+// object: `Data` is unconstrained, so it may hold an array, a `Map`, or a class instance,
+// and copying those key by key would strip their prototype and silently produce a plain
+// object. Such a patch is dropped instead, with a warning in development.
+function resolveDataPatch<Data extends object>(
+  prevData: Data | undefined,
+  updates: ToastManagerUpdateOptions<Data>,
+): Omit<ToastManagerUpdateOptions<Data>, 'dataPatch'> {
+  const { dataPatch, ...rest } = updates;
+  if (dataPatch === undefined) {
+    return rest;
+  }
+
+  const base = Object.hasOwn(rest, 'data') ? rest.data : prevData;
+  if (isPlainObject(base) && isPlainObject(dataPatch)) {
+    return { ...rest, data: mergeData(base, dataPatch) };
+  }
+
+  warn(
+    'The `dataPatch` option was ignored because it can only be shallow merged into custom data ' +
+      'that is a plain object, and the toast either has no data or its data is not a plain ' +
+      'object (an array, a `Map`, a class instance, etc.). ' +
+      'Pass `data` to replace the value instead.',
+  );
+  return rest;
 }
 
 function createToastMetadata(toasts: StoredToast[]) {
@@ -248,29 +275,19 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     return id;
   };
 
-  // The only entry point whose `data` is a patch rather than a complete value, so the only
-  // one that merges. `updateToastInternal` always replaces, which keeps a future internal
+  // The only entry point that accepts `dataPatch`, so the only one that merges. `data`
+  // always replaces, here and in `updateToastInternal`, which keeps a future internal
   // caller from silently patching a value it meant to overwrite.
   updateToast = <Data extends object>(id: string, updates: ToastManagerUpdateOptions<Data>) => {
     const prevToast = selectors.toast(this.state, id);
-    // `updateToastInternal` ignores these too, but bail out before touching `data` so an
+    // `updateToastInternal` ignores these too, but bail out before touching the data so an
     // ignored update (a promise settling after its toast was dismissed, say) never reads
     // the caller's getters or proxies.
     if (!prevToast || prevToast.transitionStatus === 'ending') {
       return;
     }
 
-    const prevData = prevToast.data;
-    // Only a plain object can be patched by a plain object. `Data` is unconstrained, so
-    // `data` may hold an array, a `Map`, or a class instance, and copying those key by key
-    // would strip their prototype and silently produce a plain object. Every other
-    // combination is passed through untouched and replaces `data` wholesale.
-    const merged =
-      isPlainObject(updates.data) && isPlainObject(prevData)
-        ? { ...updates, data: mergeData(prevData, updates.data) }
-        : updates;
-
-    this.updateToastInternal(id, merged, false, true);
+    this.updateToastInternal(id, resolveDataPatch(prevToast.data, updates), false, true);
   };
 
   updateToastInternal = <Data extends object>(
@@ -372,8 +389,9 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     promiseValue: Promise<Value>,
     options: ToastManagerPromiseOptions<Value, Data>,
   ): Promise<Value> => {
-    // Create a loading toast (which does not auto-dismiss).
-    const loadingOptions = resolvePromiseOptions(options.loading);
+    // Create a loading toast (which does not auto-dismiss). It is new, so it has no data
+    // for a `dataPatch` to merge into.
+    const loadingOptions = resolveDataPatch(undefined, resolvePromiseOptions(options.loading));
     const id = this.addToast({
       ...loadingOptions,
       type: 'loading',

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -44,46 +44,15 @@ type ToastMetadata = {
 
 type InitialState = Omit<State, 'toastMetadata'>;
 
-const nativeObjectSource = Function.prototype.toString.call(Object);
-
-// Whether `value` is a record that can be patched key by key without losing anything, which
-// is true when its prototype is some realm's `Object.prototype`. That accepts object
-// literals built inside an iframe, and rejects the values a copy would silently reshape:
-// arrays, `Map`, `Set`, `Date`, class instances (even those whose prototype chain ends
-// right after the class, so "one hop from `null`" is not enough), and `Object.create(null)`
-// dictionaries, whose null prototype is the point of them.
+// Whether `value` is a record that can be patched key by key without losing anything: an
+// object whose prototype is `Object.prototype`. That rejects the values a copy would
+// silently reshape (arrays, `Map`, `Set`, `Date`, class instances) and `Object.create(null)`
+// dictionaries, whose null prototype is the point of them. A record from another realm is
+// rejected as well: recognizing it would cost more bytes than the case is worth.
 function isPlainObject(value: unknown): value is object {
-  if (value === null || typeof value !== 'object') {
-    return false;
-  }
-  const proto = Object.getPrototypeOf(value);
-  if (proto === null) {
-    return false;
-  }
-  if (proto === Object.prototype) {
-    return true;
-  }
-  // Another realm's `Object.prototype` is recognized through its own `constructor`: that
-  // realm's native `Object`, whose prototype is `proto` itself.
-  const Ctor = Object.hasOwn(proto, 'constructor') ? proto.constructor : undefined;
   return (
-    typeof Ctor === 'function' &&
-    Ctor.prototype === proto &&
-    Function.prototype.toString.call(Ctor) === nativeObjectSource
+    value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype
   );
-}
-
-// Copies `patch` over `prev` while keeping `prev`'s prototype, which an object literal
-// would replace with this realm's `Object.prototype`. Spread defines own data properties,
-// unlike `Object.assign`, which writes through inherited setters, so an own `__proto__`
-// key (as `JSON.parse` produces) stays an own key instead of swapping the prototype.
-function mergeData<Data extends object>(prev: Data, patch: Partial<Data>): Data {
-  const merged = { ...prev, ...patch };
-  const prevPrototype = Object.getPrototypeOf(prev);
-  if (prevPrototype !== Object.prototype) {
-    Object.setPrototypeOf(merged, prevPrototype);
-  }
-  return merged;
 }
 
 // Folds `dataPatch` into `data`, patching the `data` given alongside it when there is one
@@ -102,14 +71,17 @@ function resolveDataPatch<Data extends object>(
 
   const base = Object.hasOwn(rest, 'data') ? rest.data : prevData;
   if (isPlainObject(base) && isPlainObject(dataPatch)) {
-    return { ...rest, data: mergeData(base, dataPatch) };
+    // Spread defines own data properties, unlike `Object.assign`, which writes through
+    // inherited setters, so an own `__proto__` key (as `JSON.parse` produces) stays an own
+    // key instead of swapping the prototype.
+    return { ...rest, data: { ...base, ...dataPatch } };
   }
 
   warn(
-    'The `dataPatch` option was ignored because it can only be shallow merged into custom data ' +
-      'that is a plain object, and the toast either has no data or its data is not a plain ' +
-      'object (an array, a `Map`, a class instance, etc.). ' +
-      'Pass `data` to replace the value instead.',
+    'The `dataPatch` option was ignored because it can only shallow merge a plain object into ' +
+      'custom data that is a plain object: the toast has no data, its data is not a plain ' +
+      'object (an array, a `Map`, a class instance, an object with a `null` prototype, etc.), ' +
+      'or the patch itself is not one. Pass `data` to replace the value instead.',
   );
   return rest;
 }
@@ -275,9 +247,9 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     return id;
   };
 
-  // The only entry point that accepts `dataPatch`, so the only one that merges. `data`
-  // always replaces, here and in `updateToastInternal`, which keeps a future internal
-  // caller from silently patching a value it meant to overwrite.
+  // `data` always replaces, here and in `updateToastInternal`; only `resolveDataPatch`
+  // merges, which keeps a future internal caller from silently patching a value it meant
+  // to overwrite.
   updateToast = <Data extends object>(id: string, updates: ToastManagerUpdateOptions<Data>) => {
     const prevToast = selectors.toast(this.state, id);
     // `updateToastInternal` ignores these too, but bail out before touching the data so an
@@ -389,8 +361,10 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     promiseValue: Promise<Value>,
     options: ToastManagerPromiseOptions<Value, Data>,
   ): Promise<Value> => {
-    // Create a loading toast (which does not auto-dismiss). It is new, so it has no data
-    // for a `dataPatch` to merge into.
+    // Create a loading toast (which does not auto-dismiss). The `loading` type omits
+    // `dataPatch` because the toast is new, but one passed from JavaScript is still resolved
+    // here so it never lands on the toast: it merges into `data` given alongside it or is
+    // dropped with a warning.
     const loadingOptions = resolveDataPatch(undefined, resolvePromiseOptions(options.loading));
     const id = this.addToast({
       ...loadingOptions,

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -2,7 +2,6 @@ import { ReactStore } from '@base-ui/utils/store';
 import { generateId } from '@base-ui/utils/generateId';
 import { ownerDocument } from '@base-ui/utils/owner';
 import { Timeout } from '@base-ui/utils/useTimeout';
-import { warn } from '@base-ui/utils/warn';
 import {
   ToastManagerAddOptions,
   ToastManagerPromiseOptions,
@@ -14,8 +13,9 @@ import { activeElement, contains, getTarget } from '../floating-ui-react/utils';
 import { isFocusVisible } from './utils/focusVisible';
 
 type ToastInternalUpdateOptions<Data extends object> = Partial<
-  Omit<ToastObject<Data>, 'id' | 'updateKey'>
->;
+  Omit<ToastObject<Data>, 'id' | 'updateKey' | 'data'>
+> &
+  Pick<ToastManagerUpdateOptions<Data>, 'data'>;
 
 /**
  * A toast once it lives in the store. `addToast` is the only way in and it always
@@ -44,14 +44,11 @@ type ToastMetadata = {
 
 type InitialState = Omit<State, 'toastMetadata'>;
 
-// Whether `value` is a record that can be patched key by key without losing anything: an
-// object whose prototype is `Object.prototype`. That rejects the values a copy would
-// silently reshape (arrays, `Map`, `Set`, `Date`, class instances) and `Object.create(null)`
-// dictionaries, whose null prototype is the point of them. A record from another realm is
-// rejected as well: recognizing it would cost more bytes than the case is worth.
-function isPlainObject(value: unknown): value is object {
-  // Primitives resolve to their own prototype, so only `null` and `undefined` need guarding.
-  return value != null && Object.getPrototypeOf(value) === Object.prototype;
+function resolveData<Data extends object>(
+  data: ToastManagerUpdateOptions<Data>['data'],
+  prevData: Data | undefined,
+): Data | undefined {
+  return typeof data === 'function' ? data(prevData) : data;
 }
 
 function createToastMetadata(toasts: StoredToast[]) {
@@ -185,8 +182,6 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
           this.removeToast(toast.id, true);
         } else {
           const { id: ignoredId, transitionStatus: ignoredTransitionStatus, ...updates } = toast;
-          // `ToastManagerAddOptions.data` is a complete `Data`, not a patch, so re-adding
-          // a toast under an existing id replaces its data rather than merging into it.
           this.updateToastInternal(toast.id, updates, true, true);
           return toast.id;
         }
@@ -215,43 +210,8 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     return id;
   };
 
-  // `data` always replaces, here and in `updateToastInternal`; only `dataPatch` merges, and
-  // only here, which keeps a future internal caller from silently patching a value it meant
-  // to overwrite.
   updateToast = <Data extends object>(id: string, updates: ToastManagerUpdateOptions<Data>) => {
-    const prevToast = selectors.toast(this.state, id);
-    // `updateToastInternal` ignores these too, but bail out before touching the data so an
-    // ignored update (a promise settling after its toast was dismissed, say) never reads
-    // the caller's getters or proxies.
-    if (!prevToast || prevToast.transitionStatus === 'ending') {
-      return;
-    }
-
-    const { dataPatch, ...rest } = updates;
-    if (dataPatch !== undefined) {
-      // The patch goes over the `data` given alongside it when there is one and over the
-      // toast's current data otherwise. Only a plain object can be patched by a plain object:
-      // `Data` is unconstrained, so it may hold an array, a `Map`, or a class instance, and
-      // copying those key by key would strip their prototype and silently produce a plain
-      // object. Such a patch is dropped instead, with a warning in development.
-      const base: Data | undefined = 'data' in rest ? rest.data : prevToast.data;
-      if (isPlainObject(base) && isPlainObject(dataPatch)) {
-        // Spread defines own data properties, unlike `Object.assign`, which writes through
-        // inherited setters, so an own `__proto__` key (as `JSON.parse` produces) stays an
-        // own key instead of swapping the prototype.
-        rest.data = { ...base, ...dataPatch };
-      } else if (process.env.NODE_ENV !== 'production') {
-        // The guard lets production bundles drop the message and, with it, the whole logger.
-        warn(
-          'The `dataPatch` option was ignored because it can only shallow merge a plain object into ' +
-            'custom data that is a plain object: the toast has no data, its data is not a plain ' +
-            'object (an array, a `Map`, a class instance, an object with a `null` prototype, etc.), ' +
-            'or the patch itself is not one. Pass `data` to replace the value instead.',
-        );
-      }
-    }
-
-    this.updateToastInternal(id, rest, false, true);
+    this.updateToastInternal(id, updates, false, true);
   };
 
   updateToastInternal = <Data extends object>(
@@ -276,6 +236,10 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     const nextToast: StoredToast<Data> = {
       ...prevToast,
       ...updates,
+      // An explicit `data: undefined` clears the value, while omitting the key keeps it.
+      data: Object.hasOwn(updates, 'data')
+        ? resolveData(updates.data, prevToast.data)
+        : prevToast.data,
       ...(markUpdated && {
         updateKey: prevToast.updateKey + 1,
       }),
@@ -357,6 +321,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     const loadingOptions = resolvePromiseOptions(options.loading);
     const id = this.addToast({
       ...loadingOptions,
+      data: resolveData(loadingOptions.data, undefined),
       type: 'loading',
     });
 

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -13,9 +13,8 @@ import { activeElement, contains, getTarget } from '../floating-ui-react/utils';
 import { isFocusVisible } from './utils/focusVisible';
 
 type ToastInternalUpdateOptions<Data extends object> = Partial<
-  Omit<ToastObject<Data>, 'id' | 'updateKey' | 'data'>
-> &
-  Pick<ToastManagerUpdateOptions<Data>, 'data'>;
+  Omit<ToastObject<Data>, 'id' | 'updateKey'>
+>;
 
 /**
  * A toast once it lives in the store. `addToast` is the only way in and it always
@@ -211,7 +210,19 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
   };
 
   updateToast = <Data extends object>(id: string, updates: ToastManagerUpdateOptions<Data>) => {
-    this.updateToastInternal(id, updates, false, true);
+    let resolved = updates;
+    if (typeof updates.data === 'function') {
+      const prevToast = selectors.toast(this.state, id);
+      // Never run the updater for an update the store is going to ignore.
+      if (!prevToast || prevToast.transitionStatus === 'ending') {
+        return;
+      }
+      resolved = { ...updates, data: updates.data(prevToast.data) };
+    }
+
+    // `data` is a plain value now, and the updater may have called back into the
+    // store, so the internal update reads the current state again.
+    this.updateToastInternal(id, resolved as ToastInternalUpdateOptions<Data>, false, true);
   };
 
   updateToastInternal = <Data extends object>(
@@ -236,10 +247,6 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     const nextToast: StoredToast<Data> = {
       ...prevToast,
       ...updates,
-      // An explicit `data: undefined` clears the value, while omitting the key keeps it.
-      data: Object.hasOwn(updates, 'data')
-        ? resolveData(updates.data, prevToast.data)
-        : prevToast.data,
       ...(markUpdated && {
         updateKey: prevToast.updateKey + 1,
       }),

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -77,12 +77,15 @@ function resolveDataPatch<Data extends object>(
     return { ...rest, data: { ...base, ...dataPatch } };
   }
 
-  warn(
-    'The `dataPatch` option was ignored because it can only shallow merge a plain object into ' +
-      'custom data that is a plain object: the toast has no data, its data is not a plain ' +
-      'object (an array, a `Map`, a class instance, an object with a `null` prototype, etc.), ' +
-      'or the patch itself is not one. Pass `data` to replace the value instead.',
-  );
+  // The guard lets production bundles drop the message and, with it, the whole logger.
+  if (process.env.NODE_ENV !== 'production') {
+    warn(
+      'The `dataPatch` option was ignored because it can only shallow merge a plain object into ' +
+        'custom data that is a plain object: the toast has no data, its data is not a plain ' +
+        'object (an array, a `Map`, a class instance, an object with a `null` prototype, etc.), ' +
+        'or the patch itself is not one. Pass `data` to replace the value instead.',
+    );
+  }
   return rest;
 }
 

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -210,7 +210,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
   };
 
   updateToast = <Data extends object>(id: string, updates: ToastManagerUpdateOptions<Data>) => {
-    let resolved = updates;
+    let resolved = updates as ToastInternalUpdateOptions<Data>;
     if (typeof updates.data === 'function') {
       const prevToast = selectors.toast(this.state, id);
       // Never run the updater for an update the store is going to ignore.
@@ -222,7 +222,7 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
 
     // `data` is a plain value now, and the updater may have called back into the
     // store, so the internal update reads the current state again.
-    this.updateToastInternal(id, resolved as ToastInternalUpdateOptions<Data>, false, true);
+    this.updateToastInternal(id, resolved, false, true);
   };
 
   updateToastInternal = <Data extends object>(

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -50,43 +50,8 @@ type InitialState = Omit<State, 'toastMetadata'>;
 // dictionaries, whose null prototype is the point of them. A record from another realm is
 // rejected as well: recognizing it would cost more bytes than the case is worth.
 function isPlainObject(value: unknown): value is object {
-  return (
-    value !== null && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype
-  );
-}
-
-// Folds `dataPatch` into `data`, patching the `data` given alongside it when there is one
-// and the toast's current data otherwise. Only a plain object can be patched by a plain
-// object: `Data` is unconstrained, so it may hold an array, a `Map`, or a class instance,
-// and copying those key by key would strip their prototype and silently produce a plain
-// object. Such a patch is dropped instead, with a warning in development.
-function resolveDataPatch<Data extends object>(
-  prevData: Data | undefined,
-  updates: ToastManagerUpdateOptions<Data>,
-): Omit<ToastManagerUpdateOptions<Data>, 'dataPatch'> {
-  const { dataPatch, ...rest } = updates;
-  if (dataPatch === undefined) {
-    return rest;
-  }
-
-  const base = Object.hasOwn(rest, 'data') ? rest.data : prevData;
-  if (isPlainObject(base) && isPlainObject(dataPatch)) {
-    // Spread defines own data properties, unlike `Object.assign`, which writes through
-    // inherited setters, so an own `__proto__` key (as `JSON.parse` produces) stays an own
-    // key instead of swapping the prototype.
-    return { ...rest, data: { ...base, ...dataPatch } };
-  }
-
-  // The guard lets production bundles drop the message and, with it, the whole logger.
-  if (process.env.NODE_ENV !== 'production') {
-    warn(
-      'The `dataPatch` option was ignored because it can only shallow merge a plain object into ' +
-        'custom data that is a plain object: the toast has no data, its data is not a plain ' +
-        'object (an array, a `Map`, a class instance, an object with a `null` prototype, etc.), ' +
-        'or the patch itself is not one. Pass `data` to replace the value instead.',
-    );
-  }
-  return rest;
+  // Primitives resolve to their own prototype, so only `null` and `undefined` need guarding.
+  return value != null && Object.getPrototypeOf(value) === Object.prototype;
 }
 
 function createToastMetadata(toasts: StoredToast[]) {
@@ -250,8 +215,8 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     return id;
   };
 
-  // `data` always replaces, here and in `updateToastInternal`; only `resolveDataPatch`
-  // merges, which keeps a future internal caller from silently patching a value it meant
+  // `data` always replaces, here and in `updateToastInternal`; only `dataPatch` merges, and
+  // only here, which keeps a future internal caller from silently patching a value it meant
   // to overwrite.
   updateToast = <Data extends object>(id: string, updates: ToastManagerUpdateOptions<Data>) => {
     const prevToast = selectors.toast(this.state, id);
@@ -262,7 +227,31 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
       return;
     }
 
-    this.updateToastInternal(id, resolveDataPatch(prevToast.data, updates), false, true);
+    const { dataPatch, ...rest } = updates;
+    if (dataPatch !== undefined) {
+      // The patch goes over the `data` given alongside it when there is one and over the
+      // toast's current data otherwise. Only a plain object can be patched by a plain object:
+      // `Data` is unconstrained, so it may hold an array, a `Map`, or a class instance, and
+      // copying those key by key would strip their prototype and silently produce a plain
+      // object. Such a patch is dropped instead, with a warning in development.
+      const base: Data | undefined = 'data' in rest ? rest.data : prevToast.data;
+      if (isPlainObject(base) && isPlainObject(dataPatch)) {
+        // Spread defines own data properties, unlike `Object.assign`, which writes through
+        // inherited setters, so an own `__proto__` key (as `JSON.parse` produces) stays an
+        // own key instead of swapping the prototype.
+        rest.data = { ...base, ...dataPatch };
+      } else if (process.env.NODE_ENV !== 'production') {
+        // The guard lets production bundles drop the message and, with it, the whole logger.
+        warn(
+          'The `dataPatch` option was ignored because it can only shallow merge a plain object into ' +
+            'custom data that is a plain object: the toast has no data, its data is not a plain ' +
+            'object (an array, a `Map`, a class instance, an object with a `null` prototype, etc.), ' +
+            'or the patch itself is not one. Pass `data` to replace the value instead.',
+        );
+      }
+    }
+
+    this.updateToastInternal(id, rest, false, true);
   };
 
   updateToastInternal = <Data extends object>(
@@ -364,11 +353,8 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     promiseValue: Promise<Value>,
     options: ToastManagerPromiseOptions<Value, Data>,
   ): Promise<Value> => {
-    // Create a loading toast (which does not auto-dismiss). The `loading` type omits
-    // `dataPatch` because the toast is new, but one passed from JavaScript is still resolved
-    // here so it never lands on the toast: it merges into `data` given alongside it or is
-    // dropped with a warning.
-    const loadingOptions = resolveDataPatch(undefined, resolvePromiseOptions(options.loading));
+    // Create a loading toast (which does not auto-dismiss).
+    const loadingOptions = resolvePromiseOptions(options.loading);
     const id = this.addToast({
       ...loadingOptions,
       type: 'loading',

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -59,9 +59,16 @@ function isPlainObject(value: unknown): value is object {
 }
 
 // Copies `updates` over `prev` while keeping `prev`'s prototype, which an object literal
-// would replace with this realm's `Object.prototype`.
+// would replace with this realm's `Object.prototype`. Spread defines own data properties,
+// unlike `Object.assign`, which writes through inherited setters, so an own `__proto__`
+// key (as `JSON.parse` produces) stays an own key instead of swapping the prototype.
 function mergeData<Data extends object>(prev: Data, updates: Partial<Data>): Data {
-  return Object.assign(Object.create(Object.getPrototypeOf(prev)), prev, updates);
+  const merged = { ...prev, ...updates };
+  const prevPrototype = Object.getPrototypeOf(prev);
+  if (prevPrototype !== Object.prototype) {
+    Object.setPrototypeOf(merged, prevPrototype);
+  }
+  return merged;
 }
 
 function createToastMetadata(toasts: StoredToast[]) {
@@ -229,7 +236,15 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
   // one that merges. `updateToastInternal` always replaces, which keeps a future internal
   // caller from silently patching a value it meant to overwrite.
   updateToast = <Data extends object>(id: string, updates: ToastManagerUpdateOptions<Data>) => {
-    const prevData = selectors.toast(this.state, id)?.data;
+    const prevToast = selectors.toast(this.state, id);
+    // `updateToastInternal` ignores these too, but bail out before touching `data` so an
+    // ignored update (a promise settling after its toast was dismissed, say) never reads
+    // the caller's getters or proxies.
+    if (!prevToast || prevToast.transitionStatus === 'ending') {
+      return;
+    }
+
+    const prevData = prevToast.data;
     // Only a plain object can be patched by a plain object. `Data` is unconstrained, so
     // `data` may hold an array, a `Map`, or a class instance, and copying those key by key
     // would strip their prototype and silently produce a plain object. Every other

--- a/packages/react/src/toast/store.ts
+++ b/packages/react/src/toast/store.ts
@@ -45,6 +45,25 @@ type ToastMetadata = {
 
 type InitialState = Omit<State, 'toastMetadata'>;
 
+// Whether `value` is a record that can be copied key by key without losing anything, which
+// is true when its prototype is one hop from `null`. That accepts object literals from any
+// realm, so a record built inside an iframe still merges, and rejects the values a copy
+// would silently reshape: arrays, `Map`, `Set`, `Date`, class instances, and
+// `Object.create(null)` dictionaries, whose null prototype is the point of them.
+function isPlainObject(value: unknown): value is object {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto !== null && Object.getPrototypeOf(proto) === null;
+}
+
+// Copies `updates` over `prev` while keeping `prev`'s prototype, which an object literal
+// would replace with this realm's `Object.prototype`.
+function mergeData<Data extends object>(prev: Data, updates: Partial<Data>): Data {
+  return Object.assign(Object.create(Object.getPrototypeOf(prev)), prev, updates);
+}
+
 function createToastMetadata(toasts: StoredToast[]) {
   const metadata = new Map<string, ToastMetadata>();
   let visibleIndex = 0;
@@ -176,6 +195,8 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
           this.removeToast(toast.id, true);
         } else {
           const { id: ignoredId, transitionStatus: ignoredTransitionStatus, ...updates } = toast;
+          // `ToastManagerAddOptions.data` is a complete `Data`, not a patch, so re-adding
+          // a toast under an existing id replaces its data rather than merging into it.
           this.updateToastInternal(toast.id, updates, true, true);
           return toast.id;
         }
@@ -204,8 +225,21 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     return id;
   };
 
+  // The only entry point whose `data` is a patch rather than a complete value, so the only
+  // one that merges. `updateToastInternal` always replaces, which keeps a future internal
+  // caller from silently patching a value it meant to overwrite.
   updateToast = <Data extends object>(id: string, updates: ToastManagerUpdateOptions<Data>) => {
-    this.updateToastInternal(id, updates, false, true);
+    const prevData = selectors.toast(this.state, id)?.data;
+    // Only a plain object can be patched by a plain object. `Data` is unconstrained, so
+    // `data` may hold an array, a `Map`, or a class instance, and copying those key by key
+    // would strip their prototype and silently produce a plain object. Every other
+    // combination is passed through untouched and replaces `data` wholesale.
+    const merged =
+      isPlainObject(updates.data) && isPlainObject(prevData)
+        ? { ...updates, data: mergeData(prevData, updates.data) }
+        : updates;
+
+    this.updateToastInternal(id, merged, false, true);
   };
 
   updateToastInternal = <Data extends object>(
@@ -230,9 +264,6 @@ export class ToastStore extends ReactStore<State, {}, typeof selectors> {
     const nextToast: StoredToast<Data> = {
       ...prevToast,
       ...updates,
-      ...(updates.data && {
-        data: { ...prevToast.data, ...updates.data },
-      }),
       ...(markUpdated && {
         updateKey: prevToast.updateKey + 1,
       }),

--- a/packages/react/src/toast/useToastManager.spec.tsx
+++ b/packages/react/src/toast/useToastManager.spec.tsx
@@ -115,3 +115,33 @@ legacyManager.promise<number, ToastPayload>(Promise.resolve(5), {
   }),
   error: 'error',
 });
+
+type CallableData = () => string;
+const callableManager = useToastManager<CallableData>();
+
+callableManager.add({ data: () => 'initial' });
+
+callableManager.update('callable', {
+  // @ts-expect-error - a function is always an updater, so a callable value must be wrapped
+  data: () => 'replacement',
+});
+
+callableManager.update('callable', {
+  data: () => () => 'replacement',
+});
+
+callableManager.update('callable', {
+  data: (prevData) => {
+    expectType<CallableData | undefined, typeof prevData>(prevData);
+    return prevData;
+  },
+});
+
+callableManager.promise(Promise.resolve(1), {
+  loading: {
+    // @ts-expect-error - a function is always an updater, so a callable value must be wrapped
+    data: () => 'loading',
+  },
+  success: { data: () => () => 'done' },
+  error: 'failed',
+});

--- a/packages/react/src/toast/useToastManager.spec.tsx
+++ b/packages/react/src/toast/useToastManager.spec.tsx
@@ -38,6 +38,12 @@ typedManager.add({
   },
 });
 
+typedManager.add({
+  title: 'updater',
+  // @ts-expect-error - add takes a value, not an updater function
+  data: () => ({ id: 'typed', count: 1 }),
+});
+
 typedManager.update('typed', {
   data: {
     id: 'typed-update',

--- a/packages/react/src/toast/useToastManager.spec.tsx
+++ b/packages/react/src/toast/useToastManager.spec.tsx
@@ -46,8 +46,22 @@ typedManager.update('typed', {
 });
 
 typedManager.update('typed', {
+  // @ts-expect-error - id is a missing property, `data` replaces the whole value
   data: {
     count: 2,
+  },
+});
+
+typedManager.update('typed', {
+  dataPatch: {
+    count: 2,
+  },
+});
+
+typedManager.update('typed', {
+  dataPatch: {
+    // @ts-expect-error - message is not a valid property
+    message: 'not a number',
   },
 });
 
@@ -77,6 +91,12 @@ expectType<string, typeof legacyAddId>(legacyAddId);
 legacyManager.update<ToastPayload>('legacy', {
   data: {
     id: 'legacy-update',
+    count: 4,
+  },
+});
+
+legacyManager.update<ToastPayload>('legacy', {
+  dataPatch: {
     count: 4,
   },
 });

--- a/packages/react/src/toast/useToastManager.spec.tsx
+++ b/packages/react/src/toast/useToastManager.spec.tsx
@@ -53,16 +53,15 @@ typedManager.update('typed', {
 });
 
 typedManager.update('typed', {
-  dataPatch: {
-    count: 2,
+  data: (prevData) => {
+    expectType<ToastPayload | undefined, typeof prevData>(prevData);
+    return { id: 'typed-update', count: 2 };
   },
 });
 
 typedManager.update('typed', {
-  dataPatch: {
-    // @ts-expect-error - message is not a valid property
-    message: 'not a number',
-  },
+  // @ts-expect-error - count is a missing property, the updater returns the whole value
+  data: () => ({ id: 'typed-update' }),
 });
 
 typedManager.promise(Promise.resolve(2), {
@@ -74,16 +73,6 @@ typedManager.promise(Promise.resolve(2), {
       count: value,
     },
   }),
-  error: 'error',
-});
-
-typedManager.promise(Promise.resolve(2), {
-  loading: {
-    title: 'loading',
-    // @ts-expect-error - dataPatch cannot merge into a new loading toast
-    dataPatch: { count: 1 },
-  },
-  success: 'success',
   error: 'error',
 });
 
@@ -106,9 +95,7 @@ legacyManager.update<ToastPayload>('legacy', {
 });
 
 legacyManager.update<ToastPayload>('legacy', {
-  dataPatch: {
-    count: 4,
-  },
+  data: (prevData) => ({ id: 'legacy', count: (prevData?.count ?? 0) + 1 }),
 });
 
 legacyManager.promise<number, ToastPayload>(Promise.resolve(5), {

--- a/packages/react/src/toast/useToastManager.spec.tsx
+++ b/packages/react/src/toast/useToastManager.spec.tsx
@@ -77,6 +77,16 @@ typedManager.promise(Promise.resolve(2), {
   error: 'error',
 });
 
+typedManager.promise(Promise.resolve(2), {
+  loading: {
+    title: 'loading',
+    // @ts-expect-error - dataPatch cannot merge into a new loading toast
+    dataPatch: { count: 1 },
+  },
+  success: 'success',
+  error: 'error',
+});
+
 const legacyManager = useToastManager();
 
 const legacyAddId = legacyManager.add<ToastPayload>({

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -136,9 +136,11 @@ export interface ToastManagerUpdateOptions<Data extends object> extends Partial<
 > {
   /**
    * Custom data for the toast.
-   * Replaces the stored value. Pass a function to derive the next value from the current one.
+   * Replaces the stored value. Pass a function to derive the next value from the
+   * current one; it receives `undefined` when the toast has no data yet and may
+   * return `undefined` to clear the value.
    */
-  data?: Data | ((prevData: Data | undefined) => Data) | undefined;
+  data?: Data | ((prevData: Data | undefined) => Data | undefined) | undefined;
 }
 
 export interface ToastManagerPromiseOptions<Value, Data extends object> {

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -129,20 +129,33 @@ export interface ToastManagerAddOptions<Data extends object> extends Omit<
 }
 
 export interface ToastManagerUpdateOptions<Data extends object> extends Partial<
-  Omit<ToastObject<Data>, 'id' | 'ref' | 'height' | 'transitionStatus' | 'limited' | 'updateKey'>
+  Omit<
+    ToastObject<Data>,
+    'id' | 'ref' | 'height' | 'transitionStatus' | 'limited' | 'updateKey' | 'data'
+  >
 > {
   /**
+   * Custom data for the toast.
+   * Replaces the stored value. Use `dataPatch` to shallow merge into it instead.
+   */
+  data?: Data | undefined;
+  /**
    * A partial value shallow merged into the toast's custom data.
-   * Only a plain object can be patched, so when the toast has no data yet, or its
-   * data is an array, a `Map`, a `Set`, a `Date`, or a class instance, the patch
-   * is ignored. Use `data` to replace the value instead. When both are given,
-   * `data` is stored first and the patch is merged into it.
+   * Both the stored data and the patch must be plain objects, so the patch is ignored
+   * when the toast has no data yet, or when either value is an array, a `Map`, a `Set`,
+   * a `Date`, a class instance, or an object with a `null` prototype.
+   * Use `data` to replace the value instead. When both are given, `data` is stored
+   * first and the patch is merged into it.
    */
   dataPatch?: Partial<Data> | undefined;
 }
 
 export interface ToastManagerPromiseOptions<Value, Data extends object> {
-  loading: string | ToastManagerUpdateOptions<Data>;
+  /**
+   * Options for the toast while the promise is pending. It is a new toast, so
+   * `dataPatch` is not accepted; pass `data` instead.
+   */
+  loading: string | Omit<ToastManagerUpdateOptions<Data>, 'dataPatch'>;
   success:
     | string
     | ToastManagerUpdateOptions<Data>

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -136,26 +136,13 @@ export interface ToastManagerUpdateOptions<Data extends object> extends Partial<
 > {
   /**
    * Custom data for the toast.
-   * Replaces the stored value. Use `dataPatch` to shallow merge into it instead.
+   * Replaces the stored value. Pass a function to derive the next value from the current one.
    */
-  data?: Data | undefined;
-  /**
-   * A partial value shallow merged into the toast's custom data.
-   * Both the stored data and the patch must be plain objects, so the patch is ignored
-   * when the toast has no data yet, or when either value is an array, a `Map`, a `Set`,
-   * a `Date`, a class instance, or an object with a `null` prototype.
-   * Use `data` to replace the value instead. When both are given, `data` is stored
-   * first and the patch is merged into it.
-   */
-  dataPatch?: Partial<Data> | undefined;
+  data?: Data | ((prevData: Data | undefined) => Data) | undefined;
 }
 
 export interface ToastManagerPromiseOptions<Value, Data extends object> {
-  /**
-   * Options for the toast while the promise is pending. It is a new toast, so
-   * `dataPatch` is not accepted; pass `data` instead.
-   */
-  loading: string | Omit<ToastManagerUpdateOptions<Data>, 'dataPatch'>;
+  loading: string | ToastManagerUpdateOptions<Data>;
   success:
     | string
     | ToastManagerUpdateOptions<Data>

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -123,26 +123,22 @@ export interface ToastManagerAddOptions<Data extends object> extends Omit<
 > {
   /**
    * The unique identifier for the toast. Adding a toast with an existing ID
-   * updates it in place and refreshes its auto-dismiss timer. `data` given
-   * here replaces the existing data instead of being merged into it.
+   * updates it in place and refreshes its auto-dismiss timer.
    */
   id?: string | undefined;
 }
 
 export interface ToastManagerUpdateOptions<Data extends object> extends Partial<
-  Omit<
-    ToastObject<Data>,
-    'id' | 'ref' | 'height' | 'transitionStatus' | 'limited' | 'updateKey' | 'data'
-  >
+  Omit<ToastObject<Data>, 'id' | 'ref' | 'height' | 'transitionStatus' | 'limited' | 'updateKey'>
 > {
   /**
-   * Custom data for the toast.
-   * Shallow merged into the existing data only when the stored value and the
-   * given value are both plain objects. In every other case—arrays, `Map`,
-   * `Set`, `Date`, class instances, and a toast that has no data yet—the given
-   * value replaces the existing data. Passing `undefined` clears it.
+   * A partial value shallow merged into the toast's custom data.
+   * Only a plain object can be patched, so when the toast has no data yet, or its
+   * data is an array, a `Map`, a `Set`, a `Date`, or a class instance, the patch
+   * is ignored. Use `data` to replace the value instead. When both are given,
+   * `data` is stored first and the patch is merged into it.
    */
-  data?: Partial<Data> | undefined;
+  dataPatch?: Partial<Data> | undefined;
 }
 
 export interface ToastManagerPromiseOptions<Value, Data extends object> {

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -138,7 +138,8 @@ export interface ToastManagerUpdateOptions<Data extends object> extends Partial<
    * Custom data for the toast.
    * Replaces the stored value. Pass a function to derive the next value from the
    * current one; it receives `undefined` when the toast has no data yet and may
-   * return `undefined` to clear the value.
+   * return `undefined` to clear the value. A function is always called as an
+   * updater, never stored as the value.
    */
   data?: Data | ((prevData: Data | undefined) => Data | undefined) | undefined;
 }

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -123,7 +123,8 @@ export interface ToastManagerAddOptions<Data extends object> extends Omit<
 > {
   /**
    * The unique identifier for the toast. Adding a toast with an existing ID
-   * updates it in place and refreshes its auto-dismiss timer.
+   * updates it in place and refreshes its auto-dismiss timer. `data` given
+   * here replaces the existing data instead of being merged into it.
    */
   id?: string | undefined;
 }
@@ -136,6 +137,10 @@ export interface ToastManagerUpdateOptions<Data extends object> extends Partial<
 > {
   /**
    * Custom data for the toast.
+   * Shallow merged into the existing data only when the stored value and the
+   * given value are both plain objects. In every other case—arrays, `Map`,
+   * `Set`, `Date`, class instances, and a toast that has no data yet—the given
+   * value replaces the existing data. Passing `undefined` clears it.
    */
   data?: Partial<Data> | undefined;
 }

--- a/packages/react/src/toast/useToastManager.ts
+++ b/packages/react/src/toast/useToastManager.ts
@@ -139,9 +139,12 @@ export interface ToastManagerUpdateOptions<Data extends object> extends Partial<
    * Replaces the stored value. Pass a function to derive the next value from the
    * current one; it receives `undefined` when the toast has no data yet and may
    * return `undefined` to clear the value. A function is always called as an
-   * updater, never stored as the value.
+   * updater, never stored as the value; to store a function, return it from one.
    */
-  data?: Data | ((prevData: Data | undefined) => Data | undefined) | undefined;
+  data?:
+    | (Data extends (...args: any[]) => any ? never : Data)
+    | ((prevData: Data | undefined) => Data | undefined)
+    | undefined;
 }
 
 export interface ToastManagerPromiseOptions<Value, Data extends object> {


### PR DESCRIPTION
## The bug

`ToastStore.updateToastInternal` object-spread the toast's `data` on every update that carried one:

```js
...(updates.data && {
  data: { ...prevToast.data, ...updates.data },
}),
```

The public generic is `Data extends object = any`, so `data` legitimately holds arrays, `Map`/`Set`, and class instances — not just plain records. Spreading those silently converts them to plain objects, and for arrays it merges *index-wise*, so a shorter update leaves stale trailing elements behind.

| initial `data` | update | on `master` | with this PR |
| :--- | :--- | :--- | :--- |
| `['x', 'y']` | `['z']` | `{"0":"z","1":"y"}` — not an array, stale `'y'` survives | `['z']` |
| `new Model('a')` | `new Model('b')` | prototype lost, `greet()` gone | the instance, intact |
| `new Map([['k',1]])` | `new Map([['j',2]])` | `{}` — every entry lost | the `Map`, intact |

This is a regression against 1.7.0, where `...updates` replaced `data` wholesale. The merge came in with #5464 ("[toast] Support partial data updates"), which is unreleased.

The same commit also typed `ToastManagerUpdateOptions.data` as `Partial<Data>` while `ToastObject.data` stayed a complete `Data`. Any partial value — a fragment of a class instance, or a patch for a toast that has no data yet — type-checks, is stored as the whole value, and `toast.data.greet()` then throws even though the types say it is there.

A second instance of the merge regression sits on the `add` path: re-adding a toast under an existing id kept keys the caller had deliberately dropped, since `ToastManagerAddOptions.data` is a complete `Data`, not a patch.

## The fix

**`data` replaces; a function derives.** `ToastManagerUpdateOptions.data` is a complete `Data` again and always replaces — on `update`, on `promise` settlement, and on duplicate-id `add` alike, matching 1.7.0. A partial update is written as a function that receives the current value and returns the next one:

```js
update(id, { data: { status: 'ok' } });                              // replaces the whole value
update(id, { data: (prev) => prev && { ...prev, progress: 100 } });  // derives from the current value
```

The function receives `undefined` when the toast has no data yet and may return `undefined` to clear the value, mirroring `data: undefined`. Because the caller owns the merge, every `Data` shape works — arrays, `Map`s, class instances — with no plain-object detection, no development warning, and no logger in the bundle.

**Ignored updates never call the function.** `updateToast` resolves it only after checking that the toast exists and is not ending, so a promise settling after its toast was dismissed never runs it. The internal update then re-reads the store, so an updater that calls back into the manager (`add`, `close`, `update`) does not have its work overwritten. `promise` resolves a `loading` function against `undefined`, since that toast is new.

An earlier revision of this PR added a separate `dataPatch: Partial<Data>` option that shallow merged into plain-object data only; the function form of `data` replaces it.

JSDoc, the type specs for `useToastManager` and `createToastManager`, the `update` section of the docs page, and the regenerated `types.md` all reflect this.

## Tests

`packages/react/src/toast/store.test.ts`, passing in jsdom and Chromium:

- `data` replaces wholesale, `undefined` clears, and omitting it leaves the value alone
- a function derives the next value from the current one and bumps `updateKey`
- a function receives `undefined` when the toast has no data
- a function is not called for a missing or ending toast
- re-adding under an existing id replaces `data`
- `loading` and `success` functions on a promise toast resolve against the loading data

Type specs assert that an incomplete `data` is a type error, that the function receives `Data | undefined`, that an incomplete return is a type error, and that a callable `Data` is rejected as a direct value on `update` and `promise` while the wrapped `data: () => fn` form is accepted. Full toast suite in jsdom: 306 passed / 38 skipped.

## Bundle size

`@base-ui/react/toast` entry, esbuild in production mode with React external: 20666 gzipped bytes against 20635 at the merge base, +31. The PR as first submitted was +361.

## Breaking change?

`Partial<Data>` on `data` came in with #5464, which has not shipped, so reverting it is not a released change. Against 1.7.0, the only behavior change is that a function passed as `data` to `update`, or to the `loading`/`success`/`error` options of `promise`, is now called as an updater instead of stored; `add` still stores it as a value. This only affects a `Data` that is itself a function type. For that shape the types now reject a callable value on those paths, so the change surfaces as a compile error rather than at runtime: return the function from an updater (`data: () => fn`) to store it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



