### PR TITLE
[slider] End the drag on pointercancel/touchcancel without committing

### DIFF
--- a/packages/react/src/slider/control/SliderControl.test.tsx
+++ b/packages/react/src/slider/control/SliderControl.test.tsx
@@ -277,6 +277,209 @@ describe('<Slider.Control />', () => {
     },
   );
 
+  describe('cancelled gestures', () => {
+    function CancelTestSlider(props: {
+      onValueChange: (value: number | number[]) => void;
+      onValueCommitted: (value: number | number[], details: unknown) => void;
+    }) {
+      return (
+        <React.Fragment>
+          <Slider.Root defaultValue={20} {...props}>
+            <Slider.Control data-testid="control">
+              <Slider.Thumb />
+            </Slider.Control>
+          </Slider.Root>
+          <div data-testid="elsewhere" />
+        </React.Fragment>
+      );
+    }
+
+    it.skipIf(isJSDOM)(
+      'ends the drag on pointercancel without committing the pending value',
+      async () => {
+        const onValueChange = vi.fn();
+        const onValueCommitted = vi.fn();
+
+        await render(
+          <CancelTestSlider onValueChange={onValueChange} onValueCommitted={onValueCommitted} />,
+        );
+
+        const control = screen.getByTestId('control');
+        const elsewhere = screen.getByTestId('elsewhere');
+        vi.spyOn(control, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+        const releasePointerCapture = vi.fn();
+        Object.defineProperties(control, {
+          setPointerCapture: { configurable: true, value: vi.fn() },
+          hasPointerCapture: { configurable: true, value: () => true },
+          releasePointerCapture: { configurable: true, value: releasePointerCapture },
+        });
+
+        const pointer = { pointerId: 7, pointerType: 'touch' };
+
+        fireEvent.pointerDown(control, { ...pointer, button: 0, buttons: 1, clientX: 40 });
+        fireEvent.pointerMove(document.body, { ...pointer, buttons: 1, clientX: 70 });
+
+        expect(onValueChange).toHaveBeenLastCalledWith(
+          70,
+          expect.objectContaining({ reason: 'drag' }),
+        );
+        expect(control).toHaveAttribute('data-dragging', '');
+
+        fireEvent.pointerCancel(document.body, { ...pointer, buttons: 0, clientX: 70 });
+
+        expect(onValueCommitted).not.toHaveBeenCalled();
+        expect(releasePointerCapture).toHaveBeenCalledWith(7);
+        expect(control).not.toHaveAttribute('data-dragging');
+
+        onValueChange.mockClear();
+
+        // The document listeners are gone: a later, unrelated pointer must be ignored.
+        fireEvent.pointerMove(elsewhere, { ...pointer, buttons: 1, clientX: 90 });
+        fireEvent.pointerUp(elsewhere, { ...pointer, buttons: 0, clientX: 90 });
+
+        expect(onValueChange).not.toHaveBeenCalled();
+        expect(onValueCommitted).not.toHaveBeenCalled();
+
+        // A fresh gesture on the slider still commits normally.
+        fireEvent.pointerDown(control, { ...pointer, button: 0, buttons: 1, clientX: 50 });
+        fireEvent.pointerMove(document.body, { ...pointer, buttons: 1, clientX: 60 });
+        fireEvent.pointerUp(document.body, { ...pointer, buttons: 0, clientX: 60 });
+
+        expect(onValueCommitted).toHaveBeenCalledTimes(1);
+        expect(onValueCommitted).toHaveBeenCalledWith(
+          60,
+          expect.objectContaining({ reason: 'drag' }),
+        );
+      },
+    );
+
+    it.skipIf(isJSDOM || typeof Touch === 'undefined')(
+      'ends the drag on touchcancel without committing the pending value',
+      async () => {
+        const onValueChange = vi.fn();
+        const onValueCommitted = vi.fn();
+
+        await render(
+          <CancelTestSlider onValueChange={onValueChange} onValueCommitted={onValueCommitted} />,
+        );
+
+        const control = screen.getByTestId('control');
+        const elsewhere = screen.getByTestId('elsewhere');
+        vi.spyOn(control, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+
+        fireEvent.touchStart(control, createTouches([{ identifier: 1, clientX: 40, clientY: 0 }]));
+        for (const clientX of [50, 60, 70]) {
+          fireEvent.touchMove(
+            document.body,
+            createTouches([{ identifier: 1, clientX, clientY: 0 }]),
+          );
+        }
+
+        expect(onValueChange).toHaveBeenLastCalledWith(
+          70,
+          expect.objectContaining({ reason: 'drag' }),
+        );
+        expect(control).toHaveAttribute('data-dragging', '');
+
+        fireEvent.touchCancel(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 70, clientY: 0 }]),
+        );
+
+        expect(onValueCommitted).not.toHaveBeenCalled();
+        expect(control).not.toHaveAttribute('data-dragging');
+
+        onValueChange.mockClear();
+
+        // The document listeners are gone: a later, unrelated touch must be ignored.
+        fireEvent.touchMove(elsewhere, createTouches([{ identifier: 1, clientX: 90, clientY: 0 }]));
+        fireEvent.touchEnd(elsewhere, createTouches([{ identifier: 1, clientX: 90, clientY: 0 }]));
+
+        expect(onValueChange).not.toHaveBeenCalled();
+        expect(onValueCommitted).not.toHaveBeenCalled();
+
+        // A fresh gesture on the slider still commits normally.
+        fireEvent.touchStart(control, createTouches([{ identifier: 2, clientX: 50, clientY: 0 }]));
+        fireEvent.touchMove(
+          document.body,
+          createTouches([{ identifier: 2, clientX: 60, clientY: 0 }]),
+        );
+        fireEvent.touchEnd(
+          document.body,
+          createTouches([{ identifier: 2, clientX: 60, clientY: 0 }]),
+        );
+
+        expect(onValueCommitted).toHaveBeenCalledTimes(1);
+        expect(onValueCommitted).toHaveBeenCalledWith(
+          60,
+          expect.objectContaining({ reason: 'drag' }),
+        );
+      },
+    );
+
+    it.skipIf(isJSDOM || typeof Touch === 'undefined')(
+      'handles a cancellation delivered through both pointer and touch events',
+      async () => {
+        const onValueChange = vi.fn();
+        const onValueCommitted = vi.fn();
+
+        await render(
+          <CancelTestSlider onValueChange={onValueChange} onValueCommitted={onValueCommitted} />,
+        );
+
+        const control = screen.getByTestId('control');
+        const elsewhere = screen.getByTestId('elsewhere');
+        vi.spyOn(control, 'getBoundingClientRect').mockImplementation(getHorizontalSliderRect);
+
+        const pointer = { pointerType: 'touch' };
+
+        // Browsers dispatch both models for a single finger.
+        fireEvent.touchStart(control, createTouches([{ identifier: 1, clientX: 40, clientY: 0 }]));
+        fireEvent.pointerDown(control, { ...pointer, button: 0, buttons: 1, clientX: 40 });
+        for (const clientX of [50, 60, 70]) {
+          fireEvent.touchMove(
+            document.body,
+            createTouches([{ identifier: 1, clientX, clientY: 0 }]),
+          );
+          fireEvent.pointerMove(document.body, { ...pointer, buttons: 1, clientX });
+        }
+
+        expect(onValueChange).toHaveBeenLastCalledWith(
+          70,
+          expect.objectContaining({ reason: 'drag' }),
+        );
+
+        fireEvent.pointerCancel(document.body, { ...pointer, buttons: 0, clientX: 70 });
+        fireEvent.touchCancel(
+          document.body,
+          createTouches([{ identifier: 1, clientX: 70, clientY: 0 }]),
+        );
+
+        expect(onValueCommitted).not.toHaveBeenCalled();
+        expect(control).not.toHaveAttribute('data-dragging');
+
+        onValueChange.mockClear();
+
+        fireEvent.pointerUp(elsewhere, { ...pointer, buttons: 0, clientX: 90 });
+        fireEvent.touchEnd(elsewhere, createTouches([{ identifier: 1, clientX: 90, clientY: 0 }]));
+
+        expect(onValueChange).not.toHaveBeenCalled();
+        expect(onValueCommitted).not.toHaveBeenCalled();
+
+        // A fresh gesture on the slider still commits normally.
+        fireEvent.pointerDown(control, { ...pointer, button: 0, buttons: 1, clientX: 50 });
+        fireEvent.pointerMove(document.body, { ...pointer, buttons: 1, clientX: 60 });
+        fireEvent.pointerUp(document.body, { ...pointer, buttons: 0, clientX: 60 });
+
+        expect(onValueCommitted).toHaveBeenCalledTimes(1);
+        expect(onValueCommitted).toHaveBeenCalledWith(
+          60,
+          expect.objectContaining({ reason: 'drag' }),
+        );
+      },
+    );
+  });
+
   // Requires layout: the range drag relies on real thumb measurements.
   it.skipIf(isJSDOM)(
     'does not resurrect a removed thumb value when the range shrinks mid-drag',

--- a/packages/react/src/slider/control/SliderControl.tsx
+++ b/packages/react/src/slider/control/SliderControl.tsx
@@ -343,12 +343,29 @@ export const SliderControl = React.forwardRef(function SliderControl(
     }
   });
 
