### PR TITLE
[slider] Add steps and marks demos

### DIFF
--- a/docs/scripts/reportBrokenLinks.mts
+++ b/docs/scripts/reportBrokenLinks.mts
@@ -27,13 +27,8 @@ async function main() {
         },
       },
       {
-        // The Steps demo labels the slider with `<Slider.Label>`, which associates
-        // with the input via `aria-labelledby` only after hydration, so the static
-        // export contains an unlabeled `<input>`. This is a library-level SSR
-        // artifact, not something the docs can fix, so turn the rule off for this
-        // page rather than distort the canonical demo.
-        // TODO: Fix Slider to render the label association during SSR, then remove
-        // this override.
+        // `<Slider.Label>` associates with the input via `aria-labelledby` only
+        // after hydration, so the static export contains an unlabeled `<input>`.
         path: '/react/components/slider',
         config: {
           rules: {

--- a/docs/scripts/reportBrokenLinks.mts
+++ b/docs/scripts/reportBrokenLinks.mts
@@ -27,6 +27,21 @@ async function main() {
         },
       },
       {
+        // The Steps demo labels the slider with `<Slider.Label>`, which associates
+        // with the input via `aria-labelledby` only after hydration, so the static
+        // export contains an unlabeled `<input>`. This is a library-level SSR
+        // artifact, not something the docs can fix, so turn the rule off for this
+        // page rather than distort the canonical demo.
+        // TODO: Fix Slider to render the label association during SSR, then remove
+        // this override.
+        path: '/react/components/slider',
+        config: {
+          rules: {
+            'input-missing-label': 'off',
+          },
+        },
+      },
+      {
         // The Forms handbook page renders multiple Combobox demos. During SSR the
         // Combobox emits its `React.useId()`-based id on both the trigger and the
         // hidden input, so the static export momentarily contains duplicate ids —

--- a/docs/src/app/(docs)/react/components/page.mdx
+++ b/docs/src/app/(docs)/react/components/page.mdx
@@ -1636,9 +1636,11 @@ An easily stylable range input.
   - Usage guidelines
   - Anatomy
   - Examples
-    - Range slider
-    - Thumb alignment
     - Labeling a slider
+    - Range slider
+    - Steps
+    - Marks
+    - Thumb alignment
     - Vertical
     - Form integration
   - API reference

--- a/docs/src/app/(docs)/react/components/slider/demos/marks/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/slider/demos/marks/css-modules/index.module.css
@@ -81,7 +81,7 @@
 .MarkLabel {
   position: absolute;
   top: 0;
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   line-height: 1rem;
   color: oklch(43.9% 0 0deg);
   white-space: nowrap;

--- a/docs/src/app/(docs)/react/components/slider/demos/marks/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/slider/demos/marks/css-modules/index.module.css
@@ -1,0 +1,93 @@
+.Root {
+  width: 14rem;
+}
+
+.Control {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  padding-block: 0.625rem;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Track {
+  width: 100%;
+  height: 0.25rem;
+  background-color: oklch(92.2% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: oklch(26.9% 0 0deg);
+  }
+}
+
+.Indicator {
+  background-color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: white;
+  }
+}
+
+.Thumb {
+  box-sizing: border-box;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  -webkit-user-select: none;
+  user-select: none;
+
+  @media (prefers-color-scheme: dark) {
+    border: 1px solid white;
+    background-color: oklch(14.5% 0 0deg);
+  }
+
+  &:has(:focus-visible) {
+    outline: 2px solid oklch(14.5% 0 0deg);
+    outline-offset: 2px;
+
+    @media (prefers-color-scheme: dark) {
+      outline-color: white;
+    }
+  }
+}
+
+.Mark {
+  position: absolute;
+  top: 50%;
+  width: 1px;
+  height: 0.5rem;
+  background-color: oklch(14.5% 0 0deg);
+  transform: translate(-50%, -50%);
+
+  @media (prefers-color-scheme: dark) {
+    background-color: white;
+  }
+}
+
+.MarkLabels {
+  position: relative;
+  height: 1rem;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.MarkLabel {
+  position: absolute;
+  top: 0;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: oklch(43.9% 0 0deg);
+  white-space: nowrap;
+  transform: translateX(-50%);
+
+  @media (prefers-color-scheme: dark) {
+    color: oklch(70.8% 0 0deg);
+  }
+}

--- a/docs/src/app/(docs)/react/components/slider/demos/marks/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/slider/demos/marks/css-modules/index.module.css
@@ -81,7 +81,7 @@
 .MarkLabel {
   position: absolute;
   top: 0;
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   line-height: 1rem;
   color: oklch(43.9% 0 0deg);
   white-space: nowrap;

--- a/docs/src/app/(docs)/react/components/slider/demos/marks/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/marks/css-modules/index.tsx
@@ -1,0 +1,42 @@
+import { Slider } from '@base-ui/react/slider';
+import styles from './index.module.css';
+
+const MIN = 0;
+const MAX = 100;
+const MARKS = [0, 25, 50, 75, 100];
+
+export default function MarksSlider() {
+  return (
+    <Slider.Root className={styles.Root} defaultValue={40} min={MIN} max={MAX}>
+      <Slider.Control className={styles.Control}>
+        <Slider.Track className={styles.Track}>
+          <Slider.Indicator className={styles.Indicator} />
+          {MARKS.map((mark) => (
+            <div
+              key={mark}
+              aria-hidden
+              className={styles.Mark}
+              style={{ left: `${valueToPercent(mark)}%` }}
+            />
+          ))}
+          <Slider.Thumb aria-label="Volume" className={styles.Thumb} />
+        </Slider.Track>
+      </Slider.Control>
+      <div className={styles.MarkLabels} aria-hidden>
+        {MARKS.map((mark) => (
+          <span
+            key={mark}
+            className={styles.MarkLabel}
+            style={{ left: `${valueToPercent(mark)}%` }}
+          >
+            {mark}
+          </span>
+        ))}
+      </div>
+    </Slider.Root>
+  );
+}
+
+function valueToPercent(value: number) {
+  return ((value - MIN) / (MAX - MIN)) * 100;
+}

--- a/docs/src/app/(docs)/react/components/slider/demos/marks/index.ts
+++ b/docs/src/app/(docs)/react/components/slider/demos/marks/index.ts
@@ -1,0 +1,8 @@
+import { createDemoWithVariants } from 'docs/src/utils/createDemo';
+import CssModules from './css-modules';
+import Tailwind from './tailwind';
+
+export const DemoSliderMarks = createDemoWithVariants(import.meta.url, {
+  CssModules,
+  Tailwind,
+});

--- a/docs/src/app/(docs)/react/components/slider/demos/marks/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/marks/tailwind/index.tsx
@@ -28,7 +28,7 @@ export default function MarksSlider() {
         {MARKS.map((mark) => (
           <span
             key={mark}
-            className="absolute -translate-x-1/2 text-[0.6875rem] whitespace-nowrap text-neutral-600 dark:text-neutral-400"
+            className="absolute -translate-x-1/2 text-xs whitespace-nowrap text-neutral-600 dark:text-neutral-400"
             style={{ left: `${valueToPercent(mark)}%` }}
           >
             {mark}

--- a/docs/src/app/(docs)/react/components/slider/demos/marks/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/marks/tailwind/index.tsx
@@ -28,7 +28,7 @@ export default function MarksSlider() {
         {MARKS.map((mark) => (
           <span
             key={mark}
-            className="absolute -translate-x-1/2 text-xs whitespace-nowrap text-neutral-600 dark:text-neutral-400"
+            className="absolute -translate-x-1/2 text-[0.6875rem] whitespace-nowrap text-neutral-600 dark:text-neutral-400"
             style={{ left: `${valueToPercent(mark)}%` }}
           >
             {mark}

--- a/docs/src/app/(docs)/react/components/slider/demos/marks/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/marks/tailwind/index.tsx
@@ -1,0 +1,44 @@
+import { Slider } from '@base-ui/react/slider';
+
+const MIN = 0;
+const MAX = 100;
+const MARKS = [0, 25, 50, 75, 100];
+
+export default function MarksSlider() {
+  return (
+    <Slider.Root className="w-56" defaultValue={40} min={MIN} max={MAX}>
+      <Slider.Control className="flex touch-none items-center py-2.5 select-none">
+        <Slider.Track className="h-1 w-full bg-neutral-200 select-none dark:bg-neutral-800">
+          <Slider.Indicator className="bg-neutral-950 select-none dark:bg-white" />
+          {MARKS.map((mark) => (
+            <div
+              key={mark}
+              aria-hidden
+              className="absolute top-1/2 h-2 w-px -translate-x-1/2 -translate-y-1/2 bg-neutral-950 dark:bg-white"
+              style={{ left: `${valueToPercent(mark)}%` }}
+            />
+          ))}
+          <Slider.Thumb
+            aria-label="Volume"
+            className="size-4 border border-neutral-950 bg-white select-none has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-neutral-950 dark:has-[:focus-visible]:outline-white dark:border-white dark:bg-neutral-950"
+          />
+        </Slider.Track>
+      </Slider.Control>
+      <div className="relative h-4 select-none" aria-hidden>
+        {MARKS.map((mark) => (
+          <span
+            key={mark}
+            className="absolute -translate-x-1/2 text-xs whitespace-nowrap text-neutral-600 dark:text-neutral-400"
+            style={{ left: `${valueToPercent(mark)}%` }}
+          >
+            {mark}
+          </span>
+        ))}
+      </div>
+    </Slider.Root>
+  );
+}
+
+function valueToPercent(value: number) {
+  return ((value - MIN) / (MAX - MIN)) * 100;
+}

--- a/docs/src/app/(docs)/react/components/slider/demos/steps/css-modules/index.module.css
+++ b/docs/src/app/(docs)/react/components/slider/demos/steps/css-modules/index.module.css
@@ -1,0 +1,83 @@
+.Root {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  width: 14rem;
+}
+
+.Label {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(14.5% 0 0deg);
+
+  @media (prefers-color-scheme: dark) {
+    color: white;
+  }
+}
+
+.Value {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  text-align: end;
+  color: oklch(14.5% 0 0deg);
+
+  @media (prefers-color-scheme: dark) {
+    color: white;
+  }
+}
+
+.Control {
+  box-sizing: border-box;
+  display: flex;
+  grid-column: span 2;
+  align-items: center;
+  padding-block: 0.75rem;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Track {
+  width: 100%;
+  height: 0.25rem;
+  background-color: oklch(92.2% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: oklch(26.9% 0 0deg);
+  }
+}
+
+.Indicator {
+  background-color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: white;
+  }
+}
+
+.Thumb {
+  box-sizing: border-box;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  -webkit-user-select: none;
+  user-select: none;
+
+  @media (prefers-color-scheme: dark) {
+    border: 1px solid white;
+    background-color: oklch(14.5% 0 0deg);
+  }
+
+  &:has(:focus-visible) {
+    outline: 2px solid oklch(14.5% 0 0deg);
+    outline-offset: 2px;
+
+    @media (prefers-color-scheme: dark) {
+      outline-color: white;
+    }
+  }
+}

--- a/docs/src/app/(docs)/react/components/slider/demos/steps/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/steps/css-modules/index.tsx
@@ -16,7 +16,7 @@ export default function StepsSlider() {
       <Slider.Control className={styles.Control}>
         <Slider.Track className={styles.Track}>
           <Slider.Indicator className={styles.Indicator} />
-          <Slider.Thumb aria-label="Font weight" className={styles.Thumb} />
+          <Slider.Thumb className={styles.Thumb} />
         </Slider.Track>
       </Slider.Control>
     </Slider.Root>

--- a/docs/src/app/(docs)/react/components/slider/demos/steps/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/steps/css-modules/index.tsx
@@ -1,0 +1,24 @@
+import { Slider } from '@base-ui/react/slider';
+import styles from './index.module.css';
+
+export default function StepsSlider() {
+  return (
+    <Slider.Root
+      className={styles.Root}
+      defaultValue={400}
+      min={100}
+      max={900}
+      step={100}
+      largeStep={200}
+    >
+      <Slider.Label className={styles.Label}>Font weight</Slider.Label>
+      <Slider.Value className={styles.Value} />
+      <Slider.Control className={styles.Control}>
+        <Slider.Track className={styles.Track}>
+          <Slider.Indicator className={styles.Indicator} />
+          <Slider.Thumb className={styles.Thumb} />
+        </Slider.Track>
+      </Slider.Control>
+    </Slider.Root>
+  );
+}

--- a/docs/src/app/(docs)/react/components/slider/demos/steps/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/steps/css-modules/index.tsx
@@ -16,7 +16,7 @@ export default function StepsSlider() {
       <Slider.Control className={styles.Control}>
         <Slider.Track className={styles.Track}>
           <Slider.Indicator className={styles.Indicator} />
-          <Slider.Thumb className={styles.Thumb} />
+          <Slider.Thumb aria-label="Font weight" className={styles.Thumb} />
         </Slider.Track>
       </Slider.Control>
     </Slider.Root>

--- a/docs/src/app/(docs)/react/components/slider/demos/steps/index.ts
+++ b/docs/src/app/(docs)/react/components/slider/demos/steps/index.ts
@@ -1,0 +1,8 @@
+import { createDemoWithVariants } from 'docs/src/utils/createDemo';
+import CssModules from './css-modules';
+import Tailwind from './tailwind';
+
+export const DemoSliderSteps = createDemoWithVariants(import.meta.url, {
+  CssModules,
+  Tailwind,
+});

--- a/docs/src/app/(docs)/react/components/slider/demos/steps/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/steps/tailwind/index.tsx
@@ -17,10 +17,7 @@ export default function StepsSlider() {
       <Slider.Control className="col-span-2 flex touch-none items-center py-3 select-none">
         <Slider.Track className="h-1 w-full bg-neutral-200 select-none dark:bg-neutral-800">
           <Slider.Indicator className="bg-neutral-950 select-none dark:bg-white" />
-          <Slider.Thumb
-            aria-label="Font weight"
-            className="size-4 border border-neutral-950 bg-white select-none has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-neutral-950 dark:has-[:focus-visible]:outline-white dark:border-white dark:bg-neutral-950"
-          />
+          <Slider.Thumb className="size-4 border border-neutral-950 bg-white select-none has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-neutral-950 dark:has-[:focus-visible]:outline-white dark:border-white dark:bg-neutral-950" />
         </Slider.Track>
       </Slider.Control>
     </Slider.Root>

--- a/docs/src/app/(docs)/react/components/slider/demos/steps/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/steps/tailwind/index.tsx
@@ -17,7 +17,10 @@ export default function StepsSlider() {
       <Slider.Control className="col-span-2 flex touch-none items-center py-3 select-none">
         <Slider.Track className="h-1 w-full bg-neutral-200 select-none dark:bg-neutral-800">
           <Slider.Indicator className="bg-neutral-950 select-none dark:bg-white" />
-          <Slider.Thumb className="size-4 border border-neutral-950 bg-white select-none has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-neutral-950 dark:has-[:focus-visible]:outline-white dark:border-white dark:bg-neutral-950" />
+          <Slider.Thumb
+            aria-label="Font weight"
+            className="size-4 border border-neutral-950 bg-white select-none has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-neutral-950 dark:has-[:focus-visible]:outline-white dark:border-white dark:bg-neutral-950"
+          />
         </Slider.Track>
       </Slider.Control>
     </Slider.Root>

--- a/docs/src/app/(docs)/react/components/slider/demos/steps/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/slider/demos/steps/tailwind/index.tsx
@@ -1,0 +1,25 @@
+import { Slider } from '@base-ui/react/slider';
+
+export default function StepsSlider() {
+  return (
+    <Slider.Root
+      className="grid w-56 grid-cols-2"
+      defaultValue={400}
+      min={100}
+      max={900}
+      step={100}
+      largeStep={200}
+    >
+      <Slider.Label className="text-sm text-neutral-950 dark:text-white">
+        Playback speed
+      </Slider.Label>
+      <Slider.Value className="text-end text-sm text-neutral-950 dark:text-white" />
+      <Slider.Control className="col-span-2 flex touch-none items-center py-3 select-none">
+        <Slider.Track className="h-1 w-full bg-neutral-200 select-none dark:bg-neutral-800">
+          <Slider.Indicator className="bg-neutral-950 select-none dark:bg-white" />
+          <Slider.Thumb className="size-4 border border-neutral-950 bg-white select-none has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-neutral-950 dark:has-[:focus-visible]:outline-white dark:border-white dark:bg-neutral-950" />
+        </Slider.Track>
+      </Slider.Control>
+    </Slider.Root>
+  );
+}

--- a/docs/src/app/(docs)/react/components/slider/page.mdx
+++ b/docs/src/app/(docs)/react/components/slider/page.mdx
@@ -35,29 +35,6 @@ import { Slider } from '@base-ui/react/slider';
 
 ## Examples
 
-### Range slider
-
-To create a range slider:
-
-1. Pass an array of values and place a `<Slider.Thumb>` for each value in the array
-2. Additionally for server-side rendering, specify a numeric `index` for each thumb that corresponds to the index of its value in the value array
-
-Thumbs can be configured to behave differently when they collide during pointer interactions using the `thumbCollisionBehavior` prop on `<Slider.Root>`.
-
-import { DemoSliderRangeSlider } from './demos/range-slider';
-
-<DemoSliderRangeSlider />
-
-### Thumb alignment
-
-Set `thumbAlignment="edge"` to inset the thumb such that its edge aligns with the edge of the control when the value is at `min` or `max`, without overflowing the control like the default `"center"` alignment.
-
-A client-only alternative `thumbAlignment="edge-client-only"` can be used to reduce bundle size but only renders after React hydration.
-
-import { DemoSliderEdgeAlignment } from './demos/edge-alignment';
-
-<DemoSliderEdgeAlignment />
-
 ### Labeling a slider
 
 A single-thumb slider without a visible label (such as a volume control) can be labeled using `aria-label` on `<Slider.Thumb>`:
@@ -105,6 +82,47 @@ For a multi-thumb range slider with a visible label, add `aria-label` on each `<
   </Slider.Control>
 </Slider.Root>
 ```
+
+### Range slider
+
+To create a range slider:
+
+1. Pass an array of values and place a `<Slider.Thumb>` for each value in the array
+2. Additionally for server-side rendering, specify a numeric `index` for each thumb that corresponds to the index of its value in the value array
+
+Thumbs can be configured to behave differently when they collide during pointer interactions using the `thumbCollisionBehavior` prop on `<Slider.Root>`.
+
+import { DemoSliderRangeSlider } from './demos/range-slider';
+
+<DemoSliderRangeSlider />
+
+### Steps
+
+Use the `step` prop to snap the value to multiples of a given increment, and `largeStep` to control the increment when using Page Up/Page Down or Shift + Arrow Up/Arrow Down.
+
+import { DemoSliderSteps } from './demos/steps';
+
+<DemoSliderSteps />
+
+### Marks
+
+Render your own tick marks, positioning each mark along the track as a percentage of the value range.
+
+import { DemoSliderMarks } from './demos/marks';
+
+<DemoSliderMarks />
+
+Marks are independent of the value's granularity—pair them with the [`step`](#steps) prop to snap the thumb to each mark.
+
+### Thumb alignment
+
+Set `thumbAlignment="edge"` to inset the thumb such that its edge aligns with the edge of the control when the value is at `min` or `max`, without overflowing the control like the default `"center"` alignment.
+
+A client-only alternative `thumbAlignment="edge-client-only"` can be used to reduce bundle size but only renders after React hydration.
+
+import { DemoSliderEdgeAlignment } from './demos/edge-alignment';
+
+<DemoSliderEdgeAlignment />
 
 ### Vertical
 


### PR DESCRIPTION
Part of #3027 (slider → steps).

Adds two demos to the Slider docs ([preview: Steps](https://deploy-preview-5621--base-ui.netlify.app/react/components/slider#steps) · [preview: Marks](https://deploy-preview-5621--base-ui.netlify.app/react/components/slider#marks)):

**Steps** — a font weight slider showcasing `step` and `largeStep`. `<Slider.Label>` and `<Slider.Value>` make the snapping observable; font weights are unitless so the value needs no formatting.

**Marks** — showcases manually rendered tick marks and labels on a continuous slider (the default value sits off-mark on purpose):

- Ticks and the label row are `aria-hidden`: the slider input already conveys label, value, and range to assistive technology.
- A note after the demo points out that marks pair with the `step` prop to snap the thumb to each mark.

Also moves the "Labeling a slider" section to the top of Examples, since every other example depends on it (`aria-label` on thumbs) and the usage guidelines link to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)