### PR TITLE
[combobox][docs] Add screen reader hints to the multiple-select demos

### DIFF
--- a/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/css-modules/index.tsx
@@ -138,38 +138,41 @@ export default function ExampleAsyncMultipleCombobox() {
           Assign reviewers
         </label>
         <Combobox.InputGroup className={styles.InputGroup}>
-          <Combobox.Chips className={styles.Chips}>
-            <Combobox.Value>
-              {(value: DirectoryUser[]) => (
-                <React.Fragment>
-                  {value.map((user) => (
-                    <Combobox.Chip
-                      key={user.id}
-                      className={styles.Chip}
-                      aria-label={user.name}
-                      aria-description="Press Backspace or Delete to remove"
+          <Combobox.Value>
+            {(value: DirectoryUser[]) => (
+              <Combobox.Chips
+                className={styles.Chips}
+                aria-label={value.length > 0 ? 'Selected reviewers' : undefined}
+              >
+                {value.map((user) => (
+                  <Combobox.Chip
+                    key={user.id}
+                    className={styles.Chip}
+                    aria-label={user.name}
+                    aria-description="Press Backspace or Delete to remove"
+                  >
+                    {user.name}
+                    <Combobox.ChipRemove
+                      className={styles.ChipRemove}
+                      aria-label={`Remove ${user.name}`}
                     >
-                      {user.name}
-                      <Combobox.ChipRemove
-                        className={styles.ChipRemove}
-                        aria-label={`Remove ${user.name}`}
-                      >
-                        <XIcon />
-                      </Combobox.ChipRemove>
-                    </Combobox.Chip>
-                  ))}
-                  <Combobox.Input
-                    id={id}
-                    placeholder={value.length > 0 ? '' : 'e.g. Michael'}
-                    aria-description={
-                      value.length > 0 ? 'Press Left Arrow to edit the selected items' : undefined
-                    }
-                    className={styles.Input}
-                  />
-                </React.Fragment>
-              )}
-            </Combobox.Value>
-          </Combobox.Chips>
+                      <XIcon />
+                    </Combobox.ChipRemove>
+                  </Combobox.Chip>
+                ))}
+                <Combobox.Input
+                  id={id}
+                  placeholder={value.length > 0 ? '' : 'e.g. Michael'}
+                  aria-description={
+                    value.length > 0
+                      ? `${value.length} selected. From the start of the input, press Left Arrow to focus the selected items`
+                      : undefined
+                  }
+                  className={styles.Input}
+                />
+              </Combobox.Chips>
+            )}
+          </Combobox.Value>
         </Combobox.InputGroup>
       </div>
 

--- a/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/css-modules/index.tsx
@@ -143,7 +143,12 @@ export default function ExampleAsyncMultipleCombobox() {
               {(value: DirectoryUser[]) => (
                 <React.Fragment>
                   {value.map((user) => (
-                    <Combobox.Chip key={user.id} className={styles.Chip} aria-label={user.name}>
+                    <Combobox.Chip
+                      key={user.id}
+                      className={styles.Chip}
+                      aria-label={user.name}
+                      aria-description="Press Backspace or Delete to remove"
+                    >
                       {user.name}
                       <Combobox.ChipRemove
                         className={styles.ChipRemove}
@@ -156,6 +161,9 @@ export default function ExampleAsyncMultipleCombobox() {
                   <Combobox.Input
                     id={id}
                     placeholder={value.length > 0 ? '' : 'e.g. Michael'}
+                    aria-description={
+                      value.length > 0 ? 'Press Left Arrow to edit the selected items' : undefined
+                    }
                     className={styles.Input}
                   />
                 </React.Fragment>

--- a/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/tailwind/index.tsx
@@ -143,38 +143,41 @@ export default function ExampleAsyncMultipleCombobox() {
           Assign reviewers
         </label>
         <Combobox.InputGroup className="flex min-h-8 w-64 cursor-text flex-wrap items-center gap-0.5 border border-neutral-950 bg-white dark:bg-neutral-950 px-2 py-1 focus-within:outline-2 focus-within:-outline-offset-1 focus-within:outline-neutral-950 dark:focus-within:outline-white has-[button]:px-1 dark:border-white min-[32rem]:w-[22rem]">
-          <Combobox.Chips className="flex w-full flex-wrap items-center gap-1">
-            <Combobox.Value>
-              {(value: DirectoryUser[]) => (
-                <React.Fragment>
-                  {value.map((user) => (
-                    <Combobox.Chip
-                      key={user.id}
-                      className="group flex min-h-[calc(1.5rem-2px)] cursor-default items-center gap-1 overflow-hidden bg-neutral-100 py-0 pr-[0.2rem] pl-[0.4rem] text-sm leading-none text-neutral-950 outline-none focus-within:bg-neutral-950 focus-within:text-white [@media(hover:hover)]:data-highlighted:bg-neutral-950 [@media(hover:hover)]:data-highlighted:text-white dark:bg-neutral-800 dark:text-white dark:focus-within:bg-white dark:focus-within:text-neutral-950 dark:[@media(hover:hover)]:data-highlighted:bg-white dark:[@media(hover:hover)]:data-highlighted:text-neutral-950"
-                      aria-label={user.name}
-                      aria-description="Press Backspace or Delete to remove"
+          <Combobox.Value>
+            {(value: DirectoryUser[]) => (
+              <Combobox.Chips
+                className="flex w-full flex-wrap items-center gap-1"
+                aria-label={value.length > 0 ? 'Selected reviewers' : undefined}
+              >
+                {value.map((user) => (
+                  <Combobox.Chip
+                    key={user.id}
+                    className="group flex min-h-[calc(1.5rem-2px)] cursor-default items-center gap-1 overflow-hidden bg-neutral-100 py-0 pr-[0.2rem] pl-[0.4rem] text-sm leading-none text-neutral-950 outline-none focus-within:bg-neutral-950 focus-within:text-white [@media(hover:hover)]:data-highlighted:bg-neutral-950 [@media(hover:hover)]:data-highlighted:text-white dark:bg-neutral-800 dark:text-white dark:focus-within:bg-white dark:focus-within:text-neutral-950 dark:[@media(hover:hover)]:data-highlighted:bg-white dark:[@media(hover:hover)]:data-highlighted:text-neutral-950"
+                    aria-label={user.name}
+                    aria-description="Press Backspace or Delete to remove"
+                  >
+                    {user.name}
+                    <Combobox.ChipRemove
+                      className="flex size-4 items-center justify-center border-0 bg-transparent p-0 text-inherit hover:bg-neutral-200 group-focus-within:hover:bg-neutral-700 dark:hover:bg-neutral-700 dark:group-focus-within:hover:bg-neutral-200"
+                      aria-label={`Remove ${user.name}`}
                     >
-                      {user.name}
-                      <Combobox.ChipRemove
-                        className="flex size-4 items-center justify-center border-0 bg-transparent p-0 text-inherit hover:bg-neutral-200 group-focus-within:hover:bg-neutral-700 dark:hover:bg-neutral-700 dark:group-focus-within:hover:bg-neutral-200"
-                        aria-label={`Remove ${user.name}`}
-                      >
-                        <XIcon />
-                      </Combobox.ChipRemove>
-                    </Combobox.Chip>
-                  ))}
-                  <Combobox.Input
-                    id={id}
-                    placeholder={value.length > 0 ? '' : 'e.g. Michael'}
-                    aria-description={
-                      value.length > 0 ? 'Press Left Arrow to edit the selected items' : undefined
-                    }
-                    className="h-[calc(1.5rem-2px)] min-w-12 flex-1 border-0 bg-white p-0 text-sm any-pointer-coarse:text-base dark:bg-neutral-950 font-normal text-neutral-950 outline-none placeholder:text-neutral-500 dark:placeholder:text-neutral-400 dark:text-white"
-                  />
-                </React.Fragment>
-              )}
-            </Combobox.Value>
-          </Combobox.Chips>
+                      <XIcon />
+                    </Combobox.ChipRemove>
+                  </Combobox.Chip>
+                ))}
+                <Combobox.Input
+                  id={id}
+                  placeholder={value.length > 0 ? '' : 'e.g. Michael'}
+                  aria-description={
+                    value.length > 0
+                      ? `${value.length} selected. From the start of the input, press Left Arrow to focus the selected items`
+                      : undefined
+                  }
+                  className="h-[calc(1.5rem-2px)] min-w-12 flex-1 border-0 bg-white p-0 text-sm any-pointer-coarse:text-base dark:bg-neutral-950 font-normal text-neutral-950 outline-none placeholder:text-neutral-500 dark:placeholder:text-neutral-400 dark:text-white"
+                />
+              </Combobox.Chips>
+            )}
+          </Combobox.Value>
         </Combobox.InputGroup>
       </div>
 

--- a/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/async-multiple/tailwind/index.tsx
@@ -152,6 +152,7 @@ export default function ExampleAsyncMultipleCombobox() {
                       key={user.id}
                       className="group flex min-h-[calc(1.5rem-2px)] cursor-default items-center gap-1 overflow-hidden bg-neutral-100 py-0 pr-[0.2rem] pl-[0.4rem] text-sm leading-none text-neutral-950 outline-none focus-within:bg-neutral-950 focus-within:text-white [@media(hover:hover)]:data-highlighted:bg-neutral-950 [@media(hover:hover)]:data-highlighted:text-white dark:bg-neutral-800 dark:text-white dark:focus-within:bg-white dark:focus-within:text-neutral-950 dark:[@media(hover:hover)]:data-highlighted:bg-white dark:[@media(hover:hover)]:data-highlighted:text-neutral-950"
                       aria-label={user.name}
+                      aria-description="Press Backspace or Delete to remove"
                     >
                       {user.name}
                       <Combobox.ChipRemove
@@ -165,6 +166,9 @@ export default function ExampleAsyncMultipleCombobox() {
                   <Combobox.Input
                     id={id}
                     placeholder={value.length > 0 ? '' : 'e.g. Michael'}
+                    aria-description={
+                      value.length > 0 ? 'Press Left Arrow to edit the selected items' : undefined
+                    }
                     className="h-[calc(1.5rem-2px)] min-w-12 flex-1 border-0 bg-white p-0 text-sm any-pointer-coarse:text-base dark:bg-neutral-950 font-normal text-neutral-950 outline-none placeholder:text-neutral-500 dark:placeholder:text-neutral-400 dark:text-white"
                   />
                 </React.Fragment>

--- a/docs/src/app/(docs)/react/components/combobox/demos/creatable/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/creatable/css-modules/index.tsx
@@ -127,36 +127,43 @@ export default function ExampleCreatableCombobox() {
             Labels
           </label>
           <Combobox.InputGroup className={styles.InputGroup}>
-            <Combobox.Chips className={styles.Chips}>
-              <Combobox.Value>
-                {(value: LabelItem[]) => (
-                  <React.Fragment>
-                    {value.map((label) => (
-                      <Combobox.Chip
-                        key={label.id}
-                        className={styles.Chip}
-                        aria-label={label.value}
+            <Combobox.Value>
+              {(value: LabelItem[]) => (
+                <Combobox.Chips
+                  className={styles.Chips}
+                  aria-label={value.length > 0 ? 'Selected labels' : undefined}
+                >
+                  {value.map((label) => (
+                    <Combobox.Chip
+                      key={label.id}
+                      className={styles.Chip}
+                      aria-label={label.value}
+                      aria-description="Press Backspace or Delete to remove"
+                    >
+                      {label.value}
+                      <Combobox.ChipRemove
+                        className={styles.ChipRemove}
+                        aria-label={`Remove ${label.value}`}
                       >
-                        {label.value}
-                        <Combobox.ChipRemove
-                          className={styles.ChipRemove}
-                          aria-label={`Remove ${label.value}`}
-                        >
-                          <XIcon />
-                        </Combobox.ChipRemove>
-                      </Combobox.Chip>
-                    ))}
-                    <Combobox.Input
-                      ref={comboboxInputRef}
-                      id={id}
-                      placeholder={value.length > 0 ? '' : 'e.g. bug'}
-                      className={styles.Input}
-                      onKeyDown={handleInputKeyDown}
-                    />
-                  </React.Fragment>
-                )}
-              </Combobox.Value>
-            </Combobox.Chips>
+                        <XIcon />
+                      </Combobox.ChipRemove>
+                    </Combobox.Chip>
+                  ))}
+                  <Combobox.Input
+                    ref={comboboxInputRef}
+                    id={id}
+                    placeholder={value.length > 0 ? '' : 'e.g. bug'}
+                    aria-description={
+                      value.length > 0
+                        ? `${value.length} selected. From the start of the input, press Left Arrow to focus the selected items`
+                        : undefined
+                    }
+                    className={styles.Input}
+                    onKeyDown={handleInputKeyDown}
+                  />
+                </Combobox.Chips>
+              )}
+            </Combobox.Value>
           </Combobox.InputGroup>
         </div>
 

--- a/docs/src/app/(docs)/react/components/combobox/demos/creatable/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/creatable/tailwind/index.tsx
@@ -129,36 +129,43 @@ export default function ExampleCreatableCombobox() {
             Labels
           </label>
           <Combobox.InputGroup className="flex min-h-8 w-64 cursor-text flex-wrap items-center gap-0.5 border border-neutral-950 bg-white dark:bg-neutral-950 px-2 py-1 focus-within:outline-2 focus-within:-outline-offset-1 focus-within:outline-neutral-950 dark:focus-within:outline-white has-[button]:px-1 dark:border-white min-[32rem]:w-[22rem]">
-            <Combobox.Chips className="flex w-full flex-wrap items-center gap-1">
-              <Combobox.Value>
-                {(value: LabelItem[]) => (
-                  <React.Fragment>
-                    {value.map((label) => (
-                      <Combobox.Chip
-                        key={label.id}
-                        className="group flex min-h-[calc(1.5rem-2px)] cursor-default items-center gap-1 overflow-hidden bg-neutral-100 py-0 pr-[0.2rem] pl-[0.4rem] text-sm leading-none text-neutral-950 outline-none focus-within:bg-neutral-950 focus-within:text-white [@media(hover:hover)]:data-highlighted:bg-neutral-950 [@media(hover:hover)]:data-highlighted:text-white dark:bg-neutral-800 dark:text-white dark:focus-within:bg-white dark:focus-within:text-neutral-950 dark:[@media(hover:hover)]:data-highlighted:bg-white dark:[@media(hover:hover)]:data-highlighted:text-neutral-950"
-                        aria-label={label.value}
+            <Combobox.Value>
+              {(value: LabelItem[]) => (
+                <Combobox.Chips
+                  className="flex w-full flex-wrap items-center gap-1"
+                  aria-label={value.length > 0 ? 'Selected labels' : undefined}
+                >
+                  {value.map((label) => (
+                    <Combobox.Chip
+                      key={label.id}
+                      className="group flex min-h-[calc(1.5rem-2px)] cursor-default items-center gap-1 overflow-hidden bg-neutral-100 py-0 pr-[0.2rem] pl-[0.4rem] text-sm leading-none text-neutral-950 outline-none focus-within:bg-neutral-950 focus-within:text-white [@media(hover:hover)]:data-highlighted:bg-neutral-950 [@media(hover:hover)]:data-highlighted:text-white dark:bg-neutral-800 dark:text-white dark:focus-within:bg-white dark:focus-within:text-neutral-950 dark:[@media(hover:hover)]:data-highlighted:bg-white dark:[@media(hover:hover)]:data-highlighted:text-neutral-950"
+                      aria-label={label.value}
+                      aria-description="Press Backspace or Delete to remove"
+                    >
+                      {label.value}
+                      <Combobox.ChipRemove
+                        className="flex size-4 items-center justify-center border-0 bg-transparent p-0 text-inherit hover:bg-neutral-200 group-focus-within:hover:bg-neutral-700 dark:hover:bg-neutral-700 dark:group-focus-within:hover:bg-neutral-200"
+                        aria-label={`Remove ${label.value}`}
                       >
-                        {label.value}
-                        <Combobox.ChipRemove
-                          className="flex size-4 items-center justify-center border-0 bg-transparent p-0 text-inherit hover:bg-neutral-200 group-focus-within:hover:bg-neutral-700 dark:hover:bg-neutral-700 dark:group-focus-within:hover:bg-neutral-200"
-                          aria-label={`Remove ${label.value}`}
-                        >
-                          <XIcon />
-                        </Combobox.ChipRemove>
-                      </Combobox.Chip>
-                    ))}
-                    <Combobox.Input
-                      ref={comboboxInputRef}
-                      id={id}
-                      placeholder={value.length > 0 ? '' : 'e.g. bug'}
-                      className="h-[calc(1.5rem-2px)] min-w-12 flex-1 border-0 bg-white p-0 text-sm any-pointer-coarse:text-base dark:bg-neutral-950 font-normal text-neutral-950 outline-none placeholder:text-neutral-500 dark:placeholder:text-neutral-400 dark:text-white"
-                      onKeyDown={handleInputKeyDown}
-                    />
-                  </React.Fragment>
-                )}
-              </Combobox.Value>
-            </Combobox.Chips>
+                        <XIcon />
+                      </Combobox.ChipRemove>
+                    </Combobox.Chip>
+                  ))}
+                  <Combobox.Input
+                    ref={comboboxInputRef}
+                    id={id}
+                    placeholder={value.length > 0 ? '' : 'e.g. bug'}
+                    aria-description={
+                      value.length > 0
+                        ? `${value.length} selected. From the start of the input, press Left Arrow to focus the selected items`
+                        : undefined
+                    }
+                    className="h-[calc(1.5rem-2px)] min-w-12 flex-1 border-0 bg-white p-0 text-sm any-pointer-coarse:text-base dark:bg-neutral-950 font-normal text-neutral-950 outline-none placeholder:text-neutral-500 dark:placeholder:text-neutral-400 dark:text-white"
+                    onKeyDown={handleInputKeyDown}
+                  />
+                </Combobox.Chips>
+              )}
+            </Combobox.Value>
           </Combobox.InputGroup>
         </div>
 

--- a/docs/src/app/(docs)/react/components/combobox/demos/multiple/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/multiple/css-modules/index.tsx
@@ -13,38 +13,41 @@ export default function ExampleMultipleCombobox() {
           Programming languages
         </label>
         <Combobox.InputGroup className={styles.InputGroup}>
-          <Combobox.Chips className={styles.Chips}>
-            <Combobox.Value>
-              {(value: ProgrammingLanguage[]) => (
-                <React.Fragment>
-                  {value.map((language) => (
-                    <Combobox.Chip
-                      key={language.id}
-                      className={styles.Chip}
-                      aria-label={language.value}
-                      aria-description="Press Backspace or Delete to remove"
+          <Combobox.Value>
+            {(value: ProgrammingLanguage[]) => (
+              <Combobox.Chips
+                className={styles.Chips}
+                aria-label={value.length > 0 ? 'Selected languages' : undefined}
+              >
+                {value.map((language) => (
+                  <Combobox.Chip
+                    key={language.id}
+                    className={styles.Chip}
+                    aria-label={language.value}
+                    aria-description="Press Backspace or Delete to remove"
+                  >
+                    {language.value}
+                    <Combobox.ChipRemove
+                      className={styles.ChipRemove}
+                      aria-label={`Remove ${language.value}`}
                     >
-                      {language.value}
-                      <Combobox.ChipRemove
-                        className={styles.ChipRemove}
-                        aria-label={`Remove ${language.value}`}
-                      >
-                        <XIcon />
-                      </Combobox.ChipRemove>
-                    </Combobox.Chip>
-                  ))}
-                  <Combobox.Input
-                    id={id}
-                    placeholder={value.length > 0 ? '' : 'e.g. TypeScript'}
-                    aria-description={
-                      value.length > 0 ? 'Press Left Arrow to edit the selected items' : undefined
-                    }
-                    className={styles.Input}
-                  />
-                </React.Fragment>
-              )}
-            </Combobox.Value>
-          </Combobox.Chips>
+                      <XIcon />
+                    </Combobox.ChipRemove>
+                  </Combobox.Chip>
+                ))}
+                <Combobox.Input
+                  id={id}
+                  placeholder={value.length > 0 ? '' : 'e.g. TypeScript'}
+                  aria-description={
+                    value.length > 0
+                      ? `${value.length} selected. From the start of the input, press Left Arrow to focus the selected items`
+                      : undefined
+                  }
+                  className={styles.Input}
+                />
+              </Combobox.Chips>
+            )}
+          </Combobox.Value>
         </Combobox.InputGroup>
       </div>
 

--- a/docs/src/app/(docs)/react/components/combobox/demos/multiple/css-modules/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/multiple/css-modules/index.tsx
@@ -22,6 +22,7 @@ export default function ExampleMultipleCombobox() {
                       key={language.id}
                       className={styles.Chip}
                       aria-label={language.value}
+                      aria-description="Press Backspace or Delete to remove"
                     >
                       {language.value}
                       <Combobox.ChipRemove
@@ -35,6 +36,9 @@ export default function ExampleMultipleCombobox() {
                   <Combobox.Input
                     id={id}
                     placeholder={value.length > 0 ? '' : 'e.g. TypeScript'}
+                    aria-description={
+                      value.length > 0 ? 'Press Left Arrow to edit the selected items' : undefined
+                    }
                     className={styles.Input}
                   />
                 </React.Fragment>

--- a/docs/src/app/(docs)/react/components/combobox/demos/multiple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/multiple/tailwind/index.tsx
@@ -24,6 +24,7 @@ export default function ExampleMultipleCombobox() {
                       key={language.id}
                       className="group flex min-h-[calc(1.5rem-2px)] cursor-default items-center gap-1 overflow-hidden bg-neutral-100 py-0 pr-[0.2rem] pl-[0.4rem] text-sm leading-none text-neutral-950 outline-none focus-within:bg-neutral-950 focus-within:text-white [@media(hover:hover)]:data-highlighted:bg-neutral-950 [@media(hover:hover)]:data-highlighted:text-white dark:bg-neutral-800 dark:text-white dark:focus-within:bg-white dark:focus-within:text-neutral-950 dark:[@media(hover:hover)]:data-highlighted:bg-white dark:[@media(hover:hover)]:data-highlighted:text-neutral-950"
                       aria-label={language.value}
+                      aria-description="Press Backspace or Delete to remove"
                     >
                       {language.value}
                       <Combobox.ChipRemove
@@ -37,6 +38,9 @@ export default function ExampleMultipleCombobox() {
                   <Combobox.Input
                     id={id}
                     placeholder={value.length > 0 ? '' : 'e.g. TypeScript'}
+                    aria-description={
+                      value.length > 0 ? 'Press Left Arrow to edit the selected items' : undefined
+                    }
                     className="h-[calc(1.5rem-2px)] min-w-12 flex-1 border-0 bg-white p-0 text-sm any-pointer-coarse:text-base dark:bg-neutral-950 font-normal text-neutral-950 outline-none placeholder:text-neutral-500 dark:placeholder:text-neutral-400 dark:text-white"
                   />
                 </React.Fragment>

--- a/docs/src/app/(docs)/react/components/combobox/demos/multiple/tailwind/index.tsx
+++ b/docs/src/app/(docs)/react/components/combobox/demos/multiple/tailwind/index.tsx
@@ -15,38 +15,41 @@ export default function ExampleMultipleCombobox() {
           Programming languages
         </label>
         <Combobox.InputGroup className="flex min-h-8 w-64 cursor-text flex-wrap items-center gap-0.5 border border-neutral-950 bg-white dark:bg-neutral-950 px-2 py-1 focus-within:outline-2 focus-within:-outline-offset-1 focus-within:outline-neutral-950 dark:focus-within:outline-white has-[button]:px-1 dark:border-white min-[32rem]:w-[22rem]">
-          <Combobox.Chips className="flex w-full flex-wrap items-center gap-1">
-            <Combobox.Value>
-              {(value: ProgrammingLanguage[]) => (
-                <React.Fragment>
-                  {value.map((language) => (
-                    <Combobox.Chip
-                      key={language.id}
-                      className="group flex min-h-[calc(1.5rem-2px)] cursor-default items-center gap-1 overflow-hidden bg-neutral-100 py-0 pr-[0.2rem] pl-[0.4rem] text-sm leading-none text-neutral-950 outline-none focus-within:bg-neutral-950 focus-within:text-white [@media(hover:hover)]:data-highlighted:bg-neutral-950 [@media(hover:hover)]:data-highlighted:text-white dark:bg-neutral-800 dark:text-white dark:focus-within:bg-white dark:focus-within:text-neutral-950 dark:[@media(hover:hover)]:data-highlighted:bg-white dark:[@media(hover:hover)]:data-highlighted:text-neutral-950"
-                      aria-label={language.value}
-                      aria-description="Press Backspace or Delete to remove"
+          <Combobox.Value>
+            {(value: ProgrammingLanguage[]) => (
+              <Combobox.Chips
+                className="flex w-full flex-wrap items-center gap-1"
+                aria-label={value.length > 0 ? 'Selected languages' : undefined}
+              >
+                {value.map((language) => (
+                  <Combobox.Chip
+                    key={language.id}
+                    className="group flex min-h-[calc(1.5rem-2px)] cursor-default items-center gap-1 overflow-hidden bg-neutral-100 py-0 pr-[0.2rem] pl-[0.4rem] text-sm leading-none text-neutral-950 outline-none focus-within:bg-neutral-950 focus-within:text-white [@media(hover:hover)]:data-highlighted:bg-neutral-950 [@media(hover:hover)]:data-highlighted:text-white dark:bg-neutral-800 dark:text-white dark:focus-within:bg-white dark:focus-within:text-neutral-950 dark:[@media(hover:hover)]:data-highlighted:bg-white dark:[@media(hover:hover)]:data-highlighted:text-neutral-950"
+                    aria-label={language.value}
+                    aria-description="Press Backspace or Delete to remove"
+                  >
+                    {language.value}
+                    <Combobox.ChipRemove
+                      className="flex size-4 items-center justify-center border-0 bg-transparent p-0 text-inherit hover:bg-neutral-200 group-focus-within:hover:bg-neutral-700 dark:hover:bg-neutral-700 dark:group-focus-within:hover:bg-neutral-200"
+                      aria-label={`Remove ${language.value}`}
                     >
-                      {language.value}
-                      <Combobox.ChipRemove
-                        className="flex size-4 items-center justify-center border-0 bg-transparent p-0 text-inherit hover:bg-neutral-200 group-focus-within:hover:bg-neutral-700 dark:hover:bg-neutral-700 dark:group-focus-within:hover:bg-neutral-200"
-                        aria-label={`Remove ${language.value}`}
-                      >
-                        <XIcon />
-                      </Combobox.ChipRemove>
-                    </Combobox.Chip>
-                  ))}
-                  <Combobox.Input
-                    id={id}
-                    placeholder={value.length > 0 ? '' : 'e.g. TypeScript'}
-                    aria-description={
-                      value.length > 0 ? 'Press Left Arrow to edit the selected items' : undefined
-                    }
-                    className="h-[calc(1.5rem-2px)] min-w-12 flex-1 border-0 bg-white p-0 text-sm any-pointer-coarse:text-base dark:bg-neutral-950 font-normal text-neutral-950 outline-none placeholder:text-neutral-500 dark:placeholder:text-neutral-400 dark:text-white"
-                  />
-                </React.Fragment>
-              )}
-            </Combobox.Value>
-          </Combobox.Chips>
+                      <XIcon />
+                    </Combobox.ChipRemove>
+                  </Combobox.Chip>
+                ))}
+                <Combobox.Input
+                  id={id}
+                  placeholder={value.length > 0 ? '' : 'e.g. TypeScript'}
+                  aria-description={
+                    value.length > 0
+                      ? `${value.length} selected. From the start of the input, press Left Arrow to focus the selected items`
+                      : undefined
+                  }
+                  className="h-[calc(1.5rem-2px)] min-w-12 flex-1 border-0 bg-white p-0 text-sm any-pointer-coarse:text-base dark:bg-neutral-950 font-normal text-neutral-950 outline-none placeholder:text-neutral-500 dark:placeholder:text-neutral-400 dark:text-white"
+                />
+              </Combobox.Chips>
+            )}
+          </Combobox.Value>
         </Combobox.InputGroup>
       </div>
 

--- a/docs/src/app/(docs)/react/components/combobox/page.mdx
+++ b/docs/src/app/(docs)/react/components/combobox/page.mdx
@@ -183,7 +183,7 @@ import { DemoComboboxMultiple } from './demos/multiple';
 
 <DemoComboboxMultiple />
 
-In order for screen readers to announce the chips and how to remove them, add `aria-description` to `<Combobox.Chip>` and `<Combobox.Input>`, alongside the `aria-label` on `<Combobox.ChipRemove>`.
+In order for screen readers to announce how to reach and remove the chips, add `aria-description` to `<Combobox.Chip>` and `<Combobox.Input>`, alongside the `aria-label` on `<Combobox.Chips>` and `<Combobox.ChipRemove>`.
 Base UI does not ship these strings. Translate them together with the rest of your interface.
 
 Visible chips can be limited by slicing the selected values rendered in `<Combobox.Value>`:
@@ -200,7 +200,7 @@ const CHIP_LIMIT = 3;
     return (
       <>
         {visibleValue.map((item) => (
-          <Combobox.Chip key={item}>
+          <Combobox.Chip key={item} aria-description="Press Backspace or Delete to remove">
             {item}
             <Combobox.ChipRemove aria-label={`Remove ${item}`} />
           </Combobox.Chip>
@@ -208,7 +208,13 @@ const CHIP_LIMIT = 3;
         {/* @highlight-start */}
         {hiddenCount > 0 && <span>{`+${hiddenCount} more`}</span>}
         {/* @highlight-end */}
-        <Combobox.Input />
+        <Combobox.Input
+          aria-description={
+            selectedValue.length > 0
+              ? `${selectedValue.length} selected. From the start of the input, press Left Arrow to focus the selected items`
+              : undefined
+          }
+        />
       </>
     );
   }}

--- a/docs/src/app/(docs)/react/components/combobox/page.mdx
+++ b/docs/src/app/(docs)/react/components/combobox/page.mdx
@@ -183,6 +183,9 @@ import { DemoComboboxMultiple } from './demos/multiple';
 
 <DemoComboboxMultiple />
 
+In order for screen readers to announce the chips and how to remove them, add `aria-description` to `<Combobox.Chip>` and `<Combobox.Input>`, alongside the `aria-label` on `<Combobox.ChipRemove>`.
+Base UI does not ship these strings. Translate them together with the rest of your interface.
+
 Visible chips can be limited by slicing the selected values rendered in `<Combobox.Value>`:
 
 ```tsx title="Limiting visible chips"


### PR DESCRIPTION
In `multiple` mode, screen reader users get no hint that selected chips exist, that Left Arrow from the input reaches them, or that Backspace/Delete removes a focused chip. The chips have no role, so nothing is announced beyond the chip text and the nested remove button.

This adds `aria-description` in the `multiple` and `async-multiple` demos (CSS Modules and Tailwind): "Press Backspace or Delete to remove" on each `<Combobox.Chip>`, and "Press Left Arrow to edit the selected items" on `<Combobox.Input>` while the value is non-empty. A short note under the demo says these are app strings to translate.

The library ships no user-facing text, so the hints live in the demos only. `aria-description` is used over `aria-describedby` because Safari 17+ is the support floor. String-free library improvements (a role on `Combobox.Chip`, `aria-keyshortcuts`, Enter on a focused chip) are left for a separate issue.