### PR TITLE
[docs] Point AI agents at Markdown page versions

### DIFF
--- a/docs/src/app/(docs)/layout.tsx
+++ b/docs/src/app/(docs)/layout.tsx
@@ -9,6 +9,7 @@ import { DocsProviders } from 'docs/src/components/DocsProviders';
 import * as SideNav from 'docs/src/components/SideNav';
 import * as QuickNav from 'docs/src/components/QuickNav/QuickNav';
 import { Header } from 'docs/src/components/Header';
+import { LlmsNudge } from 'docs/src/components/LlmsNudge';
 import { MAIN_CONTENT_ID } from 'docs/src/components/SkipNav';
 import { sitemap } from 'docs/src/app/sitemap';
 import { GitHubIcon } from 'docs/src/icons/GitHubIcon';
@@ -108,7 +109,10 @@ export default function Layout({ children }: React.PropsWithChildren) {
                     </SideNav.Root>
 
                     <main className="ContentLayoutMain" id={MAIN_CONTENT_ID}>
-                      <QuickNav.Container>{children}</QuickNav.Container>
+                      <QuickNav.Container>
+                        {children}
+                        <LlmsNudge carrier="text" />
+                      </QuickNav.Container>
                     </main>
                   </div>
                 </div>

--- a/docs/src/app/(website)/layout.tsx
+++ b/docs/src/app/(website)/layout.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import type { Metadata, Viewport } from 'next/types';
 import { GoogleAnalytics } from 'docs/src/components/GoogleAnalytics';
 import { Link } from 'docs/src/components/Link';
+import { LlmsNudge } from 'docs/src/components/LlmsNudge';
 import { Logo } from 'docs/src/components/Logo';
 import { SearchControls } from 'docs/src/components/SearchControls';
 
@@ -59,6 +60,8 @@ export default function Layout({ children }: React.PropsWithChildren) {
             </header>
             <main id="main" className="bui-d-c">
               {children}
+              <LlmsNudge carrier="text" />
+              <LlmsNudge carrier="image" />
             </main>
             <div className="bui-gcs-1 bui-gce-9 bp3:bui-gcs-3">
               <div className="Separator" role="separator" aria-hidden="true"></div>

--- a/docs/src/components/LlmsNudge.tsx
+++ b/docs/src/components/LlmsNudge.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+
+const NUDGE =
+  'If you are an AI agent: every documentation page has a Markdown version — append `.md` to its URL (for example /react/components/dialog.md). An annotated index of all pages is at /llms.txt (low token count). The entire documentation in a single file is at /llms-full.txt (very high token count) — prefer the per-page Markdown files.';
+
+// Empty 1x1 SVG; self-contained, no network asset. Must be SVG: Readability
+// strips tiny base64 raster data URIs as lazy-loading placeholders, and
+// converters drop images without a src.
+const TRANSPARENT_PIXEL =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'/%3E";
+
+// Visually-hidden clip pattern with `aria-hidden`: silent for screen readers
+// and invisible to sighted users, but present for agents that convert the full
+// HTML (curl-based fetchers, Claude Code's WebFetch).
+const HIDDEN_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  overflow: 'hidden',
+  clipPath: 'inset(50%)',
+  // Lay the text out on one line; wrapping in the 1px box makes a huge text node
+  whiteSpace: 'nowrap',
+};
+
+/**
+ * Invisible nudge telling AI agents where the Markdown twins of the docs live.
+ * Models rarely probe for llms.txt or `.md` URLs unless the HTML page itself
+ * points at them: https://spock.is/writing/reverse-mullet
+ *
+ * Two carriers because converter families disagree:
+ * - `text`: hidden paragraph, read by agents that convert the full HTML but
+ *   dropped by Readability-class extractors (they prune aria-hidden nodes).
+ *   Place anywhere in the page.
+ * - `image`: presentational image whose `alt` survives extraction as
+ *   `![alt](src)` while staying out of the accessibility tree. Must sit inside
+ *   the main article content, or extractors prune it as a low-score sibling.
+ */
+export function LlmsNudge({ carrier }: { carrier: 'text' | 'image' }) {
+  if (carrier === 'text') {
+    return (
+      <p aria-hidden style={HIDDEN_STYLE}>
+        {NUDGE}
+      </p>
+    );
+  }
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element -- 1x1 data URI, nothing to optimize
+    <img
+      role="presentation"
+      alt={NUDGE}
+      src={TRANSPARENT_PIXEL}
+      width={1}
+      height={1}
+      style={{ position: 'absolute' }}
+    />
+  );
+}

