### PR TITLE
[slider] End a cancelled touch drag without committing

### DIFF
--- a/packages/react/src/slider/control/SliderControl.test.tsx
+++ b/packages/react/src/slider/control/SliderControl.test.tsx
@@ -5,6 +5,17 @@ import { Slider } from '@base-ui/react/slider';
 import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
 import { createTouches, getHorizontalSliderRect } from '../utils/test-utils';
 
+// jsdom has no pointer capture API.
+function stubPointerCapture(control: HTMLElement) {
+  const releasePointerCapture = vi.fn();
+  Object.defineProperties(control, {
+    setPointerCapture: { configurable: true, value: vi.fn() },
+    hasPointerCapture: { configurable: true, value: () => true },
+    releasePointerCapture: { configurable: true, value: releasePointerCapture },
+  });
+  return releasePointerCapture;
+}
+
 describe('<Slider.Control />', () => {
   const { render } = createRenderer();
 
@@ -203,6 +214,137 @@ describe('<Slider.Control />', () => {
 
     expect(releasePointerCapture).toHaveBeenCalledWith(7);
   });
+
+  it('does not commit a cancelled drag on the next unrelated pointerup', async () => {
+    const onValueCommitted = vi.fn();
+
+    await render(
+      <Slider.Root defaultValue={20} onValueCommitted={onValueCommitted}>
+        <Slider.Control data-testid="control">
+          <Slider.Thumb />
+        </Slider.Control>
+      </Slider.Root>,
+    );
+
+    const control = screen.getByTestId('control');
+    vi.spyOn(control, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+    const releasePointerCapture = stubPointerCapture(control);
+
+    const touch = { pointerId: 3, pointerType: 'touch' };
+    fireEvent.pointerDown(control, { ...touch, button: 0, buttons: 1, clientX: 20 });
+    fireEvent.pointerMove(document.body, { ...touch, buttons: 1, clientX: 70 });
+    expect(control).toHaveAttribute('data-dragging');
+
+    fireEvent.pointerCancel(document.body, { ...touch, buttons: 0, clientX: 70 });
+
+    expect(onValueCommitted).not.toHaveBeenCalled();
+    expect(releasePointerCapture).toHaveBeenCalledWith(3);
+    expect(control).not.toHaveAttribute('data-dragging');
+
+    // Tap somewhere else on the page.
+    fireEvent.pointerUp(document.body, { ...touch, buttons: 0, clientX: 90 });
+
+    expect(onValueCommitted).not.toHaveBeenCalled();
+  });
+
+  it('starts a fresh drag after a cancelled one and commits it once', async () => {
+    const onValueCommitted = vi.fn();
+
+    await render(
+      <Slider.Root defaultValue={20} onValueCommitted={onValueCommitted}>
+        <Slider.Control data-testid="control">
+          <Slider.Thumb />
+        </Slider.Control>
+      </Slider.Root>,
+    );
+
+    const control = screen.getByTestId('control');
+    vi.spyOn(control, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+    stubPointerCapture(control);
+
+    fireEvent.pointerDown(control, { button: 0, buttons: 1, clientX: 20 });
+    fireEvent.pointerMove(document.body, { buttons: 1, clientX: 70 });
+    // Browsers may deliver the cancellation more than once (pointercancel + touchcancel).
+    fireEvent.pointerCancel(document.body, { buttons: 0, clientX: 70 });
+    fireEvent.pointerCancel(document.body, { buttons: 0, clientX: 70 });
+    // Tap somewhere else on the page.
+    fireEvent.pointerUp(document.body, { buttons: 0, clientX: 90 });
+
+    expect(onValueCommitted).not.toHaveBeenCalled();
+
+    fireEvent.pointerDown(control, { button: 0, buttons: 1, clientX: 30 });
+    fireEvent.pointerMove(document.body, { buttons: 1, clientX: 40 });
+    fireEvent.pointerUp(document.body, { buttons: 0, clientX: 40 });
+
+    expect(onValueCommitted).toHaveBeenCalledTimes(1);
+    expect(onValueCommitted).toHaveBeenCalledWith(40, expect.objectContaining({ reason: 'drag' }));
+  });
+
+  it('commits a released drag exactly once', async () => {
+    const onValueCommitted = vi.fn();
+
+    await render(
+      <Slider.Root defaultValue={20} onValueCommitted={onValueCommitted}>
+        <Slider.Control data-testid="control">
+          <Slider.Thumb />
+        </Slider.Control>
+      </Slider.Root>,
+    );
+
+    const control = screen.getByTestId('control');
+    vi.spyOn(control, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+    stubPointerCapture(control);
+
+    fireEvent.pointerDown(control, { button: 0, buttons: 1, clientX: 20 });
+    fireEvent.pointerMove(document.body, { buttons: 1, clientX: 70 });
+    fireEvent.pointerUp(document.body, { buttons: 0, clientX: 70 });
+
+    expect(onValueCommitted).toHaveBeenCalledTimes(1);
+    expect(onValueCommitted).toHaveBeenCalledWith(70, expect.objectContaining({ reason: 'drag' }));
+
+    fireEvent.pointerCancel(document.body, { buttons: 0, clientX: 70 });
+    fireEvent.pointerUp(document.body, { buttons: 0, clientX: 90 });
+
+    expect(onValueCommitted).toHaveBeenCalledTimes(1);
+  });
+
+  it.skipIf(isJSDOM || typeof Touch === 'undefined')(
+    'does not commit a drag ended by touchcancel on the next unrelated touchend',
+    async () => {
+      const onValueCommitted = vi.fn();
+
+      await render(
+        <Slider.Root defaultValue={20} onValueCommitted={onValueCommitted}>
+          <Slider.Control data-testid="control">
+            <Slider.Thumb />
+          </Slider.Control>
+        </Slider.Root>,
+      );
+
+      const control = screen.getByTestId('control');
+      vi.spyOn(control, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+
+      fireEvent.touchStart(control, createTouches([{ identifier: 1, clientX: 20, clientY: 0 }]));
+      fireEvent.touchMove(
+        document.body,
+        createTouches([{ identifier: 1, clientX: 70, clientY: 0 }]),
+      );
+      fireEvent.touchCancel(
+        document.body,
+        createTouches([{ identifier: 1, clientX: 70, clientY: 0 }]),
+      );
+
+      expect(onValueCommitted).not.toHaveBeenCalled();
+
+      fireEvent.touchEnd(
+        document.body,
+        createTouches([{ identifier: 2, clientX: 90, clientY: 0 }]),
+      );
+      fireEvent.pointerUp(document.body, { pointerType: 'touch', buttons: 0, clientX: 90 });
+
+      expect(onValueCommitted).not.toHaveBeenCalled();
+    },
+  );
 
   it('degrades safely when a custom render function drops the control ref', async () => {
     const onValueChange = vi.fn();

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -151,6 +151,13 @@ export const SliderControl = React.forwardRef(function SliderControl(
     pressedThumbCenterOffsetRef.current = null;
   }
 
+  function releaseCapture(nativeEvent: TouchEvent | PointerEvent) {
+    const control = controlRef.current;
+    if ('pointerType' in nativeEvent && control?.hasPointerCapture(nativeEvent.pointerId)) {
+      control.releasePointerCapture(nativeEvent.pointerId);
+    }
+  }
+
   function isTargetDisabledThumb(target: EventTarget | null) {
     if (!isElement(target)) {
       return false;
@@ -365,14 +372,23 @@ export const SliderControl = React.forwardRef(function SliderControl(
       );
     }
 
-    if (
-      'pointerType' in nativeEvent &&
-      controlRef.current?.hasPointerCapture(nativeEvent.pointerId)
-    ) {
-      controlRef.current?.releasePointerCapture(nativeEvent.pointerId);
-    }
+    releaseCapture(nativeEvent);
 
     pressedThumbIndexRef.current = -1;
+    touchIdRef.current = null;
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    stopListening();
+  });
+
+  // The browser took the touch away (scroll, system gesture, second finger). End the
+  // interaction without committing; the next unrelated tap must not commit the drag value.
+  const handleTouchCancel = useStableCallback((nativeEvent: TouchEvent | PointerEvent) => {
+    setActive(-1);
+    setDragging(false);
+
+    releaseCapture(nativeEvent);
+
+    resetPressedThumb();
     touchIdRef.current = null;
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     stopListening();
@@ -411,14 +427,17 @@ export const SliderControl = React.forwardRef(function SliderControl(
     const doc = ownerDocument(controlRef.current);
     doc.addEventListener('touchmove', handleTouchMove, { passive: true });
     doc.addEventListener('touchend', handleTouchEnd, { passive: true });
+    doc.addEventListener('touchcancel', handleTouchCancel, { passive: true });
   });
 
   const stopListening = useStableCallback(() => {
     const doc = ownerDocument(controlRef.current);
     doc.removeEventListener('pointermove', handleTouchMove);
     doc.removeEventListener('pointerup', handleTouchEnd);
+    doc.removeEventListener('pointercancel', handleTouchCancel);
     doc.removeEventListener('touchmove', handleTouchMove);
     doc.removeEventListener('touchend', handleTouchEnd);
+    doc.removeEventListener('touchcancel', handleTouchCancel);
     pressedValuesRef.current = null;
     currentInteractionValueRef.current = null;
   });
@@ -512,6 +531,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
           const doc = ownerDocument(control);
           doc.addEventListener('pointermove', handleTouchMove, { passive: true });
           doc.addEventListener('pointerup', handleTouchEnd, { once: true });
+          doc.addEventListener('pointercancel', handleTouchCancel, { once: true });
         },
       },
       elementProps,


### PR DESCRIPTION
<!-- mui-orc:6452558d-d714-4b71-8913-a657b1a17b10:fix -->
Fixes #5637

A drag ended by `pointercancel`/`touchcancel` never reached `handleTouchEnd`, so the document `pointerup` listener stayed armed and `currentInteractionValueRef` kept the last dragged value. The next tap anywhere on the page committed that stale value from an unrelated `pointerup`.

Changes:
- Register `pointercancel` (with the `pointerup` listener) and `touchcancel` (with the `touchend` listener) on the document.
- Route both to a new `handleTouchCancel` that clears active/dragging state, resets the pressed thumb and touch id, releases held pointer capture, and calls `stopListening()` without committing. `stopListening()` already drops the pending interaction value, and it removes all listeners on first call, so duplicate cancel events are no-ops.
- Extract the pointer-capture release into `releaseCapture()` shared by end and cancel handlers.
- `stopListening()` also removes both cancel listeners.

Tests (`SliderControl.test.tsx`):
- cancelled drag then unrelated tap: no commit, capture released, `data-dragging` cleared
- duplicate cancel events, tap elsewhere, then a fresh drag commits exactly once
- normal release commits exactly once; later cancel/up does nothing
- Chromium only: `touchcancel` path followed by unrelated `touchend`/`pointerup`

The first two fail on master.

Fixes #5637