-  const handleTouchEnd = useStableCallback((nativeEvent: TouchEvent | PointerEvent) => {
+  /**
+   * Tears down the current press/drag without committing a value. Safe to call more than once,
+   * which matters when a browser reports the same cancellation through both the pointer and
+   * touch event models.
+   */
+  const endInteraction = useStableCallback((nativeEvent: TouchEvent | PointerEvent) => {
     setActive(-1);
     setDragging(false);
 
-    pressedThumbCenterOffsetRef.current = null;
+    if (
+      'pointerType' in nativeEvent &&
+      controlRef.current?.hasPointerCapture(nativeEvent.pointerId)
+    ) {
+      controlRef.current?.releasePointerCapture(nativeEvent.pointerId);
+    }
 
+    resetPressedThumb();
+    touchIdRef.current = null;
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    stopListening();
+  });
+
+  const handleTouchEnd = useStableCallback((nativeEvent: TouchEvent | PointerEvent) => {
     // If the value array shrank or grew mid-drag, the cached interaction value no longer
     // matches the current thumbs (the pressed index can still be in range), so dropping it
     // keeps a stale or malformed array from being committed on release.
@@ -365,17 +382,15 @@ export const SliderControl = React.forwardRef(function SliderControl(
       );
     }
 
-    if (
-      'pointerType' in nativeEvent &&
-      controlRef.current?.hasPointerCapture(nativeEvent.pointerId)
-    ) {
-      controlRef.current?.releasePointerCapture(nativeEvent.pointerId);
-    }
+    endInteraction(nativeEvent);
+  });
 
-    pressedThumbIndexRef.current = -1;
-    touchIdRef.current = null;
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    stopListening();
+  // The browser ends a gesture with `pointercancel`/`touchcancel` instead of `pointerup`/`touchend`
+  // when something else claims the pointer (scrolling, a system gesture, a second finger, a
+  // context menu). The drag is over at that point: drop the pending value and disarm the document
+  // listeners so an unrelated later `pointerup` cannot commit it.
+  const handleTouchCancel = useStableCallback((nativeEvent: TouchEvent | PointerEvent) => {
+    endInteraction(nativeEvent);
   });
 
   const handleTouchStart = useStableCallback((nativeEvent: TouchEvent) => {
@@ -411,14 +426,17 @@ export const SliderControl = React.forwardRef(function SliderControl(
     const doc = ownerDocument(controlRef.current);
     doc.addEventListener('touchmove', handleTouchMove, { passive: true });
     doc.addEventListener('touchend', handleTouchEnd, { passive: true });
+    doc.addEventListener('touchcancel', handleTouchCancel, { passive: true });
   });
 
   const stopListening = useStableCallback(() => {
     const doc = ownerDocument(controlRef.current);
     doc.removeEventListener('pointermove', handleTouchMove);
     doc.removeEventListener('pointerup', handleTouchEnd);
+    doc.removeEventListener('pointercancel', handleTouchCancel);
     doc.removeEventListener('touchmove', handleTouchMove);
     doc.removeEventListener('touchend', handleTouchEnd);
+    doc.removeEventListener('touchcancel', handleTouchCancel);
     pressedValuesRef.current = null;
     currentInteractionValueRef.current = null;
   });
@@ -512,6 +530,7 @@ export const SliderControl = React.forwardRef(function SliderControl(
           const doc = ownerDocument(control);
           doc.addEventListener('pointermove', handleTouchMove, { passive: true });
           doc.addEventListener('pointerup', handleTouchEnd, { once: true });
+          doc.addEventListener('pointercancel', handleTouchCancel, { once: true });
         },
       },
       elementProps,


### PR DESCRIPTION
<!-- mui-orc:84fa6ee0-62b2-45a3-b976-f56e5ef9df72:fix -->
Closes #5637

## Problem

`SliderControl` armed document `pointermove`/`pointerup` and `touchmove`/`touchend` listeners when a press started, but nothing listened for `pointercancel` or `touchcancel`. When the browser cancelled a touch drag (scroll takeover, system gesture, second finger, long-press menu), the listeners stayed armed and `currentInteractionValueRef` kept the last dragged value. The next `pointerup` anywhere on the page, from any target, ran `handleTouchEnd` and fired `onValueCommitted` with the stale value.

## Fix

- Extracted the non-commit teardown from `handleTouchEnd` into a shared `endInteraction` helper: resets active/dragging state, releases pointer capture when held, clears the pressed-thumb index/offset and touch id, and calls `stopListening()` (which already removes every document listener and nulls the pending-commit and pressed-values refs). It is idempotent, so browsers that report the same cancellation through both `pointercancel` and `touchcancel` are handled safely.
- `handleTouchEnd` now commits the pending value (unchanged logic, including the range-length guard) and then delegates to `endInteraction`.
- Added `handleTouchCancel`, which calls `endInteraction` without committing.
- Registered `pointercancel` (`{ once: true }`) next to `pointerup` in `onPointerDown`, and `touchcancel` (passive) next to `touchend` in the native `touchstart` handler. Both are removed in `stopListening()`.

Normal release and `details.cancel()` behavior are untouched; the existing slider suites still pass.

## Tests

Added a `cancelled gestures` block to `SliderControl.test.tsx` (Chromium only, since the touch cases need the `Touch` constructor) covering:

- `pointercancel` mid-drag: no `onValueCommitted`, pointer capture released, `data-dragging` cleared, a later move/up on an unrelated element produces no callbacks, and a fresh drag on the slider commits normally.
- `touchcancel` mid-drag: same assertions through the touch event model.
- Combined delivery (`pointercancel` then `touchcancel` for one finger): single clean teardown, no callbacks from a later outside tap, fresh gesture commits normally.

All three fail on the previous source and pass with the fix.

Fixes #5637