### PR TITLE
[field] Keep pending validation when a control is disabled

### DIFF
--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -2176,48 +2176,6 @@ describe('<Field.Root />', () => {
       expect(screen.getByTestId('error')).toHaveTextContent(control.validationMessage);
     });
 
-    it('installs a custom error that resolves while disabled', async () => {
-      let resolveValidate: ((value: string | null) => void) | undefined;
-      const validate = vi.fn(
-        () =>
-          new Promise<string | null>((resolve) => {
-            resolveValidate = resolve;
-          }),
-      );
-
-      function App({ disabled }: { disabled: boolean }) {
-        return (
-          <Field.Root
-            data-testid="root"
-            validationMode="onChange"
-            validate={validate}
-            disabled={disabled}
-          >
-            <Field.Control data-testid="control" />
-            <Field.Error data-testid="error" />
-          </Field.Root>
-        );
-      }
-
-      const { setProps } = await render(<App disabled={false} />);
-      const control = screen.getByTestId<HTMLInputElement>('control');
-
-      fireEvent.change(control, { target: { value: 'abc' } });
-
-      await setProps({ disabled: true });
-
-      await act(async () => {
-        resolveValidate?.('Username is taken');
-        await flushMicrotasks();
-      });
-
-      await setProps({ disabled: false });
-
-      expect(screen.getByTestId('error')).toHaveTextContent('Username is taken');
-      expect(control.validationMessage).toBe('Username is taken');
-      expect(control.checkValidity()).toBe(false);
-    });
-
     it('drops a pending validation when a disabled control is replaced', async () => {
       let resolveValidate: ((value: string | null) => void) | undefined;
       const validate = vi.fn(

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -1972,6 +1972,42 @@ describe('<Field.Root />', () => {
       expect(screen.getByTestId('root')).not.toHaveAttribute('data-invalid');
     });
 
+    it('keeps a pending debounced validation when the control is disabled', async () => {
+      const validate = vi.fn(() => 'error');
+
+      function App({ disabled }: { disabled: boolean }) {
+        return (
+          <Field.Root
+            data-testid="root"
+            validationDebounceTime={100}
+            validationMode="onChange"
+            validate={validate}
+            disabled={disabled}
+          >
+            <Field.Control data-testid="control" />
+            <Field.Error data-testid="error" />
+          </Field.Root>
+        );
+      }
+
+      const { setProps } = await renderFakeTimers(<App disabled={false} />);
+
+      fireEvent.change(screen.getByTestId('control'), { target: { value: 'abc' } });
+
+      clock.tick(99);
+
+      await setProps({ disabled: true });
+
+      clock.tick(100);
+
+      expect(validate).toHaveBeenCalledTimes(1);
+
+      await setProps({ disabled: false });
+
+      expect(screen.getByTestId('error')).toHaveTextContent('error');
+      expect(screen.getByTestId('root')).toHaveAttribute('data-invalid', '');
+    });
+
     it('ignores async validation results superseded during debounce', async () => {
       const resolvers: Record<string, (value: string | null) => void> = {};
       const validate = vi.fn((value) => {

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -2132,6 +2132,92 @@ describe('<Field.Root />', () => {
       expect(screen.getByTestId('root')).toHaveAttribute('data-invalid', '');
     });
 
+    it('keeps a native constraint failure when the validator resolves while disabled', async () => {
+      let resolveValidate: ((value: string | null) => void) | undefined;
+      const validate = vi.fn(
+        () =>
+          new Promise<string | null>((resolve) => {
+            resolveValidate = resolve;
+          }),
+      );
+
+      function App({ disabled }: { disabled: boolean }) {
+        return (
+          <Field.Root
+            data-testid="root"
+            validationMode="onChange"
+            validate={validate}
+            disabled={disabled}
+          >
+            <Field.Control type="email" data-testid="control" />
+            <Field.Error data-testid="error" />
+          </Field.Root>
+        );
+      }
+
+      const { setProps } = await render(<App disabled={false} />);
+      const control = screen.getByTestId<HTMLInputElement>('control');
+
+      fireEvent.change(control, { target: { value: 'not-an-email' } });
+      expect(screen.getByTestId('root')).toHaveAttribute('data-invalid', '');
+
+      await setProps({ disabled: true });
+
+      await act(async () => {
+        resolveValidate?.(null);
+        await flushMicrotasks();
+      });
+
+      await setProps({ disabled: false });
+
+      expect(control.validity.typeMismatch).toBe(true);
+      expect(screen.getByTestId('root')).toHaveAttribute('data-invalid', '');
+      expect(control).toHaveAttribute('aria-invalid', 'true');
+      expect(screen.getByTestId('error')).toHaveTextContent(control.validationMessage);
+    });
+
+    it('installs a custom error that resolves while disabled', async () => {
+      let resolveValidate: ((value: string | null) => void) | undefined;
+      const validate = vi.fn(
+        () =>
+          new Promise<string | null>((resolve) => {
+            resolveValidate = resolve;
+          }),
+      );
+
+      function App({ disabled }: { disabled: boolean }) {
+        return (
+          <Field.Root
+            data-testid="root"
+            validationMode="onChange"
+            validate={validate}
+            disabled={disabled}
+          >
+            <Field.Control data-testid="control" />
+            <Field.Error data-testid="error" />
+          </Field.Root>
+        );
+      }
+
+      const { setProps } = await render(<App disabled={false} />);
+      const control = screen.getByTestId<HTMLInputElement>('control');
+
+      fireEvent.change(control, { target: { value: 'abc' } });
+
+      await setProps({ disabled: true });
+
+      await act(async () => {
+        resolveValidate?.('Username is taken');
+        await flushMicrotasks();
+      });
+
+      await setProps({ disabled: false });
+
+      expect(screen.getByTestId('error')).toHaveTextContent('Username is taken');
+      expect(control.validationMessage).toBe('Username is taken');
+      expect(control.checkValidity()).toBe(false);
+    });
+
     it('drops a pending validation when a disabled control is replaced', async () => {
       let resolveValidate: ((value: string | null) => void) | undefined;
       const validate = vi.fn(

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -2057,6 +2057,84 @@ describe('<Field.Root />', () => {
       expect(screen.getByTestId('root')).not.toHaveAttribute('data-invalid');
     });
 
+    it('keeps a pending validation when the control is disabled', async () => {
+      let resolveValidate: ((value: string | null) => void) | undefined;
+      const validate = vi.fn(
+        () =>
+          new Promise<string | null>((resolve) => {
+            resolveValidate = resolve;
+          }),
+      );
+
+      function App({ disabled }: { disabled: boolean }) {
+        return (
+          <Form onSubmit={(event) => event.preventDefault()}>
+            <Field.Root data-testid="root" name="username" validate={validate} disabled={disabled}>
+              <Field.Control data-testid="control" />
+              <Field.Error data-testid="error" />
+            </Field.Root>
+            <button type="submit">submit</button>
+          </Form>
+        );
+      }
+
+      const { setProps } = await render(<App disabled={false} />);
+
+      fireEvent.click(screen.getByText('submit'));
+      expect(validate).toHaveBeenCalledTimes(1);
+
+      await setProps({ disabled: true });
+
+      await act(async () => {
+        resolveValidate?.('Username is taken');
+        await flushMicrotasks();
+      });
+
+      await setProps({ disabled: false });
+
+      expect(screen.getByTestId('error')).toHaveTextContent('Username is taken');
+      expect(screen.getByTestId('root')).toHaveAttribute('data-invalid', '');
+    });
+
+    it('drops a pending validation when a disabled control is replaced', async () => {
+      let resolveValidate: ((value: string | null) => void) | undefined;
+      const validate = vi.fn(
+        () =>
+          new Promise<string | null>((resolve) => {
+            resolveValidate = resolve;
+          }),
+      );
+
+      function App({ disabled, controlKey }: { disabled: boolean; controlKey: string }) {
+        return (
+          <Form onSubmit={(event) => event.preventDefault()}>
+            <Field.Root data-testid="root" name="username" validate={validate} disabled={disabled}>
+              <Field.Control key={controlKey} data-testid="control" />
+              <Field.Error data-testid="error" />
+            </Field.Root>
+            <button type="submit">submit</button>
+          </Form>
+        );
+      }
+
+      const { setProps } = await render(<App disabled={false} controlKey="a" />);
+
+      fireEvent.click(screen.getByText('submit'));
+      expect(validate).toHaveBeenCalledTimes(1);
+
+      await setProps({ disabled: true, controlKey: 'a' });
+      await setProps({ disabled: true, controlKey: 'b' });
+      await setProps({ disabled: false, controlKey: 'b' });
+
+      await act(async () => {
+        resolveValidate?.('Username is taken');
+        await flushMicrotasks();
+      });
+
+      expect(screen.queryByTestId('error')).toBe(null);
+      expect(screen.getByTestId('root')).not.toHaveAttribute('data-invalid');
+    });
+
     it('keeps the published error when async validation rejects', async () => {
       const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
       let commit: ((value: unknown) => Promise<void>) | undefined;

--- a/packages/react/src/field/root/FieldRoot.test.tsx
+++ b/packages/react/src/field/root/FieldRoot.test.tsx
@@ -1972,42 +1972,6 @@ describe('<Field.Root />', () => {
       expect(screen.getByTestId('root')).not.toHaveAttribute('data-invalid');
     });
 
-    it('keeps a pending debounced validation when the control is disabled', async () => {
-      const validate = vi.fn(() => 'error');
-
-      function App({ disabled }: { disabled: boolean }) {
-        return (
-          <Field.Root
-            data-testid="root"
-            validationDebounceTime={100}
-            validationMode="onChange"
-            validate={validate}
-            disabled={disabled}
-          >
-            <Field.Control data-testid="control" />
-            <Field.Error data-testid="error" />
-          </Field.Root>
-        );
-      }
-
-      const { setProps } = await renderFakeTimers(<App disabled={false} />);
-
-      fireEvent.change(screen.getByTestId('control'), { target: { value: 'abc' } });
-
-      clock.tick(99);
-
-      await setProps({ disabled: true });
-
-      clock.tick(100);
-
-      expect(validate).toHaveBeenCalledTimes(1);
-
-      await setProps({ disabled: false });
-
-      expect(screen.getByTestId('error')).toHaveTextContent('error');
-      expect(screen.getByTestId('root')).toHaveAttribute('data-invalid', '');
-    });
-
     it('ignores async validation results superseded during debounce', async () => {
       const resolvers: Record<string, (value: string | null) => void> = {};
       const validate = vi.fn((value) => {
@@ -2104,19 +2068,22 @@ describe('<Field.Root />', () => {
 
       function App({ disabled }: { disabled: boolean }) {
         return (
-          <Form onSubmit={(event) => event.preventDefault()}>
-            <Field.Root data-testid="root" name="username" validate={validate} disabled={disabled}>
-              <Field.Control data-testid="control" />
-              <Field.Error data-testid="error" />
-            </Field.Root>
-            <button type="submit">submit</button>
-          </Form>
+          <Field.Root
+            data-testid="root"
+            validationMode="onChange"
+            validate={validate}
+            disabled={disabled}
+          >
+            <Field.Control data-testid="control" />
+            <Field.Error data-testid="error" />
+          </Field.Root>
         );
       }
 
       const { setProps } = await render(<App disabled={false} />);
+      const control = screen.getByTestId<HTMLInputElement>('control');
 
-      fireEvent.click(screen.getByText('submit'));
+      fireEvent.change(control, { target: { value: 'abc' } });
       expect(validate).toHaveBeenCalledTimes(1);
 
       await setProps({ disabled: true });
@@ -2130,6 +2097,8 @@ describe('<Field.Root />', () => {
 
       expect(screen.getByTestId('error')).toHaveTextContent('Username is taken');
       expect(screen.getByTestId('root')).toHaveAttribute('data-invalid', '');
+      expect(control.validationMessage).toBe('Username is taken');
+      expect(control.checkValidity()).toBe(false);
     });
 
     it('keeps a native constraint failure when the validator resolves while disabled', async () => {
@@ -2187,19 +2156,21 @@ describe('<Field.Root />', () => {
 
       function App({ disabled, controlKey }: { disabled: boolean; controlKey: string }) {
         return (
-          <Form onSubmit={(event) => event.preventDefault()}>
-            <Field.Root data-testid="root" name="username" validate={validate} disabled={disabled}>
-              <Field.Control key={controlKey} data-testid="control" />
-              <Field.Error data-testid="error" />
-            </Field.Root>
-            <button type="submit">submit</button>
-          </Form>
+          <Field.Root
+            data-testid="root"
+            validationMode="onChange"
+            validate={validate}
+            disabled={disabled}
+          >
+            <Field.Control key={controlKey} data-testid="control" />
+            <Field.Error data-testid="error" />
+          </Field.Root>
         );
       }
 
       const { setProps } = await render(<App disabled={false} controlKey="a" />);
 
-      fireEvent.click(screen.getByText('submit'));
+      fireEvent.change(screen.getByTestId('control'), { target: { value: 'abc' } });
       expect(validate).toHaveBeenCalledTimes(1);
 
       await setProps({ disabled: true, controlKey: 'a' });

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -323,23 +323,28 @@ export function useFieldValidation(
         if (validationCommitId !== validationCommitIdRef.current) {
           return;
         }
-        nextState = refreshState();
+        // A control barred mid-flight (for example disabled) exposes no native state, so keep
+        // the verdict and native errors captured while it could still validate.
+        if (resolveRepresentativeInput()?.willValidate) {
+          nextState = refreshState();
+        }
       } else {
         result = resultOrPromise;
       }
 
+      const nativeErrors = validationErrors;
       // Empty results and empty array entries are valid.
       validationErrors = result ? ([] as string[]).concat(result).filter(Boolean) : [];
 
       if (validationErrors.length > 0) {
         nextState.valid = false;
         nextState.customError = true;
-        // Keep custom errors for barred controls in field state only.
-        if (element?.willValidate) {
+        // A barred control hides the message until it can validate again.
+        if (element) {
           setCustomValidity(element, validationErrors.join('\n'));
         }
       } else {
-        validationErrors = getNativeErrors(element);
+        validationErrors = element?.willValidate ? getNativeErrors(element) : nativeErrors;
       }
     }
 

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -297,6 +297,7 @@ export function useFieldValidation(
         return acc;
       }, {} as Form.Values);
 
+      const elementWasValidatable = element?.willValidate;
       const resultOrPromise = validate(value, formValues);
       let result: string | string[] | null | void;
 
@@ -339,8 +340,7 @@ export function useFieldValidation(
       if (validationErrors.length > 0) {
         nextState.valid = false;
         nextState.customError = true;
-        // Keep custom errors for barred controls in field state only.
-        if (element?.willValidate) {
+        if (element && (elementWasValidatable || element.willValidate)) {
           setCustomValidity(element, validationErrors.join('\n'));
         }
       } else {

--- a/packages/react/src/field/root/useFieldValidation.ts
+++ b/packages/react/src/field/root/useFieldValidation.ts
@@ -339,8 +339,8 @@ export function useFieldValidation(
       if (validationErrors.length > 0) {
         nextState.valid = false;
         nextState.customError = true;
-        // A barred control hides the message until it can validate again.
-        if (element) {
+        // Keep custom errors for barred controls in field state only.
+        if (element?.willValidate) {
           setCustomValidity(element, validationErrors.join('\n'));
         }
       } else {

--- a/packages/react/src/internals/field-register-control/useFieldControlRegistration.ts
+++ b/packages/react/src/internals/field-register-control/useFieldControlRegistration.ts
@@ -131,12 +131,11 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
   }, [formRef]);
 
   const register = useStableCallback(
-    (source: symbol, registration: FieldControlRegistration | undefined, unmounted = false) => {
+    (source: symbol, registration: FieldControlRegistration | undefined, keepOwnership = false) => {
       if (!registration) {
         if (activeFieldControlSourceRef.current === source) {
-          // A disabled control keeps ownership: its pending result still publishes (and shows once
-          // re-enabled), and a later unmount or replacement can still identify and drop that work.
-          if (unmounted) {
+          // A disabled control keeps ownership so its pending validation can finish.
+          if (!keepOwnership) {
             activeFieldControlSourceRef.current = null;
             change(undefined, true);
           }

--- a/packages/react/src/internals/field-register-control/useFieldControlRegistration.ts
+++ b/packages/react/src/internals/field-register-control/useFieldControlRegistration.ts
@@ -134,8 +134,8 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
     (source: symbol, registration: FieldControlRegistration | undefined, unmounted = false) => {
       if (!registration) {
         if (activeFieldControlSourceRef.current === source) {
-          // A disabled control keeps ownership: its pending validation publishes once re-enabled,
-          // and a later unmount or replacement can still identify and drop that work.
+          // A disabled control keeps ownership: its pending result still publishes (and shows once
+          // re-enabled), and a later unmount or replacement can still identify and drop that work.
           if (unmounted) {
             activeFieldControlSourceRef.current = null;
             change(undefined, true);

--- a/packages/react/src/internals/field-register-control/useFieldControlRegistration.ts
+++ b/packages/react/src/internals/field-register-control/useFieldControlRegistration.ts
@@ -131,11 +131,15 @@ export function useFieldControlRegistration(params: UseFieldControlRegistrationP
   }, [formRef]);
 
   const register = useStableCallback(
-    (source: symbol, registration: FieldControlRegistration | undefined) => {
+    (source: symbol, registration: FieldControlRegistration | undefined, unmounted = false) => {
       if (!registration) {
         if (activeFieldControlSourceRef.current === source) {
-          activeFieldControlSourceRef.current = null;
-          change(undefined, true);
+          // A disabled control keeps ownership: its pending validation publishes once re-enabled,
+          // and a later unmount or replacement can still identify and drop that work.
+          if (unmounted) {
+            activeFieldControlSourceRef.current = null;
+            change(undefined, true);
+          }
           deleteRegistration();
           registrationRef.current = null;
           setRegisteredFieldName(undefined);

--- a/packages/react/src/internals/field-register-control/useRegisterFieldControl.ts
+++ b/packages/react/src/internals/field-register-control/useRegisterFieldControl.ts
@@ -22,7 +22,7 @@ export function useRegisterFieldControl(
     const source = sourceRef.current;
 
     if (!enabled) {
-      registerFieldControl(source, undefined);
+      registerFieldControl(source, undefined, true);
       return;
     }
 
@@ -40,7 +40,7 @@ export function useRegisterFieldControl(
   useIsoLayoutEffect(() => {
     const source = sourceRef.current;
     return () => {
-      registerFieldControl(source, undefined, true);
+      registerFieldControl(source, undefined);
     };
   }, [registerFieldControl, sourceRef]);
 }

--- a/packages/react/src/internals/field-register-control/useRegisterFieldControl.ts
+++ b/packages/react/src/internals/field-register-control/useRegisterFieldControl.ts
@@ -40,7 +40,7 @@ export function useRegisterFieldControl(
   useIsoLayoutEffect(() => {
     const source = sourceRef.current;
     return () => {
-      registerFieldControl(source, undefined);
+      registerFieldControl(source, undefined, true);
     };
   }, [registerFieldControl, sourceRef]);
 }

--- a/packages/react/src/internals/field-root-context/FieldRootContext.ts
+++ b/packages/react/src/internals/field-root-context/FieldRootContext.ts
@@ -25,7 +25,7 @@ export interface FieldRootContext {
   registerFieldControl: (
     source: symbol,
     registration: FieldControlRegistration | undefined,
-    unmounted?: boolean,
+    keepOwnership?: boolean,
   ) => void;
   validation: UseFieldValidationReturnValue;
 }

--- a/packages/react/src/internals/field-root-context/FieldRootContext.ts
+++ b/packages/react/src/internals/field-root-context/FieldRootContext.ts
@@ -25,6 +25,7 @@ export interface FieldRootContext {
   registerFieldControl: (
     source: symbol,
     registration: FieldControlRegistration | undefined,
+    unmounted?: boolean,
   ) => void;
   validation: UseFieldValidationReturnValue;
 }


### PR DESCRIPTION
Regression from #5449.

Disabling a field (`Field.Root`, `Field.Control`, or `Fieldset` `disabled`) unregisters its control, and since #5449 that unregister path cancelled any in-flight async `validate` result or pending debounced commit. A field disabled while a server check was pending came back neutral, and the error never showed until the next edit or submit. In 1.7.0 the pending result still published and appeared once the field was re-enabled.

## Changes

- Disabling now only removes the form registration. The control keeps source ownership and its pending validation, which publishes as before.
- Only the control's unmount cleanup passes the new `unmounted` flag, which clears ownership and cancels pending work. Replacement by a different control still cancels through the existing ownership-transfer branch.
- Keeping ownership while disabled matters: a disabled control that is later unmounted or swapped can still identify itself and drop its stale result, so it cannot land on the replacement control.
- Added regression tests for both sequences: disabled-then-re-enabled publishes the result, and disabled-then-replaced drops it.