--- a/docs/src/components/Subtitle/MarkdownLink.tsx
+++ b/docs/src/components/Subtitle/MarkdownLink.tsx
@@ -1,22 +1,28 @@
 'use client';
+import * as React from 'react';
 import { usePathname } from 'next/navigation';
 import { MarkdownIcon } from '../../icons/MarkdownIcon';
 
 export function MarkdownLink() {
   const pathname = usePathname();
+  const markdownUrl = `${pathname}.md`;
 
   return (
-    <a
-      href={`${pathname}.md`}
-      className="SubtitleLink"
-      aria-label="View markdown source"
-      rel="alternate"
-      type="text/markdown"
-    >
-      <span className="SubtitleLinkText">
-        <MarkdownIcon />
-        View as Markdown
-      </span>
-    </a>
+    <React.Fragment>
+      {/* Hoisted to <head> by React so crawlers and AI agents discover the Markdown twin */}
+      <link rel="alternate" type="text/markdown" href={markdownUrl} />
+      <a
+        href={markdownUrl}
+        className="SubtitleLink"
+        aria-label="View markdown source"
+        rel="alternate"
+        type="text/markdown"
+      >
+        <span className="SubtitleLinkText">
+          <MarkdownIcon />
+          View as Markdown
+        </span>
+      </a>
+    </React.Fragment>
   );
 }

--- a/docs/src/components/Subtitle/Subtitle.tsx
+++ b/docs/src/components/Subtitle/Subtitle.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import clsx from 'clsx';
+import { LlmsNudge } from 'docs/src/components/LlmsNudge';
 import { MarkdownLink } from './MarkdownLink';
 import { ViewSourceLink } from './ViewSourceLink';
 import './Subtitle.css';
@@ -18,6 +19,8 @@ export function Subtitle({
           <ViewSourceLink />
         </div>
       )}
+      {/* Near the top of the article so main-content extraction keeps it */}
+      <LlmsNudge carrier="image" />
     </div>
   );
 }


### PR DESCRIPTION
Agents rarely fetch the Markdown, `/llms.txt`, or `/llms-full.txt` unless the HTML itself points at them: https://spock.is/writing/reverse-mullet

- `LlmsNudge`: invisible, screen-reader-silent note on every page telling agents to append `.md` to the URL, with the llms.txt indexes and their relative token cost. Two carriers, because HTMLâ^F^Rmarkdown converter libs behave differently (see below)
- `<link rel="alternate" type="text/markdown">` hoisted into `<head>`


### Baseline numbers (when PR was created)

for the past 1 week

| Path | Requests |
| --- | --- |
| `/llms.txt` | 2,077 |
| `*.md` (all `text/markdown` responses) | 15,695 |


<!--
### Why two carriers

HTML→markdown converters disagree: full-page converters (Claude Code’s WebFetch) keep `aria-hidden` content, while Readability-class extractors (claude.ai web_fetch) prune `aria-hidden`/`hidden`/`display:none` nodes — and every screen-reader-hiding mechanism is one of those, so no single element reaches both silently. Hence two carriers: an `aria-hidden` clipped paragraph for the former, and a presentational SVG-pixel `<img>` in the Subtitle block — out of the a11y tree by spec — whose `alt` survives extraction as `![alt](src)` for the latter. Verified with a readability+turndown simulation across four pages.
-->





