### PR TITLE
[code-infra] Pin the only-allow version in the preinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.8.0",
   "private": true,
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
+    "preinstall": "npx only-allow@1.2.2 pnpm",
     "deduplicate": "pnpm dedupe",
     "build": "lerna run --no-private build",
     "release:version": "lerna version --no-changelog --no-push --no-git-tag-version --no-private",


### PR DESCRIPTION
The root `preinstall` hook runs `npx only-allow pnpm`. Because the version is unpinned, `npx` resolves and executes whatever the registry currently serves for `only-allow`, so a future release could change what runs during install with no review here.

Pin it to `only-allow@1.2.2`. Mirrors mui/material-ui#49114.
