### PR TITLE
[number field] Preserve consumer selection when focusing the input

### DIFF
--- a/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.test.tsx
@@ -2409,6 +2409,35 @@ describe('<NumberField />', () => {
       expect(screen.getByRole('textbox')).toHaveFocus();
     });
 
+    it('places the caret at the end of the visible input when forwarding focus', async () => {
+      await render(<NumberField defaultValue={100} />);
+
+      const input = screen.getByRole<HTMLInputElement>('textbox');
+      input.setSelectionRange(0, 0);
+
+      await act(async () => getHiddenInput().focus());
+
+      expect(input).toHaveFocus();
+      expect(input.selectionStart).toBe(input.value.length);
+      expect(input.selectionEnd).toBe(input.value.length);
+    });
+
+    it('keeps a selection the consumer sets in onFocus when forwarding focus', async () => {
+      await render(
+        <NumberFieldBase.Root defaultValue={100}>
+          <NumberFieldBase.Input onFocus={(event) => event.currentTarget.select()} />
+        </NumberFieldBase.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('textbox');
+
+      await act(async () => getHiddenInput().focus());
+
+      expect(input).toHaveFocus();
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe(input.value.length);
+    });
+
     it('clears the value when autofill empties the hidden input', async () => {
       const onValueChange = vi.fn();
       await render(<NumberField defaultValue={5} onValueChange={onValueChange} />);

--- a/packages/react/src/number-field/root/NumberFieldRoot.tsx
+++ b/packages/react/src/number-field/root/NumberFieldRoot.tsx
@@ -339,17 +339,17 @@ export const NumberFieldRoot = React.forwardRef(function NumberFieldRoot(
   );
 
   // Programmatic focus leaves the caret at the start (Chrome/Firefox) or selects the whole value
-  // (Safari). Place the caret at the end instead. The selection must be set after `focus()`
-  // returns, not in the focus handler: WebKit applies its own selection after dispatching the
-  // focus event. Keyboard and pointer focus keep the browser's native selection behavior.
+  // (Safari). Store the caret at the end before focusing: every engine restores the stored
+  // selection on `focus()`, and a selection the consumer sets in `onFocus` still wins. Keyboard
+  // and pointer focus keep the browser's native selection behavior.
   const focusInput = useStableCallback(() => {
     const input = inputRef.current;
     if (!input) {
       return;
     }
-    input.focus();
     const length = input.value.length;
     input.setSelectionRange(length, length);
+    input.focus();
   });
 
   // React attaches `onWheel` as a passive listener, so calling `preventDefault` there is ignored.

--- a/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.test.tsx
+++ b/packages/react/src/number-field/scrub-area/NumberFieldScrubArea.test.tsx
@@ -146,6 +146,27 @@ describe('<NumberField.ScrubArea />', () => {
 
       expect(root).not.toHaveAttribute('data-scrubbing');
     });
+
+    it('keeps a selection the consumer sets in onFocus when a mouse press focuses the input', async () => {
+      await render(
+        <NumberField.Root defaultValue={100}>
+          <NumberField.Input onFocus={(event) => event.currentTarget.select()} />
+          <NumberField.ScrubArea data-testid="scrub-area" />
+        </NumberField.Root>,
+      );
+
+      const input = screen.getByRole<HTMLInputElement>('textbox');
+
+      await act(async () => {
+        screen
+          .getByTestId('scrub-area')
+          .dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerType: 'mouse' }));
+      });
+
+      expect(input).toHaveFocus();
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe(input.value.length);
+    });
   });
 
   // Only run the following tests in Chromium/Firefox.


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

Follow-up to #5578. `focusInput()` (steppers, scrub area, hidden-input focus redirect) called `focus()` and then `setSelectionRange(end)`. A consumer `onFocus` runs synchronously inside `focus()`, so anything it did with the selection (for example `event.currentTarget.select()`) was overwritten right after.

## Changes

- Store the end caret with `setSelectionRange` before calling `focus()` and drop the post-focus write. Chromium, Firefox and WebKit all restore a stored selection on programmatic focus, none of them focus the input from `setSelectionRange`, and a selection set inside a focus listener sticks in all three. WebKit only selects the whole value when nothing was ever stored, which is what the post-focus write was working around.
- Regression tests on the hidden-input redirect and a scrub-area mouse press. The stepper buttons are not a useful test here: pressing one changes the value on pointerdown, and React's `input.value` assignment moves the caret to the end in every engine regardless of this code.
