### PR TITLE
[docs] Add alternate link to Markdown page version

### DIFF
--- a/docs/src/components/Subtitle/MarkdownLink.tsx
+++ b/docs/src/components/Subtitle/MarkdownLink.tsx
@@ -1,22 +1,28 @@
 'use client';
+import * as React from 'react';
 import { usePathname } from 'next/navigation';
 import { MarkdownIcon } from '../../icons/MarkdownIcon';
 
 export function MarkdownLink() {
   const pathname = usePathname();
+  const markdownUrl = `${pathname}.md`;
 
   return (
-    <a
-      href={`${pathname}.md`}
-      className="SubtitleLink"
-      aria-label="View markdown source"
-      rel="alternate"
-      type="text/markdown"
-    >
-      <span className="SubtitleLinkText">
-        <MarkdownIcon />
-        View as Markdown
-      </span>
-    </a>
+    <React.Fragment>
+      {/* Hoisted to <head> by React so crawlers and AI agents discover the Markdown twin */}
+      <link rel="alternate" type="text/markdown" href={markdownUrl} />
+      <a
+        href={markdownUrl}
+        className="SubtitleLink"
+        aria-label="View markdown source"
+        rel="alternate"
+        type="text/markdown"
+      >
+        <span className="SubtitleLinkText">
+          <MarkdownIcon />
+          View as Markdown
+        </span>
+      </a>
+    </React.Fragment>
   );
 }


### PR DESCRIPTION


Emits `<link rel="alternate" type="text/markdown">` alongside the "View as Markdown" link. React hoists it into `<head>`, so crawlers and AI agents can discover the Markdown twin of each docs page.