### PR TITLE
[composite] Keep controlled highlightedIndex across item changes

### DIFF
--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -1222,14 +1222,8 @@ describe('Composite', () => {
 
       return (
         <React.Fragment>
-          <button
-            onClick={() => {
-              setHighlightedIndex(2);
-              setShowLastItem(false);
-            }}
-          >
-            update
-          </button>
+          <button onClick={() => setHighlightedIndex(2)}>highlight</button>
+          <button onClick={() => setShowLastItem(false)}>remove</button>
           <CompositeRoot
             highlightedIndex={highlightedIndex}
             onHighlightedIndexChange={setHighlightedIndex}
@@ -1243,13 +1237,14 @@ describe('Composite', () => {
       );
     }
 
-    it('keeps the controlled tab stop when the items change', async () => {
+    it('keeps a directly controlled tab stop when the items change later', async () => {
       await render(<App />);
 
       act(() => screen.getByTestId('1').focus());
       expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
 
-      fireEvent.click(screen.getByRole('button', { name: 'update' }));
+      fireEvent.click(screen.getByRole('button', { name: 'highlight' }));
+      fireEvent.click(screen.getByRole('button', { name: 'remove' }));
 
       expect(screen.queryByTestId('3')).toBeNull();
       expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');

--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -9,6 +9,7 @@ import {
   waitFor,
 } from '@mui/internal-test-utils';
 import { isJSDOM } from '#test-utils';
+import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { DirectionProvider } from '../../../direction-provider';
 import { CompositeItem } from '../item/CompositeItem';
 import { type CompositeMetadata } from '../list/CompositeList';
@@ -1233,6 +1234,72 @@ describe('Composite', () => {
       await setProps({ showLast: false });
 
       expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '-1');
+    });
+  });
+
+  describe('focus from a child layout effect', () => {
+    function Item({ id, focusMe }: { id: string; focusMe?: boolean }) {
+      const ref = React.useRef<HTMLDivElement>(null);
+      useIsoLayoutEffect(() => {
+        if (focusMe) {
+          ref.current?.focus();
+        }
+      }, [focusMe]);
+      return <CompositeItem refs={[ref]} data-testid={id} />;
+    }
+
+    it('keeps the tab stop on the item focused while the focused item is removed', async () => {
+      function App() {
+        const [showFirst, setShowFirst] = React.useState(true);
+        return (
+          <React.Fragment>
+            <button onClick={() => setShowFirst(false)}>remove</button>
+            <CompositeRoot>
+              {showFirst && <Item id="1" />}
+              <Item id="2" />
+              <Item id="3" focusMe={!showFirst} />
+            </CompositeRoot>
+          </React.Fragment>
+        );
+      }
+
+      await render(<App />);
+      act(() => screen.getByTestId('1').focus());
+
+      fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+
+      expect(screen.getByTestId('3')).toHaveFocus();
+      expect(screen.getByTestId('3')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('keeps the tab stop on the item focused while the focused item is removed (controlled)', async () => {
+      function App() {
+        const [showFirst, setShowFirst] = React.useState(true);
+        const [highlightedIndex, setHighlightedIndex] = React.useState(0);
+        return (
+          <React.Fragment>
+            <button onClick={() => setShowFirst(false)}>remove</button>
+            <CompositeRoot
+              highlightedIndex={highlightedIndex}
+              onHighlightedIndexChange={setHighlightedIndex}
+            >
+              {showFirst && <Item id="1" />}
+              <Item id="2" />
+              <Item id="3" focusMe={!showFirst} />
+            </CompositeRoot>
+          </React.Fragment>
+        );
+      }
+
+      await render(<App />);
+      act(() => screen.getByTestId('1').focus());
+
+      fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+
+      expect(screen.getByTestId('3')).toHaveFocus();
+      expect(screen.getByTestId('3')).toHaveAttribute('tabindex', '0');
       expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '-1');
     });
   });

--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -1304,8 +1304,76 @@ describe('Composite', () => {
     });
   });
 
+  describe('focus from a child layout effect (controlled)', () => {
+    function Item({ id, focusMe }: { id: string; focusMe?: boolean }) {
+      const ref = React.useRef<HTMLButtonElement>(null);
+      useIsoLayoutEffect(() => {
+        if (focusMe) {
+          ref.current?.focus();
+        }
+      }, [focusMe]);
+      return <CompositeItem refs={[ref]} data-testid={id} render={<button type="button" />} />;
+    }
+
+    it('restores the tab stop after a new item focuses itself before it registers', async () => {
+      function App() {
+        const [highlightedIndex, setHighlightedIndex] = React.useState(0);
+        const [count, setCount] = React.useState(2);
+        return (
+          <React.Fragment>
+            <button onClick={() => setCount((value) => value + 1)}>add</button>
+            <CompositeRoot
+              highlightedIndex={highlightedIndex}
+              onHighlightedIndexChange={setHighlightedIndex}
+            >
+              <Item id="1" />
+              <Item id="2" />
+              {count >= 3 && <Item id="3" focusMe />}
+              {count >= 4 && <Item id="4" />}
+            </CompositeRoot>
+          </React.Fragment>
+        );
+      }
+
+      await render(<App />);
+      fireEvent.click(screen.getByRole('button', { name: 'add' }));
+      expect(screen.getByTestId('3')).toHaveFocus();
+
+      act(() => screen.getByTestId('3').blur());
+      fireEvent.click(screen.getByRole('button', { name: 'add' }));
+
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
+    });
+
+    it('keeps the tab stop on the item focused while cleared and the focused item is removed', async () => {
+      function App() {
+        const [highlightedIndex, setHighlightedIndex] = React.useState(-1);
+        const [showFirst, setShowFirst] = React.useState(true);
+        return (
+          <React.Fragment>
+            <button onClick={() => setShowFirst(false)}>remove</button>
+            <CompositeRoot
+              highlightedIndex={highlightedIndex}
+              onHighlightedIndexChange={setHighlightedIndex}
+            >
+              {showFirst && <Item id="1" />}
+              <Item id="2" />
+              <Item id="3" focusMe={!showFirst} />
+            </CompositeRoot>
+          </React.Fragment>
+        );
+      }
+
+      await render(<App />);
+      fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+
+      expect(screen.getByTestId('3')).toHaveFocus();
+      expect(screen.getByTestId('3')).toHaveAttribute('tabindex', '0');
+    });
+  });
+
   describe('controlled highlightedIndex', () => {
-    function App() {
+    function App({ lastDisabled = false }: { lastDisabled?: boolean }) {
       const [highlightedIndex, setHighlightedIndex] = React.useState(1);
       const [showFirstItem, setShowFirstItem] = React.useState(true);
       const [showLastItem, setShowLastItem] = React.useState(true);
@@ -1313,6 +1381,7 @@ describe('Composite', () => {
       return (
         <React.Fragment>
           <button onClick={() => setHighlightedIndex(2)}>highlight</button>
+          <button onClick={() => setHighlightedIndex(3)}>highlight last</button>
           <button onClick={() => setHighlightedIndex(1)}>restore</button>
           <button onClick={() => setHighlightedIndex(-1)}>clear</button>
           <button onClick={() => setShowFirstItem(false)}>remove first</button>
@@ -1332,7 +1401,12 @@ describe('Composite', () => {
             {showFirstItem && <CompositeItem data-testid="0" />}
             <CompositeItem data-testid="1" />
             <CompositeItem data-testid="2" />
-            {showLastItem && <CompositeItem data-testid="3" />}
+            {showLastItem && (
+              <CompositeItem
+                data-testid="3"
+                render={<button type="button" disabled={lastDisabled} />}
+              />
+            )}
           </CompositeRoot>
         </React.Fragment>
       );
@@ -1377,6 +1451,35 @@ describe('Composite', () => {
       expect(screen.getByTestId('0')).toHaveAttribute('tabindex', '-1');
       expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
       expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('follows a directly controlled item when an earlier item is removed later', async () => {
+      const { rerender } = await render(<App />);
+
+      act(() => screen.getByTestId('1').focus());
+      fireEvent.click(screen.getByRole('button', { name: 'highlight' }));
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+
+      fireEvent.click(screen.getByRole('button', { name: 'remove first' }));
+
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('3')).toHaveAttribute('tabindex', '-1');
+
+      rerender(<App lastDisabled />);
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+    });
+
+    it('moves the tab stop back into range when a directly controlled item is removed later', async () => {
+      await render(<App />);
+
+      act(() => screen.getByTestId('1').focus());
+      fireEvent.click(screen.getByRole('button', { name: 'highlight last' }));
+      expect(screen.getByTestId('3')).toHaveAttribute('tabindex', '0');
+
+      fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+
+      expect(screen.getByTestId('0')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
     });
 
     it('honors the same index set again after clearing while the items shifted', async () => {

--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -147,6 +147,28 @@ describe('Composite', () => {
       expect(item1).toHaveFocus();
     });
 
+    it('restores the tab stop after an item is focused before it registers', async () => {
+      function App({ showLast = false }: { showLast?: boolean }) {
+        return (
+          <CompositeRoot>
+            <CompositeItem data-testid="1" render={<button type="button" autoFocus />} />
+            <CompositeItem data-testid="2" render={<button type="button" />} />
+            {showLast && <CompositeItem data-testid="3" render={<button type="button" />} />}
+          </CompositeRoot>
+        );
+      }
+
+      const { rerender } = await render(<App />);
+      expect(screen.getByTestId('1')).toHaveFocus();
+
+      rerender(<App showLast />);
+      act(() => screen.getByTestId('1').blur());
+
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByTestId('3')).toHaveAttribute('tabindex', '-1');
+    });
+
     it('uses an active item explicit index as the initial highlighted index', async () => {
       const onHighlightedIndexChange = vi.fn();
 
@@ -1218,12 +1240,15 @@ describe('Composite', () => {
   describe('controlled highlightedIndex', () => {
     function App() {
       const [highlightedIndex, setHighlightedIndex] = React.useState(1);
+      const [showFirstItem, setShowFirstItem] = React.useState(true);
       const [showLastItem, setShowLastItem] = React.useState(true);
 
       return (
         <React.Fragment>
           <button onClick={() => setHighlightedIndex(2)}>highlight</button>
+          <button onClick={() => setHighlightedIndex(1)}>restore</button>
           <button onClick={() => setHighlightedIndex(-1)}>clear</button>
+          <button onClick={() => setShowFirstItem(false)}>remove first</button>
           <button onClick={() => setShowLastItem(false)}>remove</button>
           <button
             onClick={() => {
@@ -1237,7 +1262,7 @@ describe('Composite', () => {
             highlightedIndex={highlightedIndex}
             onHighlightedIndexChange={setHighlightedIndex}
           >
-            <CompositeItem data-testid="0" />
+            {showFirstItem && <CompositeItem data-testid="0" />}
             <CompositeItem data-testid="1" />
             <CompositeItem data-testid="2" />
             {showLastItem && <CompositeItem data-testid="3" />}
@@ -1285,6 +1310,21 @@ describe('Composite', () => {
       expect(screen.getByTestId('0')).toHaveAttribute('tabindex', '-1');
       expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
       expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('honors the same index set again after clearing while the items shifted', async () => {
+      await render(<App />);
+
+      act(() => screen.getByTestId('1').focus());
+      fireEvent.click(screen.getByRole('button', { name: 'clear' }));
+      fireEvent.click(screen.getByRole('button', { name: 'remove first' }));
+      fireEvent.click(screen.getByRole('button', { name: 'restore' }));
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+
+      fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
     });
   });
 

--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -1215,6 +1215,133 @@ describe('Composite', () => {
     });
   });
 
+  describe('controlled highlightedIndex', () => {
+    function App({
+      showItem0 = true,
+      showItem4 = true,
+      showExtraItem = false,
+    }: {
+      showItem0?: boolean;
+      showItem4?: boolean;
+      showExtraItem?: boolean;
+    }) {
+      const [highlightedIndex, setHighlightedIndex] = React.useState(1);
+      const [item4Removed, setItem4Removed] = React.useState(false);
+      return (
+        <React.Fragment>
+          <button onClick={() => setHighlightedIndex(2)}>highlight 2</button>
+          <button onClick={() => setHighlightedIndex(4)}>highlight 4</button>
+          <button
+            onClick={() => {
+              setHighlightedIndex(2);
+              setItem4Removed(true);
+            }}
+          >
+            highlight 2 and remove 4
+          </button>
+          <CompositeRoot
+            highlightedIndex={highlightedIndex}
+            onHighlightedIndexChange={setHighlightedIndex}
+          >
+            {showItem0 && <CompositeItem data-testid="0" />}
+            <CompositeItem data-testid="1" />
+            <CompositeItem data-testid="2" />
+            <CompositeItem data-testid="3" />
+            {showItem4 && !item4Removed && <CompositeItem data-testid="4" />}
+            {showExtraItem && <CompositeItem data-testid="extra" />}
+          </CompositeRoot>
+        </React.Fragment>
+      );
+    }
+
+    it('keeps the controlled tab stop when an unrelated item is removed', async () => {
+      const { rerender } = await render(<App />);
+
+      act(() => screen.getByTestId('1').focus());
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
+
+      fireEvent.click(screen.getByRole('button', { name: 'highlight 2' }));
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+
+      rerender(<App showItem4={false} />);
+
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('keeps the controlled tab stop when an unrelated item is inserted', async () => {
+      const { rerender } = await render(<App />);
+
+      act(() => screen.getByTestId('1').focus());
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
+
+      fireEvent.click(screen.getByRole('button', { name: 'highlight 2' }));
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+
+      rerender(<App showExtraItem />);
+
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('keeps the controlled tab stop when the index and the items change in the same commit', async () => {
+      await render(<App />);
+
+      act(() => screen.getByTestId('1').focus());
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
+
+      fireEvent.click(screen.getByRole('button', { name: 'highlight 2 and remove 4' }));
+
+      expect(screen.queryByTestId('4')).toBeNull();
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('moves the tab stop back into range when the controlled item is removed later', async () => {
+      const { rerender } = await render(<App />);
+
+      act(() => screen.getByTestId('1').focus());
+      fireEvent.click(screen.getByRole('button', { name: 'highlight 4' }));
+      expect(screen.getByTestId('4')).toHaveAttribute('tabindex', '0');
+
+      rerender(<App showItem4={false} />);
+
+      expect(screen.getByTestId('0')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('keeps the tab stop on the controlled item when an earlier item is removed later', async () => {
+      const { rerender } = await render(<App />);
+
+      act(() => screen.getByTestId('1').focus());
+      fireEvent.click(screen.getByRole('button', { name: 'highlight 2' }));
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+
+      rerender(<App showItem0={false} />);
+
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('3')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('follows the refreshed item when an earlier item is removed afterwards', async () => {
+      const { rerender } = await render(<App />);
+
+      act(() => screen.getByTestId('1').focus());
+      fireEvent.click(screen.getByRole('button', { name: 'highlight 2' }));
+
+      // refreshes the cached element to item 2
+      rerender(<App showItem4={false} />);
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+
+      // item 2 shifts to index 1 and must keep the tab stop
+      rerender(<App showItem4={false} showItem0={false} />);
+
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByTestId('3')).toHaveAttribute('tabindex', '-1');
+    });
+  });
+
   describe('prop: modifierKeys', () => {
     it('prevents arrow key navigation when any modifier key is pressed by default', async () => {
       render(

--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -1223,6 +1223,7 @@ describe('Composite', () => {
       return (
         <React.Fragment>
           <button onClick={() => setHighlightedIndex(2)}>highlight</button>
+          <button onClick={() => setHighlightedIndex(-1)}>clear</button>
           <button onClick={() => setShowLastItem(false)}>remove</button>
           <CompositeRoot
             highlightedIndex={highlightedIndex}
@@ -1249,6 +1250,20 @@ describe('Composite', () => {
       expect(screen.queryByTestId('3')).toBeNull();
       expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
       expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('keeps a cleared controlled highlight when the items change later', async () => {
+      await render(<App />);
+
+      act(() => screen.getByTestId('1').focus());
+      fireEvent.click(screen.getByRole('button', { name: 'clear' }));
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
+
+      fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+
+      expect(screen.getByTestId('0')).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '-1');
     });
   });
 

--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -1216,129 +1216,44 @@ describe('Composite', () => {
   });
 
   describe('controlled highlightedIndex', () => {
-    function App({
-      showItem0 = true,
-      showItem4 = true,
-      showExtraItem = false,
-    }: {
-      showItem0?: boolean;
-      showItem4?: boolean;
-      showExtraItem?: boolean;
-    }) {
+    function App() {
       const [highlightedIndex, setHighlightedIndex] = React.useState(1);
-      const [item4Removed, setItem4Removed] = React.useState(false);
+      const [showLastItem, setShowLastItem] = React.useState(true);
+
       return (
         <React.Fragment>
-          <button onClick={() => setHighlightedIndex(2)}>highlight 2</button>
-          <button onClick={() => setHighlightedIndex(4)}>highlight 4</button>
           <button
             onClick={() => {
               setHighlightedIndex(2);
-              setItem4Removed(true);
+              setShowLastItem(false);
             }}
           >
-            highlight 2 and remove 4
+            update
           </button>
           <CompositeRoot
             highlightedIndex={highlightedIndex}
             onHighlightedIndexChange={setHighlightedIndex}
           >
-            {showItem0 && <CompositeItem data-testid="0" />}
+            <CompositeItem data-testid="0" />
             <CompositeItem data-testid="1" />
             <CompositeItem data-testid="2" />
-            <CompositeItem data-testid="3" />
-            {showItem4 && !item4Removed && <CompositeItem data-testid="4" />}
-            {showExtraItem && <CompositeItem data-testid="extra" />}
+            {showLastItem && <CompositeItem data-testid="3" />}
           </CompositeRoot>
         </React.Fragment>
       );
     }
 
-    it('keeps the controlled tab stop when an unrelated item is removed', async () => {
-      const { rerender } = await render(<App />);
-
-      act(() => screen.getByTestId('1').focus());
-      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
-
-      fireEvent.click(screen.getByRole('button', { name: 'highlight 2' }));
-      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
-
-      rerender(<App showItem4={false} />);
-
-      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
-      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
-    });
-
-    it('keeps the controlled tab stop when an unrelated item is inserted', async () => {
-      const { rerender } = await render(<App />);
-
-      act(() => screen.getByTestId('1').focus());
-      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
-
-      fireEvent.click(screen.getByRole('button', { name: 'highlight 2' }));
-      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
-
-      rerender(<App showExtraItem />);
-
-      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
-      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
-    });
-
-    it('keeps the controlled tab stop when the index and the items change in the same commit', async () => {
+    it('keeps the controlled tab stop when the items change', async () => {
       await render(<App />);
 
       act(() => screen.getByTestId('1').focus());
       expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
 
-      fireEvent.click(screen.getByRole('button', { name: 'highlight 2 and remove 4' }));
+      fireEvent.click(screen.getByRole('button', { name: 'update' }));
 
-      expect(screen.queryByTestId('4')).toBeNull();
+      expect(screen.queryByTestId('3')).toBeNull();
       expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
       expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
-    });
-
-    it('moves the tab stop back into range when the controlled item is removed later', async () => {
-      const { rerender } = await render(<App />);
-
-      act(() => screen.getByTestId('1').focus());
-      fireEvent.click(screen.getByRole('button', { name: 'highlight 4' }));
-      expect(screen.getByTestId('4')).toHaveAttribute('tabindex', '0');
-
-      rerender(<App showItem4={false} />);
-
-      expect(screen.getByTestId('0')).toHaveAttribute('tabindex', '0');
-      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
-    });
-
-    it('keeps the tab stop on the controlled item when an earlier item is removed later', async () => {
-      const { rerender } = await render(<App />);
-
-      act(() => screen.getByTestId('1').focus());
-      fireEvent.click(screen.getByRole('button', { name: 'highlight 2' }));
-      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
-
-      rerender(<App showItem0={false} />);
-
-      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
-      expect(screen.getByTestId('3')).toHaveAttribute('tabindex', '-1');
-    });
-
-    it('follows the refreshed item when an earlier item is removed afterwards', async () => {
-      const { rerender } = await render(<App />);
-
-      act(() => screen.getByTestId('1').focus());
-      fireEvent.click(screen.getByRole('button', { name: 'highlight 2' }));
-
-      // refreshes the cached element to item 2
-      rerender(<App showItem4={false} />);
-      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
-
-      // item 2 shifts to index 1 and must keep the tab stop
-      rerender(<App showItem4={false} showItem0={false} />);
-
-      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
-      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
-      expect(screen.getByTestId('3')).toHaveAttribute('tabindex', '-1');
     });
   });
 

--- a/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.test.tsx
@@ -1225,6 +1225,14 @@ describe('Composite', () => {
           <button onClick={() => setHighlightedIndex(2)}>highlight</button>
           <button onClick={() => setHighlightedIndex(-1)}>clear</button>
           <button onClick={() => setShowLastItem(false)}>remove</button>
+          <button
+            onClick={() => {
+              setHighlightedIndex(2);
+              setShowLastItem(false);
+            }}
+          >
+            highlight and remove
+          </button>
           <CompositeRoot
             highlightedIndex={highlightedIndex}
             onHighlightedIndexChange={setHighlightedIndex}
@@ -1246,6 +1254,19 @@ describe('Composite', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'highlight' }));
       fireEvent.click(screen.getByRole('button', { name: 'remove' }));
+
+      expect(screen.queryByTestId('3')).toBeNull();
+      expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('keeps a directly controlled tab stop when the items change in the same commit', async () => {
+      await render(<App />);
+
+      act(() => screen.getByTestId('1').focus());
+      expect(screen.getByTestId('1')).toHaveAttribute('tabindex', '0');
+
+      fireEvent.click(screen.getByRole('button', { name: 'highlight and remove' }));
 
       expect(screen.queryByTestId('3')).toBeNull();
       expect(screen.getByTestId('2')).toHaveAttribute('tabindex', '0');

--- a/packages/react/src/internals/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/internals/composite/root/useCompositeRoot.ts
@@ -98,8 +98,10 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
   const highlightedElementRef = React.useRef<HTMLElement | null>(null);
 
   const highlightedIndex = externalHighlightedIndex ?? internalHighlightedIndex;
+  const highlightedElementIndexRef = React.useRef(highlightedIndex);
   const onHighlightedIndexChange = useStableCallback((index, shouldScrollIntoView = false) => {
     highlightedElementRef.current = elementsRef.current[index] ?? null;
+    highlightedElementIndexRef.current = index;
     (externalSetHighlightedIndex ?? internalSetHighlightedIndex)(index);
     if (shouldScrollIntoView) {
       const newActiveItem = elementsRef.current[index];
@@ -113,12 +115,17 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
     }
 
     if (hasSetDefaultIndexRef.current) {
-      // A controlled index is authoritative when the item map changes.
-      if (externalHighlightedIndex != null) {
-        return;
-      }
-
       const elements = elementsRef.current;
+
+      if (highlightedIndex !== highlightedElementIndexRef.current) {
+        // Direct controlled changes replace the cache; missing targets use the normal fallback.
+        const element = elements[highlightedIndex];
+        if (element) {
+          highlightedElementRef.current = element;
+          highlightedElementIndexRef.current = highlightedIndex;
+          return;
+        }
+      }
 
       // Items added or removed around the highlighted one shift its index, so the tab stop would
       // otherwise move to a different item and navigation would resume from the wrong position.

--- a/packages/react/src/internals/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/internals/composite/root/useCompositeRoot.ts
@@ -123,7 +123,8 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
       const elements = elementsRef.current;
 
       if (highlightedIndex !== highlightedElementIndexRef.current) {
-        // Direct controlled changes replace the cache; missing targets use the normal fallback.
+        // Direct controlled changes replace the cache; missing targets fall through to the
+        // reconciliation below.
         const element = elements[highlightedIndex];
         if (element) {
           highlightedElementRef.current = element;

--- a/packages/react/src/internals/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/internals/composite/root/useCompositeRoot.ts
@@ -98,8 +98,10 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
   const highlightedElementRef = React.useRef<HTMLElement | null>(null);
 
   const highlightedIndex = externalHighlightedIndex ?? internalHighlightedIndex;
+  const highlightedElementIndexRef = React.useRef(highlightedIndex);
   const onHighlightedIndexChange = useStableCallback((index, shouldScrollIntoView = false) => {
     highlightedElementRef.current = elementsRef.current[index] ?? null;
+    highlightedElementIndexRef.current = index;
     (externalSetHighlightedIndex ?? internalSetHighlightedIndex)(index);
     if (shouldScrollIntoView) {
       const newActiveItem = elementsRef.current[index];
@@ -114,6 +116,15 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
 
     if (hasSetDefaultIndexRef.current) {
       const elements = elementsRef.current;
+
+      if (highlightedIndex !== highlightedElementIndexRef.current) {
+        // A controlled `highlightedIndex` changed in the same commit as the items, before the
+        // layout effect below could sync the cache, so the controlled index wins.
+        highlightedElementRef.current = elements[highlightedIndex] ?? null;
+        highlightedElementIndexRef.current = highlightedIndex;
+        return;
+      }
+
       // Items added or removed around the highlighted one shift its index, so the tab stop would
       // otherwise move to a different item and navigation would resume from the wrong position.
       const nextIndex = elements.indexOf(highlightedElementRef.current);
@@ -162,6 +173,15 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
 
     scrollIntoViewIfNeeded(rootRef.current, activeItem, direction, orientation);
   });
+
+  useIsoLayoutEffect(() => {
+    // A controlled `highlightedIndex` can change without `onHighlightedIndexChange`, so the
+    // cached element would otherwise be stale on the next map change.
+    if (externalHighlightedIndex != null) {
+      highlightedElementRef.current = elementsRef.current[externalHighlightedIndex] ?? null;
+      highlightedElementIndexRef.current = externalHighlightedIndex;
+    }
+  }, [externalHighlightedIndex]);
 
   useIsoLayoutEffect(() => {
     // `disabledIndices` can resolve a render after the initial map population

--- a/packages/react/src/internals/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/internals/composite/root/useCompositeRoot.ts
@@ -115,8 +115,10 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
     }
 
     if (hasSetDefaultIndexRef.current) {
-      if (highlightedIndex === -1) {
+      if (externalHighlightedIndex === -1) {
         // A controlled parent cleared the highlight, so there is no item to keep or fall back to.
+        highlightedElementRef.current = null;
+        highlightedElementIndexRef.current = -1;
         return;
       }
 

--- a/packages/react/src/internals/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/internals/composite/root/useCompositeRoot.ts
@@ -99,9 +99,12 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
 
   const highlightedIndex = externalHighlightedIndex ?? internalHighlightedIndex;
   const highlightedElementIndexRef = React.useRef(highlightedIndex);
+  const hasPendingIndexChangeRef = React.useRef(false);
   const onHighlightedIndexChange = useStableCallback((index, shouldScrollIntoView = false) => {
     highlightedElementRef.current = elementsRef.current[index] ?? null;
     highlightedElementIndexRef.current = index;
+    // A change that will re-render only settles after the list may already have flushed.
+    hasPendingIndexChangeRef.current = index !== highlightedIndex;
     (externalSetHighlightedIndex ?? internalSetHighlightedIndex)(index);
     if (shouldScrollIntoView) {
       const newActiveItem = elementsRef.current[index];
@@ -124,9 +127,13 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
 
       const elements = elementsRef.current;
 
-      if (highlightedIndex !== highlightedElementIndexRef.current) {
+      if (
+        !hasPendingIndexChangeRef.current &&
+        highlightedIndex !== highlightedElementIndexRef.current
+      ) {
         // Direct controlled changes replace the cache; missing targets fall through to the
-        // reconciliation below.
+        // reconciliation below. A pending `onHighlightedIndexChange` call from this commit has
+        // already refreshed the cache and outranks the rendered index.
         const element = elements[highlightedIndex];
         if (element) {
           highlightedElementRef.current = element;
@@ -182,6 +189,11 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
     }
 
     scrollIntoViewIfNeeded(rootRef.current, activeItem, direction, orientation);
+  });
+
+  useIsoLayoutEffect(() => {
+    // Runs after the list flushed this commit's map changes.
+    hasPendingIndexChangeRef.current = false;
   });
 
   useIsoLayoutEffect(() => {

--- a/packages/react/src/internals/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/internals/composite/root/useCompositeRoot.ts
@@ -98,10 +98,8 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
   const highlightedElementRef = React.useRef<HTMLElement | null>(null);
 
   const highlightedIndex = externalHighlightedIndex ?? internalHighlightedIndex;
-  const highlightedElementIndexRef = React.useRef(highlightedIndex);
   const onHighlightedIndexChange = useStableCallback((index, shouldScrollIntoView = false) => {
     highlightedElementRef.current = elementsRef.current[index] ?? null;
-    highlightedElementIndexRef.current = index;
     (externalSetHighlightedIndex ?? internalSetHighlightedIndex)(index);
     if (shouldScrollIntoView) {
       const newActiveItem = elementsRef.current[index];
@@ -115,15 +113,12 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
     }
 
     if (hasSetDefaultIndexRef.current) {
-      const elements = elementsRef.current;
-
-      if (highlightedIndex !== highlightedElementIndexRef.current) {
-        // A controlled `highlightedIndex` changed in the same commit as the items, before the
-        // layout effect below could sync the cache, so the controlled index wins.
-        highlightedElementRef.current = elements[highlightedIndex] ?? null;
-        highlightedElementIndexRef.current = highlightedIndex;
+      // A controlled index is authoritative when the item map changes.
+      if (externalHighlightedIndex != null) {
         return;
       }
+
+      const elements = elementsRef.current;
 
       // Items added or removed around the highlighted one shift its index, so the tab stop would
       // otherwise move to a different item and navigation would resume from the wrong position.
@@ -173,15 +168,6 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
 
     scrollIntoViewIfNeeded(rootRef.current, activeItem, direction, orientation);
   });
-
-  useIsoLayoutEffect(() => {
-    // A controlled `highlightedIndex` can change without `onHighlightedIndexChange`, so the
-    // cached element would otherwise be stale on the next map change.
-    if (externalHighlightedIndex != null) {
-      highlightedElementRef.current = elementsRef.current[externalHighlightedIndex] ?? null;
-      highlightedElementIndexRef.current = externalHighlightedIndex;
-    }
-  }, [externalHighlightedIndex]);
 
   useIsoLayoutEffect(() => {
     // `disabledIndices` can resolve a render after the initial map population

--- a/packages/react/src/internals/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/internals/composite/root/useCompositeRoot.ts
@@ -94,16 +94,16 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
   const mergedRef = useMergedRefs(rootRef, externalRef);
 
   const elementsRef = React.useRef<Array<HTMLElement | null>>([]);
+  const previousElementsRef = React.useRef<Array<HTMLElement | null>>([]);
   const hasSetDefaultIndexRef = React.useRef(false);
-  const highlightedElementRef = React.useRef<HTMLElement | null>(null);
 
   const highlightedIndex = externalHighlightedIndex ?? internalHighlightedIndex;
-  const highlightedElementIndexRef = React.useRef(highlightedIndex);
+  // The index the items were last reconciled against. `onHighlightedIndexChange` can run between
+  // a render and the list flush of the same commit, so it also records the index it just set.
+  const settledIndexRef = React.useRef(highlightedIndex);
   const hasPendingIndexChangeRef = React.useRef(false);
   const onHighlightedIndexChange = useStableCallback((index, shouldScrollIntoView = false) => {
-    highlightedElementRef.current = elementsRef.current[index] ?? null;
-    highlightedElementIndexRef.current = index;
-    // A change that will re-render only settles after the list may already have flushed.
+    settledIndexRef.current = index;
     hasPendingIndexChangeRef.current = index !== highlightedIndex;
     (externalSetHighlightedIndex ?? internalSetHighlightedIndex)(index);
     if (shouldScrollIntoView) {
@@ -117,46 +117,40 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
       return;
     }
 
+    const elements = elementsRef.current;
+    const previousElements = previousElementsRef.current;
+    previousElementsRef.current = elements.slice();
+
     if (hasSetDefaultIndexRef.current) {
-      if (externalHighlightedIndex === -1) {
+      const isPending = hasPendingIndexChangeRef.current;
+      const index = isPending ? settledIndexRef.current : highlightedIndex;
+
+      if (!isPending && externalHighlightedIndex === -1) {
         // A controlled parent cleared the highlight, so there is no item to keep or fall back to.
-        highlightedElementRef.current = null;
-        highlightedElementIndexRef.current = -1;
         return;
       }
 
-      const elements = elementsRef.current;
-
-      if (
-        !hasPendingIndexChangeRef.current &&
-        highlightedIndex !== highlightedElementIndexRef.current
-      ) {
-        // Direct controlled changes replace the cache; missing targets fall through to the
-        // reconciliation below. A pending `onHighlightedIndexChange` call from this commit has
-        // already refreshed the cache and outranks the rendered index.
-        const element = elements[highlightedIndex];
-        if (element) {
-          highlightedElementRef.current = element;
-          highlightedElementIndexRef.current = highlightedIndex;
-          return;
+      if (!isPending && index !== settledIndexRef.current) {
+        // A controlled index changed together with the items and refers to the new items.
+        if (!elements[index] || isListIndexDisabled(elements, index, disabledIndices)) {
+          onHighlightedIndexChange(getFallbackIndex(elements, disabledIndices));
         }
+        return;
       }
 
       // Items added or removed around the highlighted one shift its index, so the tab stop would
       // otherwise move to a different item and navigation would resume from the wrong position.
-      const nextIndex = elements.indexOf(highlightedElementRef.current);
+      const previousElement = previousElements[index];
+      const nextIndex = previousElement ? elements.indexOf(previousElement) : -1;
 
       if (nextIndex === -1) {
         // A replacement at the same index can keep the tab stop. Otherwise move it to an
         // eligible item so a missing, hidden, or disabled replacement does not take the
         // composite out of the tab order.
-        const replacement = elements[highlightedIndex];
-        if (!replacement || isListIndexDisabled(elements, highlightedIndex, disabledIndices)) {
+        if (!elements[index] || isListIndexDisabled(elements, index, disabledIndices)) {
           onHighlightedIndexChange(getFallbackIndex(elements, disabledIndices));
-        } else {
-          highlightedElementRef.current = replacement;
         }
-      } else if (nextIndex !== highlightedIndex) {
+      } else if (nextIndex !== index) {
         onHighlightedIndexChange(nextIndex);
       }
       return;
@@ -193,6 +187,7 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
 
   useIsoLayoutEffect(() => {
     // Runs after the list flushed this commit's map changes.
+    settledIndexRef.current = highlightedIndex;
     hasPendingIndexChangeRef.current = false;
   });
 

--- a/packages/react/src/internals/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/internals/composite/root/useCompositeRoot.ts
@@ -115,6 +115,11 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
     }
 
     if (hasSetDefaultIndexRef.current) {
+      if (highlightedIndex === -1) {
+        // A controlled parent cleared the highlight, so there is no item to keep or fall back to.
+        return;
+      }
+
       const elements = elementsRef.current;
 
       if (highlightedIndex !== highlightedElementIndexRef.current) {


### PR DESCRIPTION
Regression from #5447. `useCompositeRoot` caches the highlighted element so that inserting or removing items around it keeps the tab stop on the same item. That cache was only refreshed inside `onHighlightedIndexChange`. A parent that drives the controlled `highlightedIndex` prop directly left the cache pointing at the previously focused item. On the next map change, the reconciliation found that stale element at a different index and called `onHighlightedIndexChange` with it, snapping `tabindex="0"` back to the old item. 1.7.0 honored the controlled index across insertions and removals.

In-repo consumers such as `TabsList` are not affected because they only change the highlight through `onHighlightedIndexChange`. The bug is reachable through the published `@base-ui/react/internals/composite` subpath.

## Changes

- Drop the cached highlighted element. The root now keeps a copy of the previous elements array, refreshed on every map change, and reconciles against it: the element that sat at the highlighted index before the change is looked up in the new list. Nothing about the highlight is remembered, so a controlled index the parent changes directly needs no refresh step, and later insertions or removals follow the item the parent chose. The copy costs well under a microsecond next to the flush that already sorts and diffs the list.
- Two small pieces cover the one race the snapshot cannot: `onHighlightedIndexChange` can run between a render and the list flush of the same commit (a child layout effect focusing an item, or `TabsTab` syncing the highlight to the active tab). The setter records the index it just set and raises a flag when it differs from the rendered one. The flush then reconciles against that index instead of the rendered one. A root layout effect settles the rendered index and clears the flag after the flush.
- A controlled index that changes together with the items in one commit refers to the new items and is honored as is, with the normal fallback when the target is missing or disabled.
- A controlled parent that clears the highlight with `-1` keeps it cleared across item changes. A `-1` the composite emitted itself (an item focused before it registers) and echoed back by a pass-through parent such as `TabsList` still gets the fallback, because the pending setter call outranks the prop.
- Uncontrolled behavior from #5447 is unchanged. The identity reconciliation is the same, only its source moved from a cache to the previous snapshot.
- Tests cover: a directly controlled index surviving a later item change, an index and item change in one commit, a cleared highlight across item changes, the same index set again after clearing while items shifted, a directly controlled item followed across an earlier removal and falling back when removed, a new item focusing itself before it registers (uncontrolled and pass-through controlled), and a child layout effect focusing a sibling in the commit that removes the focused item (uncontrolled, controlled, and cleared).
