### PR TITLE
[radio] Prevent ignored arrow keys from selecting on refocus

### DIFF
--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -650,48 +650,35 @@ describe('<RadioGroup />', () => {
   });
 
   describe('should manage arrow key navigation', () => {
-    describe.each([false, true])('ignored arrows (nativeButton: %s)', (nativeButton) => {
-      it.each(['metaKey', 'ctrlKey', 'altKey', 'single'])(
-        'does not select on refocus after %s',
-        async (scenario) => {
-          const onValueChange = vi.fn();
-          const { user } = await render(
-            <React.Fragment>
-              <RadioGroup defaultValue="" onValueChange={onValueChange}>
-                <Radio.Root
-                  value="a"
-                  aria-label="A"
-                  nativeButton={nativeButton}
-                  render={nativeButton ? <button type="button" /> : <div />}
-                />
-                <Radio.Root
-                  value="b"
-                  aria-label="B"
-                  disabled={scenario === 'single'}
-                  nativeButton={nativeButton}
-                  render={nativeButton ? <button type="button" /> : <div />}
-                />
-              </RadioGroup>
-              <button>Outside</button>
-            </React.Fragment>,
-          );
-          const radio = screen.getByRole('radio', { name: 'A' });
-          act(() => radio.focus());
-          fireEvent.keyDown(radio, {
-            key: 'ArrowDown',
-            ...(scenario === 'single' ? {} : { [scenario]: true }),
-          });
-          expect(radio).toHaveFocus();
-          expect(radio).toHaveAttribute('aria-checked', 'false');
-          await user.tab();
-          expect(screen.getByRole('button', { name: 'Outside' })).toHaveFocus();
-          await user.tab({ shift: true });
-          expect(radio).toHaveFocus();
-          expect(radio).toHaveAttribute('aria-checked', 'false');
-          expect(onValueChange).not.toHaveBeenCalled();
-        },
-      );
-    });
+    it.each(['metaKey', 'ctrlKey', 'altKey', 'single'])(
+      'does not select on refocus after an ignored arrow (%s)',
+      async (scenario) => {
+        const onValueChange = vi.fn();
+        const { user } = await render(
+          <React.Fragment>
+            <RadioGroup onValueChange={onValueChange}>
+              <Radio.Root value="a" aria-label="A" />
+              <Radio.Root value="b" aria-label="B" disabled={scenario === 'single'} />
+            </RadioGroup>
+            <button>Outside</button>
+          </React.Fragment>,
+        );
+        const radio = screen.getByRole('radio', { name: 'A' });
+        act(() => radio.focus());
+        fireEvent.keyDown(radio, {
+          key: 'ArrowDown',
+          ...(scenario === 'single' ? {} : { [scenario]: true }),
+        });
+        expect(radio).toHaveFocus();
+        expect(radio).toHaveAttribute('aria-checked', 'false');
+        await user.tab();
+        expect(screen.getByRole('button', { name: 'Outside' })).toHaveFocus();
+        await user.tab({ shift: true });
+        expect(radio).toHaveFocus();
+        expect(radio).toHaveAttribute('aria-checked', 'false');
+        expect(onValueChange).not.toHaveBeenCalled();
+      },
+    );
 
     [
       ['ltr', 'ArrowRight', 'ArrowLeft'],

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -654,6 +654,7 @@ describe('<RadioGroup />', () => {
       'does not select on refocus after an ignored arrow (%s)',
       async (scenario) => {
         const onValueChange = vi.fn();
+
         const { user } = await render(
           <React.Fragment>
             <RadioGroup onValueChange={onValueChange}>
@@ -663,17 +664,25 @@ describe('<RadioGroup />', () => {
             <button>Outside</button>
           </React.Fragment>,
         );
+
         const radio = screen.getByRole('radio', { name: 'A' });
+
         act(() => radio.focus());
+
         fireEvent.keyDown(radio, {
           key: 'ArrowDown',
           ...(scenario === 'single' ? {} : { [scenario]: true }),
         });
+
         expect(radio).toHaveFocus();
         expect(radio).toHaveAttribute('aria-checked', 'false');
+
         await user.tab();
+
         expect(screen.getByRole('button', { name: 'Outside' })).toHaveFocus();
+
         await user.tab({ shift: true });
+
         expect(radio).toHaveFocus();
         expect(radio).toHaveAttribute('aria-checked', 'false');
         expect(onValueChange).not.toHaveBeenCalled();

--- a/packages/react/src/radio-group/RadioGroup.test.tsx
+++ b/packages/react/src/radio-group/RadioGroup.test.tsx
@@ -650,6 +650,49 @@ describe('<RadioGroup />', () => {
   });
 
   describe('should manage arrow key navigation', () => {
+    describe.each([false, true])('ignored arrows (nativeButton: %s)', (nativeButton) => {
+      it.each(['metaKey', 'ctrlKey', 'altKey', 'single'])(
+        'does not select on refocus after %s',
+        async (scenario) => {
+          const onValueChange = vi.fn();
+          const { user } = await render(
+            <React.Fragment>
+              <RadioGroup defaultValue="" onValueChange={onValueChange}>
+                <Radio.Root
+                  value="a"
+                  aria-label="A"
+                  nativeButton={nativeButton}
+                  render={nativeButton ? <button type="button" /> : <div />}
+                />
+                <Radio.Root
+                  value="b"
+                  aria-label="B"
+                  disabled={scenario === 'single'}
+                  nativeButton={nativeButton}
+                  render={nativeButton ? <button type="button" /> : <div />}
+                />
+              </RadioGroup>
+              <button>Outside</button>
+            </React.Fragment>,
+          );
+          const radio = screen.getByRole('radio', { name: 'A' });
+          act(() => radio.focus());
+          fireEvent.keyDown(radio, {
+            key: 'ArrowDown',
+            ...(scenario === 'single' ? {} : { [scenario]: true }),
+          });
+          expect(radio).toHaveFocus();
+          expect(radio).toHaveAttribute('aria-checked', 'false');
+          await user.tab();
+          expect(screen.getByRole('button', { name: 'Outside' })).toHaveFocus();
+          await user.tab({ shift: true });
+          expect(radio).toHaveFocus();
+          expect(radio).toHaveAttribute('aria-checked', 'false');
+          expect(onValueChange).not.toHaveBeenCalled();
+        },
+      );
+    });
+
     [
       ['ltr', 'ArrowRight', 'ArrowLeft'],
       ['rtl', 'ArrowLeft', 'ArrowRight'],

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -238,6 +238,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
     },
     onBlur(event) {
       if (!contains(event.currentTarget, event.relatedTarget)) {
+        setTouched(false);
         setFieldTouched(true);
         setFocused(false);
 
@@ -247,7 +248,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
       }
     },
     onKeyDownCapture(event) {
-      if (event.key.startsWith('Arrow')) {
+      if (event.key.startsWith('Arrow') && !event.altKey && !event.ctrlKey && !event.metaKey) {
         setTouched(true);
         setFocused(true);
       }

--- a/packages/react/src/radio-group/RadioGroup.tsx
+++ b/packages/react/src/radio-group/RadioGroup.tsx
@@ -248,7 +248,7 @@ export const RadioGroup = React.forwardRef(function RadioGroup<Value>(
       }
     },
     onKeyDownCapture(event) {
-      if (event.key.startsWith('Arrow') && !event.altKey && !event.ctrlKey && !event.metaKey) {
+      if (event.key.startsWith('Arrow')) {
         setTouched(true);
         setFocused(true);
       }


### PR DESCRIPTION
Fixes #5626.

## Problem

RadioGroup arms selection-on-focus for every arrow key, including Alt, Control, and Meta combinations that composite navigation ignores.

When focus does not move, the pending selection state survives leaving the group. Returning via Tab then selects a radio without an intentional selection action. This also occurs when only one radio is enabled.

## Changes

- Ignore Alt, Control, and Meta arrow combinations when arming selection-on-focus, while preserving Shift+arrow navigation.
- Clear the pending selection state when focus leaves the group.
- Add eight regression cases covering these modifier combinations and the single-enabled-radio case with both non-native and native button rendering.

## Verification

All eight new regression cases fail before the fix in both JSDOM and Chromium and pass after it.

- `pnpm test:jsdom RadioGroup --no-watch` — 100 passed, 13 skipped
- `pnpm test:chromium RadioGroup --no-watch` — 113 passed
- `pnpm typescript` — passed
- `pnpm eslint` — passed
- `pnpm stylelint` — passed
- `pnpm prettier` — passed

Existing ordinary-arrow and Shift+arrow navigation tests continue to pass.

The full test suite and other browser engines were not run locally.