### PR TITLE
[floating-ui] Preserve pointer modality for untyped clicks

### DIFF
--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.test.tsx
@@ -1576,6 +1576,51 @@ describe('FloatingFocusManager', () => {
         }
       });
 
+      test('preserves the last pointer modality when a click has an empty pointer type', async () => {
+        const finalFocus = vi.fn((_closeType: InteractionType) => true);
+
+        function App() {
+          const [isOpen, setIsOpen] = React.useState(false);
+
+          const { refs, context } = useFloating({
+            open: isOpen,
+            onOpenChange: setIsOpen,
+          });
+
+          const click = useClick(context);
+          const { getReferenceProps, getFloatingProps } = useTestInteractions([click]);
+
+          return (
+            <>
+              <button data-testid="reference" ref={refs.setReference} {...getReferenceProps()} />
+              <FloatingFocusManager context={context} disabled={!isOpen} returnFocus={finalFocus}>
+                <div ref={refs.setFloating} {...getFloatingProps()}>
+                  <button data-testid="child" />
+                </div>
+              </FloatingFocusManager>
+            </>
+          );
+        }
+
+        render(<App />);
+
+        const reference = screen.getByTestId('reference');
+        await userEvent.click(reference);
+        await waitFor(() => {
+          expect(screen.getByTestId('child')).toHaveFocus();
+        });
+
+        fireEvent.pointerDown(reference, { pointerType: 'mouse' });
+        fireEvent(
+          reference,
+          new PointerEvent('click', { bubbles: true, cancelable: true, pointerType: '' }),
+        );
+
+        await waitFor(() => {
+          expect(finalFocus).toHaveBeenCalledWith('mouse');
+        });
+      });
+
       test('preserves keyboard close modality when reopening before focus restoration', async () => {
         function App() {
           const [isOpen, setIsOpen] = React.useState(false);

--- a/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
+++ b/packages/react/src/floating-ui-react/components/FloatingFocusManager.tsx
@@ -57,7 +57,9 @@ function getEventType(event: Event, lastInteractionType?: InteractionType): Inte
     return lastInteractionType || 'keyboard';
   }
   if ('pointerType' in event) {
-    return (event.pointerType as React.PointerEvent['pointerType']) || 'keyboard';
+    return (
+      (event.pointerType as React.PointerEvent['pointerType']) || lastInteractionType || 'keyboard'
+    );
   }
   if ('touches' in event) {
     return 'touch';


### PR DESCRIPTION
A pointer click can legitimately have an empty pointerType. Preserve the preceding pointer interaction in that case instead of classifying the close as keyboard-driven.

#5630 provides the dependency-level reproduction: resolving @testing-library/user-event 14.6.6 causes the Dialog and Popover finalFocus tests to fail without this change.

Includes a focused regression test that dispatches an empty-pointerType click after a mouse pointerdown.