### PR TITLE
[design-sync] Import Base UI into Claude Design

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,127 @@
+# Base UI design-sync notes
+
+- Repo uses pnpm, pinned node `>=22.23.2` (nvm has it installed as `v22.23.2`). Use
+  `export NVM_DIR="$HOME/.nvm"; source "$NVM_DIR/nvm.sh"; nvm use v22.23.2` before any
+  pnpm/node invocation in this repo.
+- `@base-ui/react` has no `main`/`module` fields at the package.json root - the built
+  output only exists after `pnpm build`, published via `publishConfig.directory: "build"`.
+  Build with workspace deps included: `pnpm -F "@base-ui/react..." build` (the trailing
+  `...` is required - it builds `@base-ui/utils` first). Bare `pnpm --filter @base-ui/react
+  build` fails with TS6305 errors because `@base-ui/utils/build/*.d.ts` doesn't exist yet.
+- Converter `--entry` -> `./packages/react/build/index.mjs`, `--node-modules` ->
+  `./packages/react/node_modules` (react/react-dom resolve there).
+- Base UI is a **headless/unstyled** library by design (see AGENTS.md) - it ships no CSS.
+  `[CSS_RUNTIME]` firing is expected, not a bug to chase. Preview styling is ported from
+  each component's own docs "hero" demo (CSS Modules variant, per AGENTS.md's own
+  demo-styling convention) into `.design-sync/previews/<Name>.tsx`.
+- Docs site layout: `docs/src/app/(docs)/react/components/<slug>/page.mdx` - every
+  component's doc file is literally named `page.mdx`, so basename-matching (the stock
+  `lib/docs.mjs` heuristic) never fires. Forked `docs.mjs` (see `libOverrides` in
+  config.json) to fall back to the enclosing directory name when the doc file's own
+  basename is `page`/`index`. `docsDir` in config.json is package-relative to
+  `PKG_DIR` (which is `dirname(--entry)` = `packages/react/build` when `--entry` is
+  passed) - hence the `../../../` prefix to reach repo-root `docs/`.
+- Demo styling source for previews: `docs/src/app/(docs)/react/components/<slug>/demos/hero/css-modules/index.tsx`
+  plus its sibling `../../_index.module.css`. Port the classNames + the CSS rules
+  (inlined into the preview's own scoped stylesheet, since previews can't import a
+  relative `.module.css` the way the docs site's build pipeline does) rather than
+  reimplementing from scratch.
+
+## Known render warns
+
+- `[RENDER_THIN] Toggle.html: mounts have no text and paint nothing` - false
+  positive. `Toggle` previews are icon-only (a heart SVG, no text label) per
+  the docs hero demo convention; the sheet (`_screenshots/general__Toggle.png`)
+  confirms Basic/Disabled/Pressed all render the icon correctly with the
+  expected checked/disabled visual states. Benign, expected on every re-sync
+  unless the preview changes.
+- `[RENDER_BLANK] Slider.html: renders but PNG is <5KB` - false positive. The
+  `Range` primary story (`cfg.overrides.Slider.primaryStory`) is a real,
+  correctly-rendered two-thumb slider (`_screenshots/general__Slider.png`
+  confirms it) - it's just visually thin (a single ~28px-tall track+thumbs
+  row), which trips the same blank-detection heuristic that flags truly empty
+  renders. Benign.
+
+## Known limitation: compound `.d.ts` props are empty stubs
+
+Every grouped compound (`Menu`, `Select`, `Accordion`, ... all 29 of them) gets
+`export interface <Name>Props { [key: string]: unknown }` and every member
+(`Menu.Root`, `Menu.Trigger`, ...) types as `React.ComponentType<any>` - the
+converter's ts-morph extractor can't flatten props here because Base UI's
+actual export shape is `export * as Menu from './index.parts'` (a real
+namespace of already-typed components), not a single top-level `<Name>`
+component - there is no "MenuProps" to synthesize, and the extractor doesn't
+walk into the namespace members to pull each one's own Props interface
+(e.g. `MenuRoot.Props`, from `export type * from './root/MenuRoot'`). This
+is a converter-level limitation (ts-morph type resolution in `lib/dts.mjs`),
+not something a `cfg.dtsPropsFor` override can practically fix at scale (29
+compounds x several members each). The `.prompt.md` for each component
+(synthesized from JSDoc + the authored preview's real JSX) is the design
+agent's best source of real prop usage for these compounds until the
+extractor is taught to walk namespace-shaped exports.
+
+## Preview-authoring findings (folded from batch learnings)
+
+- **The emitted `.d.ts` stubs are useless for prop discovery** on every
+  compound/overlay component (`{[key: string]: unknown}`, see "Known
+  limitation" above) - authoring subagents had to read
+  `packages/react/src/<slug>/**/*.tsx` source directly for `defaultOpen`,
+  `modal`, etc. Any future authoring work on this repo should go straight to
+  source, not the bundle's `.d.ts`.
+- **Radio / RadioGroup**: `radio-group` has no docs page of its own (only
+  `types.md`); its canonical composition lives in `radio`'s hero demo. A
+  standalone `Radio.Root` outside `RadioGroup` context isn't meaningfully
+  controllable (`checked` derives from `value === ''`) - both previews always
+  compose the full `RadioGroup > Radio.Root > Radio.Indicator` tree.
+- **Select**: `defaultOpen` + a matching `defaultValue` aligns the selected
+  row exactly over the trigger (`data-side="none"`), hiding the trigger under
+  the popup - use `defaultOpen` without `defaultValue` for a static shot that
+  keeps the trigger visible.
+- **NavigationMenu.Item** needs an explicit `value` prop for `Root`'s
+  `defaultValue` to target it reliably (fallback is an unpredictable
+  auto-generated id).
+- **Docs-demo containers that size via sibling count**: trimming a hero
+  demo's children (e.g. Tooltip's 3-button toolbar down to 1 trigger) can
+  break a plain `flex` container's "shrink to content" sizing - use
+  `inline-flex` or `width: fit-content` when trimming children.
+- **Slider `[data-disabled]`**: the hero/range-slider demos have no disabled
+  styling at all; `disabled` sets `data-disabled` via the generic
+  `getStateAttributesProps` boolean-state mapping (confirmed in
+  `packages/react/src/internals/getStateAttributesProps.ts`) even though the
+  demo CSS never styles it - added a small dimmed-track override.
+- **Progress indeterminate**: `Progress.Indicator`'s inline style is `{}`
+  (no height) when `value == null`, and the hero CSS never sets an explicit
+  height either (relies on the determinate-case inline `height: 'inherit'`) -
+  it collapses to zero height and disappears. Fix (correct for the real demo
+  too, not preview-only): add `height: 100%` to the base `.Indicator` rule,
+  then `width: 40%` on `[data-indeterminate]`.
+- **ScrollArea**: the hero demo's `.Scrollbar` is `opacity: 0` by default,
+  shown only via `[data-hovering]`/`[data-scrolling]` (runtime pointer
+  states that can't be simulated statically) - the preview forces
+  `.Scrollbar { opacity: 1 }` unconditionally as a documented, intentional
+  deviation so the thumb is always visible.
+- **Toast has no static-render prop** - fully imperative API
+  (`useToastManager().add(...)`; no `defaultToasts`/`open`-style prop
+  anywhere in `packages/react/src/toast/`). The preview seeds a real toast
+  via `toastManager.add()` in a mount effect (once, ref-guarded) instead of
+  a click handler - goes through the same public API the real demo's button
+  uses, so the toast is genuinely store-backed, not faked. Also strips the
+  demo's transform/animation CSS (driven by custom properties only set by
+  interaction/measurement effects that don't run in a single static mount)
+  in favor of a plain statically-positioned card.
+- **DirectionProvider** is the one provider with a real visual effect (RTL
+  mirroring); `CSPProvider`'s effect (nonce/style-element suppression) is
+  non-visual by nature - both got real authored previews (CSPProvider
+  demonstrates it doesn't break normal rendering rather than showing a
+  visual diff).
+
+## Re-sync risks
+
+- If Base UI restructures its docs site (moves off `page.mdx`, changes the
+  `components/<slug>/` layout), the `docs.mjs` fork's directory-name fallback will
+  silently stop matching - re-check `docs: N/41 components matched` after any docs
+  site refactor.
+- Preview styling is manually ported CSS (not `cfg.cssEntry`, since there is no
+  single compiled stylesheet to point at) - if a component's hero demo CSS changes
+  upstream, the preview won't pick it up automatically; a re-sync only re-verifies
+  components whose *source* changed, not demo-only CSS tweaks.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,45 @@
+{
+  "projectId": "e9789c9e-6c98-4c73-a2e5-23fc4b370d03",
+  "shape": "package",
+  "pkg": "@base-ui/react",
+  "globalName": "BaseUI",
+  "buildCmd": "pnpm -F \"@base-ui/react...\" build",
+  "docsDir": "../../../docs/src/app/(docs)/react/components",
+  "libOverrides": {
+    "docs.mjs": "Base UI docs use page.mdx per-component under a slug-named directory; basename matching never fires without falling back to the parent dir name"
+  },
+  "componentSrcMap": {
+    "ComboboxItemCollection": null
+  },
+  "docsMap": {
+    "CSPProvider": "../../../docs/src/app/(docs)/react/utils/csp-provider/page.mdx",
+    "DirectionProvider": "../../../docs/src/app/(docs)/react/utils/direction-provider/page.mdx"
+  },
+  "overrides": {
+    "Dialog": { "cardMode": "single", "viewport": "480x360" },
+    "ContextMenu": { "cardMode": "single", "viewport": "420x300" },
+    "Select": { "cardMode": "single", "viewport": "300x260" },
+    "Combobox": { "cardMode": "single", "viewport": "320x300" },
+    "Autocomplete": { "cardMode": "single", "viewport": "320x300" },
+    "NavigationMenu": { "cardMode": "single", "viewport": "420x260" },
+    "Tooltip": { "cardMode": "single", "viewport": "260x160" },
+    "AlertDialog": { "cardMode": "single", "primaryStory": "Basic", "viewport": "480x300" },
+    "Menu": { "cardMode": "single", "primaryStory": "Basic", "viewport": "320x360" },
+    "Menubar": { "cardMode": "single", "primaryStory": "SubmenuOpen", "viewport": "480x360" },
+    "NumberField": { "cardMode": "single", "primaryStory": "Basic", "viewport": "320x200" },
+    "OTPField": { "cardMode": "single", "primaryStory": "Basic", "viewport": "360x160" },
+    "Popover": { "cardMode": "single", "primaryStory": "Basic", "viewport": "360x260" },
+    "DirectionProvider": { "cardMode": "single", "primaryStory": "AccordionRtl", "viewport": "360x280" },
+    "Drawer": { "cardMode": "single", "primaryStory": "Basic", "viewport": "420x320" },
+    "Meter": { "cardMode": "single", "primaryStory": "Basic", "viewport": "320x120" },
+    "PreviewCard": { "cardMode": "single", "primaryStory": "Basic", "viewport": "360x260" },
+    "Progress": { "cardMode": "single", "primaryStory": "Basic", "viewport": "320x120" },
+    "Slider": { "cardMode": "single", "primaryStory": "Range", "viewport": "320x120" },
+    "Toast": { "cardMode": "single", "primaryStory": "Basic", "viewport": "360x200" },
+    "Toolbar": { "cardMode": "single", "primaryStory": "Basic", "viewport": "480x120" }
+  },
+  "storyImports": {
+    "loaders": { ".css": "css" }
+  },
+  "readmeHeader": ".design-sync/conventions.md"
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,78 @@
+## Base UI conventions
+
+Base UI is **headless/unstyled by design** — it ships zero CSS. Every rendered
+part is real DOM (a `button`, `input`, `div`, etc. via a `render` prop or
+plain default tag) with no default appearance. You MUST supply all visual
+styling yourself; an unstyled Base UI component renders as invisible/native
+browser chrome.
+
+### No provider required for most components
+
+Most components need no wrapper — `<Switch.Root>`, `<Accordion.Root>`, etc.
+work standalone. Two real exceptions:
+- `DirectionProvider` — wrap a subtree in `<DirectionProvider direction="rtl">`
+  to mirror layout/positioning (menus, tooltips, sliders) for RTL locales.
+- `CSPProvider` — wrap the app in `<CSPProvider nonce="...">` only when the
+  host page enforces a strict Content-Security-Policy that blocks inline
+  styles; has no visual effect otherwise.
+Everything else composes directly.
+
+### The styling idiom: target real DOM + state data-attributes
+
+There are no CSS classes or theme tokens to reach for — style with your own
+classNames/CSS (or a style prop) targeting the plain DOM elements Base UI
+renders, and react to component STATE via the `data-*` attributes Base UI
+sets on those elements (never inspect internal state directly). Verified
+attribute names actually set by components in this bundle — use these, don't
+invent new ones:
+
+| Attribute | Meaning | Seen on |
+|---|---|---|
+| `data-checked` / `data-unchecked` / `data-indeterminate` | Checkbox/Switch/Radio state | Checkbox, Switch, Radio |
+| `data-disabled` | Disabled state | almost every interactive part |
+| `data-open` / `data-closed` | Open/closed (popups, collapsible) | Dialog, Popover, Menu, Collapsible, Select... |
+| `data-panel-open` | Accordion panel expanded | Accordion.Trigger |
+| `data-starting-style` / `data-ending-style` | Enter/exit transition phase — animate FROM this state | any transitioning part |
+| `data-pressed` | Toggle pressed state | Toggle, ToggleGroup item |
+| `data-selected` / `data-highlighted` | List/menu item selection & keyboard highlight | Menu.Item, Select item, Combobox item, Tabs.Tab |
+| `data-side` | Which side a popup positioned on (`top`/`bottom`/`left`/`right`/`none`) | Popover/Menu/Select/Tooltip positioner |
+| `data-invalid` / `data-valid` / `data-dirty` / `data-touched` | Field/form validation state | Field, Input, form controls |
+| `data-required` / `data-readonly` | Field control flags | Field, Input |
+| `data-orientation` | `horizontal`/`vertical` | Slider, Tabs, Toolbar, Separator, ScrollArea |
+| `data-scrubbing` / `data-dragging` | Active pointer interaction | Slider, NumberField |
+| `data-placeholder` | Empty/placeholder state | Select, Combobox trigger |
+| `data-empty` | Empty collection/value | Select, Combobox |
+
+Example (Switch, ported directly from a verified preview):
+```css
+.Switch { border: 1px solid #111; padding: 2px; width: 36px; height: 20px; }
+.Switch[data-checked] { background-color: #111; }
+.Switch[data-disabled] { opacity: 0.4; }
+```
+
+### Compound components — always import the namespace from the root
+
+Every multi-part component (`Accordion`, `Dialog`, `Menu`, `Select`, ...) is
+a namespace object: `import { Accordion } from '@base-ui/react'`, then use
+`<Accordion.Root>`, `<Accordion.Item>`, `<Accordion.Trigger>`, etc. — never a
+flat `AccordionRoot` import. A leaf part (`Item`, `Trigger`, `Panel`) only
+renders correctly inside its full parent tree — always compose the whole
+compound, never a part in isolation.
+
+### Where the truth lives
+
+- Each component's `<Name>.d.ts` in this bundle names its exported parts.
+- Each component's `<Name>.prompt.md` carries real, working usage examples
+  (ported from Base UI's own docs hero demos) — the most reliable reference
+  for how a specific compound's parts fit together and which `data-*`
+  attributes it actually sets.
+- `styles.css` in this bundle is intentionally near-empty (headless DS) —
+  don't look there for visual reference; look at a `.prompt.md` example.
+
+### Overlay components (Dialog, Popover, Menu, Select, Tooltip, ...)
+
+These render into a `Portal` and need explicit positioning styles on their
+`Popup`/`Positioner` part (e.g. `position: fixed`, or rely on the built-in
+floating-ui positioning already applied inline) plus a `Backdrop` for modal
+ones. Copy the pattern from the component's own `.prompt.md` example rather
+than inventing overlay CSS from scratch.

--- a/.design-sync/overrides/docs.mjs
+++ b/.design-sync/overrides/docs.mjs
@@ -1,0 +1,294 @@
+// forked from design-sync lib/docs.mjs - Base UI's docs site names every
+// component's doc file `page.mdx` inside a directory named after the
+// component (e.g. accordion/page.mdx), so basename matching against the
+// component name never fires. This fork also slug-matches against the
+// PARENT DIRECTORY name when the doc file's own basename is `page`/`index`.
+//
+// Per-component doc discovery + guidelines copy. Heuristic probe (sibling ->
+// docsDir -> stories.mdx) with cfg overrides (docsMap, docsDir, guidelinesGlob),
+// plus a minimal-transform .md/.mdx ingester. The output goes into <Name>.prompt.md
+// so the design agent gets usage judgment alongside the structured API contract.
+
+import { cpSync, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { basename, dirname, extname, isAbsolute, join, relative, sep } from 'node:path';
+import { walk } from '../../.ds-sync/lib/common.mjs';
+
+// Cap on the doc body that lands in <Name>.prompt.md - the design agent reads
+// every .prompt.md, so one huge doc would crowd out the rest.
+export const DOC_BODY_CAP = 8000;
+
+// Repo-meta files the DEFAULT guidelinesGlob should skip; user-supplied globs
+// are honored as-is.
+const GUIDELINE_EXCLUDE = /^(CHANGELOG|CONTRIBUTING|MIGRATION|MIGRATING|LICENSE|LICENCE|CODE_OF_CONDUCT|SECURITY|AUTHORS|NOTICE)\b/i;
+
+const isDocExt = (p) => /\.(md|mdx)$/i.test(p);
+
+const slug = (s) => String(s ?? '').toLowerCase().replace(/[^a-z0-9]+/g, '');
+
+// Find the doc file for one component. First match wins.
+function findComponentDoc(c, { docsDirFiles, mapped, cfgPath }) {
+  // cfg.docsMap value: explicit path -> bounded via the same cfgPath/outside
+  // validation tsconfig/cssEntry/extraFonts use; null excludes. Extension-
+  // gated so a config-supplied path can't point at e.g. `.env`.
+  if (mapped !== undefined) {
+    if (!mapped) return null;
+    if (!isDocExt(mapped)) {
+      console.error(`  ! docsMap.${c.name}: ${mapped} is not .md/.mdx \u2014 skipped`);
+      return null;
+    }
+    return cfgPath(mapped, `docsMap.${c.name}`) ?? null;
+  }
+  // Sibling of the component's source. The storybook shape has no srcPath
+  // (components come from index.json) - the story source's directory is the
+  // stand-in; stories are conventionally colocated with the component, so a
+  // sibling Button.mdx is found either way. README.md only counts when the
+  // source dir is component-named (e.g. Button/README.md) - a flat-layout
+  // components/ui/README.md would otherwise match every component.
+  const near = c.srcPath ?? c.storySrc;
+  const dir = near ? dirname(near) : null;
+  if (dir) {
+    const dirIsOwn = slug(basename(dir)) === slug(c.name);
+    for (const f of [`${c.name}.md`, `${c.name}.mdx`, `${c.name}.docs.mdx`]) {
+      const p = join(dir, f);
+      if (existsSync(p)) return p;
+    }
+    if (dirIsOwn) {
+      const p = join(dir, 'README.md');
+      if (existsSync(p)) return p;
+    }
+  }
+  // Under docsDir - basename match, case/kebab/space-insensitive. Exact
+  // match wins over a plural filename (`alerts.mdx` for Alert) so that when
+  // both `Tab` and `Tabs` exist, `tabs.mdx` maps to Tabs. Multiple exact
+  // matches are announced - first-match-wins must never be silent, because
+  // the fix (a docsMap pin) only happens if someone hears about it.
+  const want = slug(c.name);
+  let plural = null;
+  const exact = [];
+  for (const p of docsDirFiles) {
+    const own = basename(p).replace(/\.(md|mdx)$/i, '');
+    // `page`/`index` carry no component identity of their own - fall back to
+    // the enclosing directory name, which is the actual slug in this repo's
+    // docs layout (docs/react/components/<slug>/page.mdx).
+    const s = slug(/^(page|index)$/i.test(own) ? basename(dirname(p)) : own);
+    if (s === want) exact.push(p);
+    else if (!plural && s === `${want}s`) plural = p;
+  }
+  if (exact.length > 1) {
+    console.error(`[DOCS_AMBIGUOUS] ${c.name}: ${exact.length} docs slug-match (${exact.map((p) => basename(p)).join(', ')}) \u2014 using ${basename(exact[0])}; pin cfg.docsMap.${c.name} to choose`);
+  }
+  if (exact.length) return exact[0];
+  if (plural) return plural;
+  // <Name>.stories.mdx alongside the source.
+  if (dir) {
+    const p = join(dir, `${c.name}.stories.mdx`);
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+// Run discovery once; attach c.docPath per component, log summary. cfgPath is
+// the bounded validator from package-build.mjs (same one tsconfig/cssEntry/
+// extraFonts route through) - outside-workspace paths are skipped + logged.
+export function discoverDocs({ components, PKG_DIR, cfg, cfgPath }) {
+  const docsDir = cfg.docsDir
+    ? cfgPath(cfg.docsDir, 'docsDir')
+    : ['docs', 'documentation'].map((d) => join(PKG_DIR, d)).find(existsSync) ?? null;
+  const docsDirFiles = docsDir
+    ? walk(docsDir, (n) => /\.(md|mdx)$/i.test(n))
+    : [];
+  let matched = 0;
+  let viaMap = 0;
+  let excluded = 0;
+  const missed = [];
+  for (const c of components) {
+    const mapped = cfg.docsMap?.[c.name];
+    // `docsMap.<Name> = null` is a deliberate exclusion - not an unmapped
+    // component, so no [DOCS_UNMAPPED] nudge to map what was just excluded.
+    if (mapped === null) { excluded++; continue; }
+    const p = findComponentDoc(c, { docsDirFiles, mapped, cfgPath });
+    if (p && existsSync(p)) {
+      c.docPath = p;
+      matched++;
+      if (mapped !== undefined) viaMap++;
+    } else missed.push(c.name);
+  }
+  // Attribution makes enumeration-smell visible: "62 via docsMap, 0
+  // discovered" says the map duplicates what discovery already does -
+  // config expresses conventions and exceptions, never enumerations.
+  console.error(`  docs: ${matched}/${components.length} components matched${docsDir ? ` (cfg.docsDir=${relative(PKG_DIR, docsDir) || '.'})` : ''}${viaMap ? ` \u2014 ${viaMap} via docsMap, ${matched - viaMap} discovered` : ''}${excluded ? `, ${excluded} excluded (docsMap null)` : ''}`);
+  if (matched > 0) for (const n of missed) console.error(`[DOCS_UNMAPPED] ${n}`);
+}
+
+// Minimal transform - NOT a parser. Strip frontmatter (parsing just
+// category/keywords), drop the .mdx import block and JSX-only lines.
+export function ingestDoc(path) {
+  let txt = readFileSync(path, 'utf8');
+  let category, keywords;
+  const fm = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(txt);
+  if (fm) {
+    txt = txt.slice(fm[0].length);
+    const cat = /^\s*(?:category|group)\s*:\s*(.+)$/m.exec(fm[1]);
+    if (cat) category = cat[1].trim().replace(/^['"]|['"]$/g, '');
+    const kw = /^\s*(?:keywords|tags)\s*:\s*(.+)$/m.exec(fm[1]);
+    if (kw) {
+      const v = kw[1].trim();
+      keywords = v.startsWith('[')
+        ? v.slice(1, v.endsWith(']') ? -1 : undefined).split(',').map((s) => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean)
+        : [v.replace(/^['"]|['"]$/g, '')];
+    }
+  }
+  // Drop noise that applies to .md and .mdx alike: HTML comments, raw
+  // <style>/<script> blocks, and VuePress/dumi-style `:::tip ... :::`
+  // admonition fences (keep the content between the fences).
+  txt = txt
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<(style|script)\b[^>]*>[\s\S]*?<\/\1>/gi, '')
+    .replace(/^:::.*$/gm, '');
+  if (/\.mdx$/i.test(path)) {
+    const lines = txt.split('\n');
+    // Drop the leading import block. A prettier-wrapped multi-line import
+    // (`import {\n  X,\n} from '...';`) spans until the `from '...';` line. A
+    // terminated single line (side-effect `import './x';` - no `from`) does
+    // NOT enter multi-line mode.
+    let i = 0, inImport = false;
+    while (i < lines.length) {
+      const l = lines[i];
+      if (inImport) { i++; if (/\bfrom\s+['"][^'"]+['"];?\s*$/.test(l)) inImport = false; continue; }
+      if (/^\s*import\b/.test(l)) {
+        i++;
+        if (!/\bfrom\s+['"][^'"]+['"];?\s*$/.test(l) && !/['"];?\s*$/.test(l)) inImport = true;
+        continue;
+      }
+      if (/^\s*$/.test(l)) { i++; continue; }
+      break;
+    }
+    // Drop JSX component blocks. Depth-track on PascalCase open/close tags so
+    // a multi-line <Canvas>\n <Story .../>\n</Canvas> is dropped in full. Only
+    // count tags on block-level-JSX lines (or inside an open block) so inline
+    // `` `<Button>` `` mentions and fenced code don't poison depth.
+    const out = [];
+    let depth = 0, fenced = false;
+    for (const l of lines.slice(i)) {
+      if (/^\s*```/.test(l)) { fenced = !fenced; if (depth === 0) out.push(l); continue; }
+      if (fenced) { if (depth === 0) out.push(l); continue; }
+      const blk = /^\s*<\/?[A-Z]/.test(l);
+      const track = depth > 0 || blk;
+      const opens = track ? (l.match(/<[A-Z][\w.]*[^>]*>/g) ?? []).filter((t) => !t.endsWith('/>')).length : 0;
+      const closes = track ? (l.match(/<\/[A-Z][\w.]*\s*>/g) ?? []).length : 0;
+      if (depth === 0 && !blk) out.push(l);
+      depth = Math.max(0, depth + opens - closes);
+    }
+    txt = out.join('\n');
+  }
+  let body = txt.trim();
+  if (body.length > DOC_BODY_CAP) {
+    const orig = body.length;
+    // Cut at a word boundary so the tail isn't a half-word; fall back to a
+    // hard cut when the nearest boundary is unreasonably far back.
+    const cut = body.slice(0, DOC_BODY_CAP).replace(/\s+\S*$/, '');
+    body = (cut.length > DOC_BODY_CAP - 500 ? cut : body.slice(0, DOC_BODY_CAP)) +
+      `\n\n_(truncated \u2014 see ${basename(path)} for full)_`;
+    console.error(`  docs: ${basename(path)} truncated (${orig} \u2192 ${body.length})`);
+  }
+  return { body, category, keywords };
+}
+
+// Tiny glob: `**` -> any depth, `*` -> any chars in one segment. Anchored under
+// PKG_DIR. The walk base and any literal (no-wildcard) entry are bounded via
+// cfgPath; matched files whose realpath escapes workspaceRoot are dropped.
+function matchGlob(glob, { PKG_DIR, cfgPath, quiet }) {
+  if (!glob.includes('*')) {
+    if (!isDocExt(glob)) {
+      if (!quiet) console.error(`  ! guidelinesGlob: ${glob} is not .md/.mdx \u2014 skipped`);
+      return [];
+    }
+    const p = cfgPath(glob, 'guidelinesGlob');
+    return p ? [p] : [];
+  }
+  const parts = glob.split('/');
+  const i = parts.findIndex((p) => p.includes('*'));
+  // Bound the walk base too - `../**/*.md` would otherwise walk arbitrary
+  // directories. Falls back to PKG_DIR (always in-bounds) when i === 0.
+  // `quiet` (default globs the user never set) skips the not-found warning.
+  if (quiet && i > 0 && !existsSync(join(PKG_DIR, ...parts.slice(0, i)))) return [];
+  const base = i > 0 ? cfgPath(parts.slice(0, i).join('/'), 'guidelinesGlob') : PKG_DIR;
+  if (!base) return [];
+  // `**/` -> zero-or-more directory segments (so `docs/**/*.md` matches both
+  // `docs/x.md` and `docs/sub/x.md`); `**` elsewhere -> any depth; `*` ->
+  // any chars within a segment.
+  const rx = new RegExp('^' + glob.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*\//g, '§§/').replace(/\*\*/g, '§§').replace(/\*/g, '[^/]*')
+    .replace(/§§\//g, '(?:[^/]+/)*').replace(/§§/g, '.*') + '$');
+  return walk(base, () => true)
+    .filter((p) => isDocExt(p) && rx.test(relative(PKG_DIR, p).split(sep).join('/')));
+}
+
+// Copy matched guidelines into OUT/guidelines/ preserving relative subpath; emit
+// a small index.md listing them. No-op when nothing matches.
+export function emitGuidelines({ cfg, PKG_DIR, OUT, cfgPath, workspaceRoot }) {
+  const usingDefault = cfg.guidelinesGlob == null;
+  const globs = []
+    .concat(cfg.guidelinesGlob ?? ['docs/guides/**/*.md', 'docs/*.md', 'guides/**/*.md'])
+    .filter(Boolean);
+  const seen = new Set();
+  const dests = new Set();
+  const copied = [];
+  for (const g of globs) {
+    for (const p of matchGlob(g, { PKG_DIR, cfgPath, quiet: usingDefault })) {
+      if (seen.has(p)) continue;
+      seen.add(p);
+      if (usingDefault && GUIDELINE_EXCLUDE.test(basename(p))) {
+        console.error(`  guidelines: skipping ${basename(p)} (repo-meta, default glob)`);
+        continue;
+      }
+      // Belt-and-suspenders: drop any matched file whose realpath escapes the
+      // workspace root (a symlink under an in-bounds dir could otherwise point
+      // outside). cfgPath does the same realpath check for the walk base and
+      // literal entries.
+      let real;
+      try { real = realpathSync(p); } catch { continue; }
+      const wsRel = relative(workspaceRoot, real);
+      if (wsRel.startsWith('..') || isAbsolute(wsRel)) {
+        console.error(`  ! guidelinesGlob: matched ${p} resolves outside the workspace root \u2014 skipped`);
+        continue;
+      }
+      // Dest preserves PKG_DIR-relative subpath when the file is inside the
+      // package; otherwise (in-workspace but outside the package - e.g. a
+      // sibling docs package) collapses to basename so the dest can never
+      // escape OUT/guidelines/.
+      let rel = relative(PKG_DIR, p).split(sep).join('/');
+      if (rel.startsWith('../') || isAbsolute(rel)) rel = basename(p);
+      const dest = join(OUT, 'guidelines', rel);
+      if (dests.has(dest)) {
+        console.error(`  ! guidelines: ${rel} would overwrite an earlier file with the same dest \u2014 skipped`);
+        continue;
+      }
+      dests.add(dest);
+      mkdirSync(dirname(dest), { recursive: true });
+      cpSync(p, dest);
+      copied.push(rel);
+    }
+  }
+  if (copied.length) {
+    writeFileSync(
+      join(OUT, 'guidelines', 'index.md'),
+      `# Guidelines\n\n${copied.map((r) => `- [${basename(r, extname(r))}](./${r})`).join('\n')}\n`,
+    );
+    console.error(`  guidelines: ${copied.length} file(s) \u2192 guidelines/`);
+  }
+  return copied;
+}
+
+// Read PascalCase named exports from a preview .tsx (either home - the caller
+// picks owned-first) as fenced JSX blocks for the synthesized ## Examples
+// section. Gracefully empty when the file/dir doesn't exist.
+export function previewExamples(previewPath) {
+  if (!existsSync(previewPath)) return [];
+  const src = readFileSync(previewPath, 'utf8');
+  const out = [];
+  for (const m of src.matchAll(/export\s+const\s+([A-Z][A-Za-z0-9_]*)\s*=\s*([\s\S]*?)(?=\n\s*export\s+const\s+[A-Z]|\n*$)/g)) {
+    out.push(`### ${m[1]}\n\n\`\`\`jsx\n${m[2].trim().replace(/;$/, '')}\n\`\`\``);
+  }
+  return out;
+}

--- a/.design-sync/previews/Accordion.css
+++ b/.design-sync/previews/Accordion.css
@@ -1,0 +1,69 @@
+.Accordion {
+  box-sizing: border-box;
+  display: flex;
+  max-width: 20rem;
+  width: 100%;
+  flex-direction: column;
+  border: 1px solid oklch(14.5% 0 0deg);
+  color: oklch(14.5% 0 0deg);
+}
+
+.Item + .Item {
+  border-top: 1px solid oklch(14.5% 0 0deg);
+}
+
+.Header {
+  margin: 0;
+}
+
+.Trigger {
+  box-sizing: border-box;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+  color: oklch(14.5% 0 0deg);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  text-align: left;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Trigger[data-disabled] {
+  color: oklch(70.8% 0 0deg);
+}
+
+.Icon {
+  transition: transform 100ms ease-out;
+}
+
+[data-panel-open] > .Icon {
+  transform: rotate(45deg);
+}
+
+.Panel {
+  box-sizing: border-box;
+  height: var(--accordion-panel-height);
+  overflow: hidden;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  transition: height 150ms ease-out;
+}
+
+.Panel[data-starting-style],
+.Panel[data-ending-style] {
+  height: 0;
+}
+
+.Content {
+  padding: 0.5rem 0.75rem;
+}

--- a/.design-sync/previews/Accordion.tsx
+++ b/.design-sync/previews/Accordion.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { Accordion } from '@base-ui/react';
+import './Accordion.css';
+
+function PlusIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="square"
+      strokeLinejoin="round"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M1.5 8h13M8 14.5v-13" />
+    </svg>
+  );
+}
+
+export const Basic = () => (
+  <Accordion.Root className="Accordion">
+    <Accordion.Item className="Item">
+      <Accordion.Header className="Header">
+        <Accordion.Trigger className="Trigger">
+          What is Base UI?
+          <PlusIcon className="Icon" />
+        </Accordion.Trigger>
+      </Accordion.Header>
+      <Accordion.Panel className="Panel">
+        <div className="Content">
+          Base UI is a library of high-quality unstyled React components for design systems and
+          web apps.
+        </div>
+      </Accordion.Panel>
+    </Accordion.Item>
+
+    <Accordion.Item className="Item">
+      <Accordion.Header className="Header">
+        <Accordion.Trigger className="Trigger">
+          How do I get started?
+          <PlusIcon className="Icon" />
+        </Accordion.Trigger>
+      </Accordion.Header>
+      <Accordion.Panel className="Panel">
+        <div className="Content">
+          Head to the "Quick start" guide in the docs. If you've used unstyled libraries before,
+          you'll feel at home.
+        </div>
+      </Accordion.Panel>
+    </Accordion.Item>
+
+    <Accordion.Item className="Item">
+      <Accordion.Header className="Header">
+        <Accordion.Trigger className="Trigger">
+          Can I use it for my project?
+          <PlusIcon className="Icon" />
+        </Accordion.Trigger>
+      </Accordion.Header>
+      <Accordion.Panel className="Panel">
+        <div className="Content">Of course! Base UI is free and open source.</div>
+      </Accordion.Panel>
+    </Accordion.Item>
+  </Accordion.Root>
+);
+
+export const MultipleOpen = () => (
+  <Accordion.Root className="Accordion" defaultValue={['a', 'b']} multiple>
+    <Accordion.Item className="Item" value="a">
+      <Accordion.Header className="Header">
+        <Accordion.Trigger className="Trigger">
+          Section one
+          <PlusIcon className="Icon" />
+        </Accordion.Trigger>
+      </Accordion.Header>
+      <Accordion.Panel className="Panel">
+        <div className="Content">Both sections can be open at the same time.</div>
+      </Accordion.Panel>
+    </Accordion.Item>
+    <Accordion.Item className="Item" value="b">
+      <Accordion.Header className="Header">
+        <Accordion.Trigger className="Trigger">
+          Section two
+          <PlusIcon className="Icon" />
+        </Accordion.Trigger>
+      </Accordion.Header>
+      <Accordion.Panel className="Panel">
+        <div className="Content">This is the second, independently toggled panel.</div>
+      </Accordion.Panel>
+    </Accordion.Item>
+  </Accordion.Root>
+);
+
+export const DisabledItem = () => (
+  <Accordion.Root className="Accordion" defaultValue={['a']}>
+    <Accordion.Item className="Item" value="a">
+      <Accordion.Header className="Header">
+        <Accordion.Trigger className="Trigger">
+          Available section
+          <PlusIcon className="Icon" />
+        </Accordion.Trigger>
+      </Accordion.Header>
+      <Accordion.Panel className="Panel">
+        <div className="Content">This section can be toggled normally.</div>
+      </Accordion.Panel>
+    </Accordion.Item>
+    <Accordion.Item className="Item" value="b" disabled>
+      <Accordion.Header className="Header">
+        <Accordion.Trigger className="Trigger">
+          Disabled section
+          <PlusIcon className="Icon" />
+        </Accordion.Trigger>
+      </Accordion.Header>
+      <Accordion.Panel className="Panel">
+        <div className="Content">This section cannot be toggled.</div>
+      </Accordion.Panel>
+    </Accordion.Item>
+  </Accordion.Root>
+);

--- a/.design-sync/previews/AlertDialog.css
+++ b/.design-sync/previews/AlertDialog.css
@@ -1,0 +1,77 @@
+.Button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  height: 2rem;
+  padding: 0 0.75rem;
+  margin: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1;
+  white-space: nowrap;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Button[data-color='red'] {
+  color: oklch(50.5% 0.213 27.518deg);
+}
+
+.Backdrop {
+  position: fixed;
+  min-height: 100dvh;
+  inset: 0;
+  background-color: black;
+  opacity: 0.2;
+}
+
+.Popup {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 24rem;
+  max-width: calc(100vw - 3rem);
+  margin-top: -2rem;
+  padding: 1rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+}
+
+.Intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.Title {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 700;
+}
+
+.Description {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(43.9% 0 0deg);
+}
+
+.Actions {
+  display: flex;
+  justify-content: end;
+  gap: 0.75rem;
+}

--- a/.design-sync/previews/AlertDialog.tsx
+++ b/.design-sync/previews/AlertDialog.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { AlertDialog } from '@base-ui/react';
+import './AlertDialog.css';
+
+export const Basic = () => (
+  <AlertDialog.Root defaultOpen>
+    <AlertDialog.Trigger data-color="red" className="Button">
+      Discard draft
+    </AlertDialog.Trigger>
+    <AlertDialog.Portal>
+      <AlertDialog.Backdrop className="Backdrop" />
+      <AlertDialog.Popup className="Popup">
+        <div className="Intro">
+          <AlertDialog.Title className="Title">Discard draft?</AlertDialog.Title>
+          <AlertDialog.Description className="Description">
+            You can&apos;t undo this action.
+          </AlertDialog.Description>
+        </div>
+        <div className="Actions">
+          <AlertDialog.Close className="Button">Cancel</AlertDialog.Close>
+          <AlertDialog.Close data-color="red" className="Button">
+            Discard
+          </AlertDialog.Close>
+        </div>
+      </AlertDialog.Popup>
+    </AlertDialog.Portal>
+  </AlertDialog.Root>
+);
+
+export const Confirm = () => (
+  <AlertDialog.Root defaultOpen>
+    <AlertDialog.Trigger className="Button">Log out</AlertDialog.Trigger>
+    <AlertDialog.Portal>
+      <AlertDialog.Backdrop className="Backdrop" />
+      <AlertDialog.Popup className="Popup">
+        <div className="Intro">
+          <AlertDialog.Title className="Title">Log out of your account?</AlertDialog.Title>
+          <AlertDialog.Description className="Description">
+            You will need to sign in again to access your dashboard.
+          </AlertDialog.Description>
+        </div>
+        <div className="Actions">
+          <AlertDialog.Close className="Button">Stay signed in</AlertDialog.Close>
+          <AlertDialog.Close className="Button">Log out</AlertDialog.Close>
+        </div>
+      </AlertDialog.Popup>
+    </AlertDialog.Portal>
+  </AlertDialog.Root>
+);

--- a/.design-sync/previews/Autocomplete.css
+++ b/.design-sync/previews/Autocomplete.css
@@ -1,0 +1,97 @@
+.Input {
+  box-sizing: border-box;
+  padding: 0 0.5rem;
+  margin: 0;
+  border-radius: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  width: 16rem;
+  height: 2rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  outline: none;
+
+  &::placeholder {
+    color: oklch(55.6% 0 0deg);
+  }
+
+  &:focus {
+    outline: 2px solid oklch(14.5% 0 0deg);
+    outline-offset: -1px;
+  }
+
+  &[data-disabled] {
+    color: oklch(55.6% 0 0deg);
+    border-color: oklch(55.6% 0 0deg);
+  }
+}
+
+.Label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Positioner {
+  outline: 0;
+}
+
+.Popup {
+  box-sizing: border-box;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  width: var(--anchor-width);
+  max-width: var(--available-width);
+  border: 1px solid oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+}
+
+.List {
+  box-sizing: border-box;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-block: 0.25rem;
+  scroll-padding-block: 0.25rem;
+  outline: 0;
+  max-height: min(22.5rem, var(--available-height));
+
+  &[data-empty] {
+    padding: 0;
+  }
+}
+
+.Item {
+  box-sizing: border-box;
+  outline: 0;
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+  padding-block: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  display: flex;
+  font-size: 0.875rem;
+  line-height: 1rem;
+
+  &[data-highlighted] {
+    z-index: 0;
+    position: relative;
+    color: white;
+  }
+
+  &[data-highlighted]::before {
+    content: '';
+    z-index: -1;
+    position: absolute;
+    inset-block: 0;
+    inset-inline: 0;
+    background-color: oklch(14.5% 0 0deg);
+  }
+}

--- a/.design-sync/previews/Autocomplete.tsx
+++ b/.design-sync/previews/Autocomplete.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { Autocomplete } from '@base-ui/react';
+import './Autocomplete.css';
+
+interface Tag {
+  id: string;
+  value: string;
+}
+
+const tags: Tag[] = [
+  { id: 't1', value: 'feature' },
+  { id: 't2', value: 'fix' },
+  { id: 't3', value: 'bug' },
+  { id: 't4', value: 'docs' },
+  { id: 't5', value: 'internal' },
+  { id: 't6', value: 'mobile' },
+];
+
+export const Basic = () => (
+  <Autocomplete.Root items={tags} defaultOpen modal={false}>
+    <label className="Label">
+      Search tags
+      <Autocomplete.Input placeholder="e.g. feature" className="Input" />
+    </label>
+
+    <Autocomplete.Portal>
+      <Autocomplete.Positioner className="Positioner" sideOffset={4}>
+        <Autocomplete.Popup className="Popup">
+          <Autocomplete.List className="List">
+            {(tag: Tag) => (
+              <Autocomplete.Item key={tag.id} className="Item" value={tag}>
+                {tag.value}
+              </Autocomplete.Item>
+            )}
+          </Autocomplete.List>
+        </Autocomplete.Popup>
+      </Autocomplete.Positioner>
+    </Autocomplete.Portal>
+  </Autocomplete.Root>
+);
+
+export const Disabled = () => (
+  <Autocomplete.Root items={tags} modal={false}>
+    <label className="Label">
+      Search tags
+      <Autocomplete.Input placeholder="e.g. feature" className="Input" disabled />
+    </label>
+  </Autocomplete.Root>
+);

--- a/.design-sync/previews/Avatar.css
+++ b/.design-sync/previews/Avatar.css
@@ -1,0 +1,37 @@
+.Row {
+  display: flex;
+  gap: 1rem;
+}
+
+.Root {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  vertical-align: middle;
+  border-radius: 100%;
+  -webkit-user-select: none;
+  user-select: none;
+  font-weight: 400;
+  color: oklch(14.5% 0 0deg);
+  background-color: oklch(92.2% 0 0deg);
+  font-size: 0.875rem;
+  line-height: 1;
+  overflow: hidden;
+  height: 2rem;
+  width: 2rem;
+}
+
+.Image {
+  object-fit: cover;
+  height: 100%;
+  width: 100%;
+}
+
+.Fallback {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+  font-size: 0.875rem;
+}

--- a/.design-sync/previews/Avatar.tsx
+++ b/.design-sync/previews/Avatar.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { Avatar } from '@base-ui/react';
+import './Avatar.css';
+
+export const Basic = () => (
+  <div className="Row">
+    <Avatar.Root className="Root">
+      <Avatar.Image
+        src="data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64'%3E%3Crect width='64' height='64' fill='%23c98ee0'/%3E%3Ccircle cx='32' cy='24' r='12' fill='%23ffffff'/%3E%3Cellipse cx='32' cy='56' rx='20' ry='16' fill='%23ffffff'/%3E%3C/svg%3E"
+        width="48"
+        height="48"
+        className="Image"
+      />
+      <Avatar.Fallback className="Fallback">LT</Avatar.Fallback>
+    </Avatar.Root>
+    <Avatar.Root className="Root">LT</Avatar.Root>
+  </div>
+);
+
+export const Fallback = () => (
+  <Avatar.Root className="Root">
+    <Avatar.Image src="data:," className="Image" />
+    <Avatar.Fallback className="Fallback">JD</Avatar.Fallback>
+  </Avatar.Root>
+);

--- a/.design-sync/previews/Button.css
+++ b/.design-sync/previews/Button.css
@@ -1,0 +1,26 @@
+.Button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  height: 2rem;
+  padding: 0 0.75rem;
+  margin: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  border-radius: 0;
+  background-color: white;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1;
+  white-space: nowrap;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Button[data-disabled] {
+  color: oklch(55.6% 0 0deg);
+  border-color: oklch(55.6% 0 0deg);
+}

--- a/.design-sync/previews/Button.tsx
+++ b/.design-sync/previews/Button.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { Button } from '@base-ui/react';
+import './Button.css';
+
+export const Basic = () => <Button className="Button">Submit</Button>;
+
+export const Disabled = () => (
+  <Button className="Button" disabled>
+    Submit
+  </Button>
+);

--- a/.design-sync/previews/CSPProvider.css
+++ b/.design-sync/previews/CSPProvider.css
@@ -1,0 +1,85 @@
+.Stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.Label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Checkbox {
+  box-sizing: border-box;
+  display: flex;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid oklch(14.5% 0 0deg);
+  border-radius: 0;
+  background-color: white;
+  color: white;
+  padding: 0;
+  margin: 0;
+}
+
+.Checkbox[data-checked],
+.Checkbox[data-indeterminate] {
+  background-color: oklch(14.5% 0 0deg);
+  color: white;
+}
+
+.Checkbox:focus-visible {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: 2px;
+}
+
+.Indicator {
+  display: flex;
+}
+
+.Indicator[data-unchecked] {
+  display: none;
+}
+
+.Switch {
+  box-sizing: border-box;
+  display: flex;
+  flex-shrink: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  padding: 0.125rem;
+  width: 2.25rem;
+  height: 1.25rem;
+  background-color: white;
+  transition: background-color 150ms ease;
+}
+
+.Switch[data-checked] {
+  background-color: oklch(14.5% 0 0deg);
+}
+
+.Switch:focus-visible {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: 2px;
+}
+
+.Thumb {
+  width: 0.875rem;
+  height: 0.875rem;
+  background-color: oklch(14.5% 0 0deg);
+  transition:
+    translate 150ms ease,
+    background-color 150ms ease;
+}
+
+.Thumb[data-checked] {
+  translate: 1rem 0;
+  background-color: white;
+}

--- a/.design-sync/previews/CSPProvider.tsx
+++ b/.design-sync/previews/CSPProvider.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { Checkbox, CSPProvider, Switch } from '@base-ui/react';
+import './CSPProvider.css';
+
+function CheckIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="m2.5 8.5 4 4 7-9" />
+    </svg>
+  );
+}
+
+// CSPProvider has no visible DOM/behavior of its own — its entire effect is
+// applying a nonce to inline <style>/<script> tags Base UI renders under a
+// strict Content Security Policy. This demonstrates that supplying a nonce
+// does not change or break normal rendering of the children it wraps.
+export const Basic = () => (
+  <CSPProvider nonce="preview-nonce-123">
+    <div className="Stack">
+      <label className="Label">
+        <Checkbox.Root defaultChecked className="Checkbox">
+          <Checkbox.Indicator className="Indicator">
+            <CheckIcon />
+          </Checkbox.Indicator>
+        </Checkbox.Root>
+        Enable notifications
+      </label>
+      <label className="Label">
+        <Switch.Root defaultChecked className="Switch">
+          <Switch.Thumb className="Thumb" />
+        </Switch.Root>
+        Auto-save
+      </label>
+    </div>
+  </CSPProvider>
+);
+
+// disableStyleElements is the other CSPProvider option, used when inline
+// <style> tags are avoided entirely instead of nonced. It also has no
+// visual effect on ordinary components like these.
+export const DisableStyleElements = () => (
+  <CSPProvider disableStyleElements>
+    <div className="Stack">
+      <label className="Label">
+        <Checkbox.Root className="Checkbox">
+          <Checkbox.Indicator className="Indicator">
+            <CheckIcon />
+          </Checkbox.Indicator>
+        </Checkbox.Root>
+        Subscribe to newsletter
+      </label>
+      <label className="Label">
+        <Switch.Root className="Switch">
+          <Switch.Thumb className="Thumb" />
+        </Switch.Root>
+        Airplane mode
+      </label>
+    </div>
+  </CSPProvider>
+);

--- a/.design-sync/previews/Checkbox.css
+++ b/.design-sync/previews/Checkbox.css
@@ -1,0 +1,48 @@
+.Label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Checkbox {
+  box-sizing: border-box;
+  display: flex;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid oklch(14.5% 0 0deg);
+  border-radius: 0;
+  background-color: white;
+  color: white;
+  padding: 0;
+  margin: 0;
+}
+
+.Checkbox[data-checked],
+.Checkbox[data-indeterminate] {
+  background-color: oklch(14.5% 0 0deg);
+  color: white;
+}
+
+.Checkbox[data-disabled] {
+  opacity: 0.4;
+}
+
+.Checkbox:focus-visible {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: 2px;
+}
+
+.Indicator {
+  display: flex;
+}
+
+.Indicator[data-unchecked] {
+  display: none;
+}

--- a/.design-sync/previews/Checkbox.tsx
+++ b/.design-sync/previews/Checkbox.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { Checkbox } from '@base-ui/react';
+import './Checkbox.css';
+
+function CheckIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="m2.5 8.5 4 4 7-9" />
+    </svg>
+  );
+}
+
+export const Basic = () => (
+  <label className="Label">
+    <Checkbox.Root defaultChecked className="Checkbox">
+      <Checkbox.Indicator className="Indicator">
+        <CheckIcon />
+      </Checkbox.Indicator>
+    </Checkbox.Root>
+    Enable notifications
+  </label>
+);
+
+export const Unchecked = () => (
+  <label className="Label">
+    <Checkbox.Root className="Checkbox">
+      <Checkbox.Indicator className="Indicator">
+        <CheckIcon />
+      </Checkbox.Indicator>
+    </Checkbox.Root>
+    Subscribe to newsletter
+  </label>
+);
+
+function MinusIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M3 8h10" />
+    </svg>
+  );
+}
+
+export const Indeterminate = () => (
+  <label className="Label">
+    <Checkbox.Root indeterminate className="Checkbox">
+      <Checkbox.Indicator className="Indicator">
+        <MinusIcon />
+      </Checkbox.Indicator>
+    </Checkbox.Root>
+    Select all
+  </label>
+);
+
+export const Disabled = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+    <label className="Label">
+      <Checkbox.Root disabled className="Checkbox">
+        <Checkbox.Indicator className="Indicator">
+          <CheckIcon />
+        </Checkbox.Indicator>
+      </Checkbox.Root>
+      Disabled, unchecked
+    </label>
+    <label className="Label">
+      <Checkbox.Root disabled defaultChecked className="Checkbox">
+        <Checkbox.Indicator className="Indicator">
+          <CheckIcon />
+        </Checkbox.Indicator>
+      </Checkbox.Root>
+      Disabled, checked
+    </label>
+  </div>
+);

--- a/.design-sync/previews/CheckboxGroup.css
+++ b/.design-sync/previews/CheckboxGroup.css
@@ -1,0 +1,61 @@
+.CheckboxGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: 0.25rem;
+  color: oklch(14.5% 0 0deg);
+}
+
+.CheckboxGroup[data-disabled] {
+  opacity: 0.4;
+}
+
+.Caption {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+}
+
+.Item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+}
+
+.Checkbox {
+  box-sizing: border-box;
+  display: flex;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid oklch(14.5% 0 0deg);
+  border-radius: 0;
+  background-color: white;
+  color: white;
+  padding: 0;
+  margin: 0;
+}
+
+.Checkbox[data-checked],
+.Checkbox[data-indeterminate] {
+  background-color: oklch(14.5% 0 0deg);
+  color: white;
+}
+
+.Checkbox:focus-visible {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: 2px;
+}
+
+.Indicator {
+  display: flex;
+}
+
+.Indicator[data-unchecked] {
+  display: none;
+}

--- a/.design-sync/previews/CheckboxGroup.tsx
+++ b/.design-sync/previews/CheckboxGroup.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { Checkbox } from '@base-ui/react';
+import { CheckboxGroup } from '@base-ui/react';
+import './CheckboxGroup.css';
+
+function CheckIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="m2.5 8.5 4 4 7-9" />
+    </svg>
+  );
+}
+
+export const Basic = () => (
+  <CheckboxGroup aria-label="Apples" defaultValue={['fuji-apple']} className="CheckboxGroup">
+    <div className="Caption">Apples</div>
+    <label className="Item">
+      <Checkbox.Root name="apple" value="fuji-apple" className="Checkbox">
+        <Checkbox.Indicator className="Indicator">
+          <CheckIcon />
+        </Checkbox.Indicator>
+      </Checkbox.Root>
+      Fuji
+    </label>
+    <label className="Item">
+      <Checkbox.Root name="apple" value="gala-apple" className="Checkbox">
+        <Checkbox.Indicator className="Indicator">
+          <CheckIcon />
+        </Checkbox.Indicator>
+      </Checkbox.Root>
+      Gala
+    </label>
+    <label className="Item">
+      <Checkbox.Root name="apple" value="granny-smith-apple" className="Checkbox">
+        <Checkbox.Indicator className="Indicator">
+          <CheckIcon />
+        </Checkbox.Indicator>
+      </Checkbox.Root>
+      Granny Smith
+    </label>
+  </CheckboxGroup>
+);
+
+export const Disabled = () => (
+  <CheckboxGroup
+    aria-label="Apples"
+    disabled
+    defaultValue={['fuji-apple']}
+    className="CheckboxGroup"
+  >
+    <div className="Caption">Apples</div>
+    <label className="Item">
+      <Checkbox.Root name="apple" value="fuji-apple" className="Checkbox">
+        <Checkbox.Indicator className="Indicator">
+          <CheckIcon />
+        </Checkbox.Indicator>
+      </Checkbox.Root>
+      Fuji
+    </label>
+    <label className="Item">
+      <Checkbox.Root name="apple" value="gala-apple" className="Checkbox">
+        <Checkbox.Indicator className="Indicator">
+          <CheckIcon />
+        </Checkbox.Indicator>
+      </Checkbox.Root>
+      Gala
+    </label>
+    <label className="Item">
+      <Checkbox.Root name="apple" value="granny-smith-apple" className="Checkbox">
+        <Checkbox.Indicator className="Indicator">
+          <CheckIcon />
+        </Checkbox.Indicator>
+      </Checkbox.Root>
+      Granny Smith
+    </label>
+  </CheckboxGroup>
+);

--- a/.design-sync/previews/Collapsible.css
+++ b/.design-sync/previews/Collapsible.css
@@ -1,0 +1,59 @@
+.Collapsible {
+  display: flex;
+  width: 12rem;
+  min-height: 9rem;
+  flex-direction: column;
+  justify-content: center;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Icon {
+  transition: transform 100ms ease-out;
+}
+
+.Trigger {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  height: 2rem;
+  padding: 0 0.5rem 0 0.75rem;
+  margin: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  border-radius: 0;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1;
+  white-space: nowrap;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Trigger[data-panel-open] .Icon {
+  transform: rotate(90deg);
+}
+
+.Panel {
+  display: flex;
+  height: var(--collapsible-panel-height);
+  flex-direction: column;
+  justify-content: end;
+  overflow: hidden;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.Panel[hidden]:not([hidden='until-found']) {
+  display: none;
+}
+
+.Content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem 0.875rem;
+}

--- a/.design-sync/previews/Collapsible.tsx
+++ b/.design-sync/previews/Collapsible.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { Collapsible } from '@base-ui/react';
+import './Collapsible.css';
+
+function CaretRightIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M6 12V4l4.5 4z" />
+    </svg>
+  );
+}
+
+export const Open = () => (
+  <Collapsible.Root className="Collapsible" defaultOpen>
+    <Collapsible.Trigger className="Trigger">
+      Recovery keys
+      <CaretRightIcon className="Icon" />
+    </Collapsible.Trigger>
+    <Collapsible.Panel className="Panel" keepMounted>
+      <div className="Content">
+        <div>alien-bean-pasta</div>
+        <div>wild-irish-burrito</div>
+        <div>horse-battery-staple</div>
+      </div>
+    </Collapsible.Panel>
+  </Collapsible.Root>
+);
+
+export const Closed = () => (
+  <Collapsible.Root className="Collapsible">
+    <Collapsible.Trigger className="Trigger">
+      Recovery keys
+      <CaretRightIcon className="Icon" />
+    </Collapsible.Trigger>
+    <Collapsible.Panel className="Panel" keepMounted>
+      <div className="Content">
+        <div>alien-bean-pasta</div>
+        <div>wild-irish-burrito</div>
+        <div>horse-battery-staple</div>
+      </div>
+    </Collapsible.Panel>
+  </Collapsible.Root>
+);

--- a/.design-sync/previews/Combobox.css
+++ b/.design-sync/previews/Combobox.css
@@ -1,0 +1,140 @@
+.InputGroup {
+  box-sizing: border-box;
+  position: relative;
+  width: 14rem;
+  height: 2rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+}
+
+.Input {
+  box-sizing: border-box;
+  padding: 0 calc(0.5rem + 2rem) 0 0.5rem;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  height: 100%;
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+
+  &::placeholder {
+    color: oklch(55.6% 0 0deg);
+  }
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.Label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  color: oklch(14.5% 0 0deg);
+  position: relative;
+}
+
+.ActionButtons {
+  box-sizing: border-box;
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  bottom: 0;
+  height: 100%;
+  right: 0;
+  border: none;
+  color: oklch(55.6% 0 0deg);
+  padding: 0;
+}
+
+.Trigger {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 100%;
+  color: oklch(14.5% 0 0deg);
+  border: none;
+  padding: 0;
+  background: none;
+}
+
+.Positioner {
+  outline: 0;
+}
+
+.Popup {
+  box-sizing: border-box;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  width: var(--anchor-width);
+  max-width: var(--available-width);
+  transform-origin: var(--transform-origin);
+
+  border: 1px solid oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+}
+
+.List {
+  box-sizing: border-box;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-block: 0.25rem;
+  scroll-padding-block: 0.25rem;
+  outline: 0;
+  max-height: min(22.5rem, var(--available-height));
+
+  &[data-empty] {
+    padding: 0;
+  }
+}
+
+.Item {
+  box-sizing: border-box;
+  outline: 0;
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+  padding-block: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  display: grid;
+  gap: 0.5rem;
+  align-items: center;
+  grid-template-columns: 1rem 1fr;
+  font-size: 0.875rem;
+  line-height: 1rem;
+
+  &[data-highlighted] {
+    z-index: 0;
+    position: relative;
+    color: white;
+  }
+
+  &[data-highlighted]::before {
+    content: '';
+    z-index: -1;
+    position: absolute;
+    inset-block: 0;
+    inset-inline: 0;
+    background-color: oklch(14.5% 0 0deg);
+  }
+}
+
+.ItemText {
+  grid-column-start: 2;
+}
+
+.ItemIndicator {
+  grid-column-start: 1;
+}

--- a/.design-sync/previews/Combobox.tsx
+++ b/.design-sync/previews/Combobox.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import { Combobox } from '@base-ui/react';
+import './Combobox.css';
+
+interface Fruit {
+  label: string;
+  value: string;
+}
+
+const fruits: Fruit[] = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Orange', value: 'orange' },
+  { label: 'Pineapple', value: 'pineapple' },
+  { label: 'Grape', value: 'grape' },
+  { label: 'Mango', value: 'mango' },
+];
+
+function CheckIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="m2.5 8.5 4 4 7-9" />
+    </svg>
+  );
+}
+
+function CaretDownIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M12 6H4l4 4.5z" />
+    </svg>
+  );
+}
+
+export const Basic = () => (
+  <Combobox.Root items={fruits} defaultValue={fruits[0]} defaultOpen modal={false}>
+    <div className="Label">
+      <label htmlFor="combobox-basic-input">Choose a fruit</label>
+      <Combobox.InputGroup className="InputGroup">
+        <Combobox.Input placeholder="e.g. Apple" id="combobox-basic-input" className="Input" />
+        <div className="ActionButtons">
+          <Combobox.Trigger className="Trigger" aria-label="Open popup">
+            <CaretDownIcon />
+          </Combobox.Trigger>
+        </div>
+      </Combobox.InputGroup>
+    </div>
+
+    <Combobox.Portal>
+      <Combobox.Positioner className="Positioner" sideOffset={4}>
+        <Combobox.Popup className="Popup">
+          <Combobox.List className="List">
+            {(item: Fruit) => (
+              <Combobox.Item key={item.value} value={item} className="Item">
+                <Combobox.ItemIndicator className="ItemIndicator">
+                  <CheckIcon />
+                </Combobox.ItemIndicator>
+                <span className="ItemText">{item.label}</span>
+              </Combobox.Item>
+            )}
+          </Combobox.List>
+        </Combobox.Popup>
+      </Combobox.Positioner>
+    </Combobox.Portal>
+  </Combobox.Root>
+);
+
+export const Disabled = () => (
+  <Combobox.Root items={fruits} disabled modal={false}>
+    <div className="Label">
+      <label htmlFor="combobox-disabled-input">Choose a fruit</label>
+      <Combobox.InputGroup className="InputGroup">
+        <Combobox.Input
+          placeholder="e.g. Apple"
+          id="combobox-disabled-input"
+          className="Input"
+        />
+        <div className="ActionButtons">
+          <Combobox.Trigger className="Trigger" aria-label="Open popup">
+            <CaretDownIcon />
+          </Combobox.Trigger>
+        </div>
+      </Combobox.InputGroup>
+    </div>
+  </Combobox.Root>
+);

--- a/.design-sync/previews/ContextMenu.css
+++ b/.design-sync/previews/ContextMenu.css
@@ -1,0 +1,69 @@
+.Trigger {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  max-width: 16rem;
+  aspect-ratio: 5 / 3;
+  outline: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Positioner {
+  outline: 0;
+}
+
+.Popup {
+  box-sizing: border-box;
+  outline: 0;
+  padding-block: 0.25rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+}
+
+.Item {
+  outline: 0;
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+  padding-block: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 2rem;
+  display: flex;
+  font-size: 0.875rem;
+  line-height: 1rem;
+}
+
+.Item[data-highlighted] {
+  z-index: 0;
+  position: relative;
+  color: white;
+}
+
+.Item[data-highlighted]::before {
+  content: '';
+  z-index: -1;
+  position: absolute;
+  inset-block: 0;
+  inset-inline: 0.25rem;
+  background-color: oklch(14.5% 0 0deg);
+}
+
+.Item[data-disabled] {
+  color: oklch(55.6% 0 0deg);
+}
+
+.Separator {
+  margin: 0.25rem;
+  height: 1px;
+  background-color: oklch(14.5% 0 0deg);
+}

--- a/.design-sync/previews/ContextMenu.tsx
+++ b/.design-sync/previews/ContextMenu.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { ContextMenu } from '@base-ui/react';
+import './ContextMenu.css';
+
+export const Basic = () => (
+  <ContextMenu.Root defaultOpen>
+    <ContextMenu.Trigger className="Trigger">Right click here</ContextMenu.Trigger>
+    <ContextMenu.Portal>
+      <ContextMenu.Positioner className="Positioner">
+        <ContextMenu.Popup className="Popup">
+          <ContextMenu.Item className="Item">Add to Library</ContextMenu.Item>
+          <ContextMenu.Item className="Item">Add to Playlist</ContextMenu.Item>
+          <ContextMenu.Separator className="Separator" />
+          <ContextMenu.Item className="Item">Play Next</ContextMenu.Item>
+          <ContextMenu.Item className="Item">Play Last</ContextMenu.Item>
+          <ContextMenu.Separator className="Separator" />
+          <ContextMenu.Item className="Item">Favorite</ContextMenu.Item>
+          <ContextMenu.Item className="Item">Share</ContextMenu.Item>
+        </ContextMenu.Popup>
+      </ContextMenu.Positioner>
+    </ContextMenu.Portal>
+  </ContextMenu.Root>
+);

--- a/.design-sync/previews/Dialog.css
+++ b/.design-sync/previews/Dialog.css
@@ -1,0 +1,73 @@
+.Button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  height: 2rem;
+  padding: 0 0.75rem;
+  margin: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1;
+  white-space: nowrap;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Backdrop {
+  position: fixed;
+  min-height: 100dvh;
+  inset: 0;
+  background-color: black;
+  opacity: 0.2;
+}
+
+.Popup {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 24rem;
+  max-width: calc(100vw - 3rem);
+  margin-top: -2rem;
+  padding: 1rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+}
+
+.Intro {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.Title {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 700;
+}
+
+.Description {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(43.9% 0 0deg);
+}
+
+.Actions {
+  display: flex;
+  justify-content: end;
+  gap: 0.75rem;
+}

--- a/.design-sync/previews/Dialog.tsx
+++ b/.design-sync/previews/Dialog.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { Dialog } from '@base-ui/react';
+import './Dialog.css';
+
+export const Basic = () => (
+  <Dialog.Root defaultOpen modal={false}>
+    <Dialog.Trigger className="Button">View notifications</Dialog.Trigger>
+    <Dialog.Portal>
+      <Dialog.Backdrop className="Backdrop" />
+      <Dialog.Popup className="Popup">
+        <div className="Intro">
+          <Dialog.Title className="Title">Notifications</Dialog.Title>
+          <Dialog.Description className="Description">
+            You are all caught up. Good job!
+          </Dialog.Description>
+        </div>
+        <div className="Actions">
+          <Dialog.Close className="Button">Close</Dialog.Close>
+        </div>
+      </Dialog.Popup>
+    </Dialog.Portal>
+  </Dialog.Root>
+);

--- a/.design-sync/previews/DirectionProvider.css
+++ b/.design-sync/previews/DirectionProvider.css
@@ -1,0 +1,128 @@
+.Control {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  width: 14rem;
+  padding-block: 0.75rem;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Track {
+  width: 100%;
+  height: 0.25rem;
+  background-color: oklch(92.2% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Indicator {
+  background-color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Thumb {
+  box-sizing: border-box;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Thumb:has(:focus-visible) {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: 2px;
+}
+
+.Row {
+  display: flex;
+  gap: 2rem;
+}
+
+.Column {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.375rem;
+}
+
+.ColumnLabel {
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: oklch(55.6% 0 0deg);
+}
+
+.Accordion {
+  box-sizing: border-box;
+  display: flex;
+  max-width: 20rem;
+  width: 100%;
+  flex-direction: column;
+  border: 1px solid oklch(14.5% 0 0deg);
+  color: oklch(14.5% 0 0deg);
+}
+
+.Item + .Item {
+  border-top: 1px solid oklch(14.5% 0 0deg);
+}
+
+.Header {
+  margin: 0;
+}
+
+.Trigger {
+  box-sizing: border-box;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+  color: oklch(14.5% 0 0deg);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Trigger[data-disabled] {
+  color: oklch(70.8% 0 0deg);
+}
+
+.Icon {
+  transition: transform 100ms ease-out;
+}
+
+[data-panel-open] > .Icon {
+  transform: rotate(45deg);
+}
+
+.Panel {
+  box-sizing: border-box;
+  height: var(--accordion-panel-height);
+  overflow: hidden;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  transition: height 150ms ease-out;
+}
+
+.Panel[data-starting-style],
+.Panel[data-ending-style] {
+  height: 0;
+}
+
+.Content {
+  padding: 0.5rem 0.75rem;
+}

--- a/.design-sync/previews/DirectionProvider.tsx
+++ b/.design-sync/previews/DirectionProvider.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import { Accordion, DirectionProvider, Slider } from '@base-ui/react';
+import './DirectionProvider.css';
+
+function PlusIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="square"
+      strokeLinejoin="round"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M1.5 8h13M8 14.5v-13" />
+    </svg>
+  );
+}
+
+// Canonical hero demo composition: a Slider whose filled indicator and
+// thumb position visibly mirror when the reading direction flips to RTL.
+export const Basic = () => (
+  <div dir="rtl">
+    <DirectionProvider direction="rtl">
+      <Slider.Root defaultValue={25}>
+        <Slider.Control className="Control">
+          <Slider.Track className="Track">
+            <Slider.Indicator className="Indicator" />
+            <Slider.Thumb aria-label="Volume" className="Thumb" />
+          </Slider.Track>
+        </Slider.Control>
+      </Slider.Root>
+    </DirectionProvider>
+  </div>
+);
+
+// Side-by-side comparison: the same Slider composition under LTR vs RTL
+// direction, so the mirrored fill/thumb position is directly comparable.
+export const LtrVsRtl = () => (
+  <div className="Row">
+    <div className="Column">
+      <span className="ColumnLabel">LTR</span>
+      <div dir="ltr">
+        <DirectionProvider direction="ltr">
+          <Slider.Root defaultValue={25}>
+            <Slider.Control className="Control">
+              <Slider.Track className="Track">
+                <Slider.Indicator className="Indicator" />
+                <Slider.Thumb aria-label="Volume" className="Thumb" />
+              </Slider.Track>
+            </Slider.Control>
+          </Slider.Root>
+        </DirectionProvider>
+      </div>
+    </div>
+    <div className="Column">
+      <span className="ColumnLabel">RTL</span>
+      <div dir="rtl">
+        <DirectionProvider direction="rtl">
+          <Slider.Root defaultValue={25}>
+            <Slider.Control className="Control">
+              <Slider.Track className="Track">
+                <Slider.Indicator className="Indicator" />
+                <Slider.Thumb aria-label="Volume" className="Thumb" />
+              </Slider.Track>
+            </Slider.Control>
+          </Slider.Root>
+        </DirectionProvider>
+      </div>
+    </div>
+  </div>
+);
+
+// A second, more "real UI" composition: an Accordion rendered under RTL
+// direction. The trigger row (icon + label) visually mirrors because
+// Base UI's Accordion, like most flex-row compositions, follows the
+// document/CSS reading direction.
+export const AccordionRtl = () => (
+  <div dir="rtl">
+    <DirectionProvider direction="rtl">
+      <Accordion.Root className="Accordion" defaultValue={['a']}>
+        <Accordion.Item className="Item" value="a">
+          <Accordion.Header className="Header">
+            <Accordion.Trigger className="Trigger">
+              ما هو Base UI؟
+              <PlusIcon className="Icon" />
+            </Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Panel className="Panel">
+            <div className="Content">
+              Base UI هي مكتبة من مكونات React عالية الجودة وغير منسقة لأنظمة التصميم وتطبيقات
+              الويب.
+            </div>
+          </Accordion.Panel>
+        </Accordion.Item>
+        <Accordion.Item className="Item">
+          <Accordion.Header className="Header">
+            <Accordion.Trigger className="Trigger">
+              كيف أبدأ؟
+              <PlusIcon className="Icon" />
+            </Accordion.Trigger>
+          </Accordion.Header>
+          <Accordion.Panel className="Panel">
+            <div className="Content">راجع دليل "البدء السريع" في الوثائق.</div>
+          </Accordion.Panel>
+        </Accordion.Item>
+      </Accordion.Root>
+    </DirectionProvider>
+  </div>
+);

--- a/.design-sync/previews/Drawer.css
+++ b/.design-sync/previews/Drawer.css
@@ -1,0 +1,80 @@
+.Button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  height: 2rem;
+  padding: 0 0.75rem;
+  margin: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1;
+  white-space: nowrap;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Backdrop {
+  --backdrop-opacity: 0.2;
+  position: fixed;
+  min-height: 100dvh;
+  inset: 0;
+  background-color: black;
+  opacity: var(--backdrop-opacity);
+}
+
+.Viewport {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.Popup {
+  --bleed: 3rem;
+  box-sizing: border-box;
+  width: calc(20rem + var(--bleed));
+  max-width: calc(100vw - 3rem + var(--bleed));
+  height: 100%;
+  padding: 1.5rem;
+  padding-right: calc(1.5rem + var(--bleed));
+  margin-right: calc(-1 * var(--bleed));
+  border-left: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  outline: 0;
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+  overflow-y: auto;
+}
+
+.Content {
+  width: 100%;
+  max-width: 32rem;
+  margin: 0 auto;
+}
+
+.Title {
+  margin-top: 0;
+  margin-bottom: 0.25rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 700;
+}
+
+.Description {
+  margin: 0 0 1.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(43.9% 0 0deg);
+}
+
+.Actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}

--- a/.design-sync/previews/Drawer.tsx
+++ b/.design-sync/previews/Drawer.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { Drawer } from '@base-ui/react';
+import './Drawer.css';
+
+export const Basic = () => (
+  <Drawer.Root swipeDirection="right" defaultOpen modal={false}>
+    <Drawer.Trigger className="Button">Open drawer</Drawer.Trigger>
+    <Drawer.Portal>
+      <Drawer.Backdrop className="Backdrop" />
+      <Drawer.Viewport className="Viewport">
+        <Drawer.Popup className="Popup">
+          <Drawer.Content className="Content">
+            <Drawer.Title className="Title">Drawer</Drawer.Title>
+            <Drawer.Description className="Description">
+              This is a drawer that slides in from the side. You can swipe to dismiss it.
+            </Drawer.Description>
+            <div className="Actions">
+              <Drawer.Close className="Button">Close</Drawer.Close>
+            </div>
+          </Drawer.Content>
+        </Drawer.Popup>
+      </Drawer.Viewport>
+    </Drawer.Portal>
+  </Drawer.Root>
+);

--- a/.design-sync/previews/Field.css
+++ b/.design-sync/previews/Field.css
@@ -1,0 +1,66 @@
+.Field {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: 0.25rem;
+  width: 100%;
+  max-width: 16rem;
+}
+
+.Label {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Field[data-disabled] .Label {
+  opacity: 0.5;
+}
+
+.Input {
+  box-sizing: border-box;
+  padding: 0 0.5rem;
+  margin: 0;
+  border-radius: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  width: 100%;
+  height: 2rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Input::placeholder {
+  color: oklch(55.6% 0 0deg);
+}
+
+.Input:focus {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: -1px;
+}
+
+.Input[aria-invalid='true'] {
+  border-color: oklch(50.5% 0.213 27.518deg);
+}
+
+.Input:disabled {
+  opacity: 0.5;
+  background-color: oklch(97% 0 0deg);
+}
+
+.Error {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(50.5% 0.213 27.518deg);
+}
+
+.Description {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(43.9% 0 0deg);
+}

--- a/.design-sync/previews/Field.tsx
+++ b/.design-sync/previews/Field.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { Field } from '@base-ui/react';
+import './Field.css';
+
+export const Basic = () => (
+  <Field.Root className="Field">
+    <Field.Label className="Label">Name</Field.Label>
+    <Field.Control required placeholder="Required" className="Input" />
+
+    <Field.Error className="Error" match="valueMissing">
+      Please enter your name
+    </Field.Error>
+
+    <Field.Description className="Description">Visible on your profile</Field.Description>
+  </Field.Root>
+);
+
+export const Invalid = () => (
+  <Field.Root className="Field" invalid>
+    <Field.Label className="Label">Email</Field.Label>
+    <Field.Control
+      defaultValue="not-an-email"
+      aria-invalid
+      className="Input"
+    />
+    <Field.Error className="Error">Please enter a valid email address</Field.Error>
+  </Field.Root>
+);
+
+export const Disabled = () => (
+  <Field.Root className="Field" disabled>
+    <Field.Label className="Label">Company</Field.Label>
+    <Field.Control defaultValue="Acme Inc." className="Input" />
+    <Field.Description className="Description">Managed by your organization</Field.Description>
+  </Field.Root>
+);

--- a/.design-sync/previews/Fieldset.css
+++ b/.design-sync/previews/Fieldset.css
@@ -1,0 +1,65 @@
+.Fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 16rem;
+}
+
+.Fieldset[data-disabled] {
+  opacity: 0.5;
+}
+
+.Legend {
+  border-bottom: 1px solid oklch(14.5% 0 0deg);
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Field {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: 0.25rem;
+}
+
+.Label {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Input {
+  box-sizing: border-box;
+  padding: 0 0.5rem;
+  margin: 0;
+  border-radius: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  width: 100%;
+  height: 2rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Input::placeholder {
+  color: oklch(55.6% 0 0deg);
+}
+
+.Input:focus {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: -1px;
+}
+
+.Input:disabled {
+  background-color: oklch(97% 0 0deg);
+}

--- a/.design-sync/previews/Fieldset.tsx
+++ b/.design-sync/previews/Fieldset.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { Field, Fieldset } from '@base-ui/react';
+import './Fieldset.css';
+
+export const Basic = () => (
+  <Fieldset.Root className="Fieldset">
+    <Fieldset.Legend className="Legend">Billing details</Fieldset.Legend>
+
+    <Field.Root className="Field">
+      <Field.Label className="Label">Company</Field.Label>
+      <Field.Control placeholder="Enter company name" className="Input" />
+    </Field.Root>
+
+    <Field.Root className="Field">
+      <Field.Label className="Label">Tax ID</Field.Label>
+      <Field.Control placeholder="Enter fiscal number" className="Input" />
+    </Field.Root>
+  </Fieldset.Root>
+);
+
+export const Disabled = () => (
+  <Fieldset.Root className="Fieldset" disabled>
+    <Fieldset.Legend className="Legend">Billing details</Fieldset.Legend>
+
+    <Field.Root className="Field">
+      <Field.Label className="Label">Company</Field.Label>
+      <Field.Control defaultValue="Acme Inc." className="Input" />
+    </Field.Root>
+
+    <Field.Root className="Field">
+      <Field.Label className="Label">Tax ID</Field.Label>
+      <Field.Control defaultValue="12-3456789" className="Input" />
+    </Field.Root>
+  </Fieldset.Root>
+);

--- a/.design-sync/previews/Form.css
+++ b/.design-sync/previews/Form.css
@@ -1,0 +1,97 @@
+.Form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 16rem;
+}
+
+.Field {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: 0.25rem;
+}
+
+.Label {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Input {
+  box-sizing: border-box;
+  padding: 0 0.5rem;
+  margin: 0;
+  border-radius: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  width: 100%;
+  height: 2rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Input::placeholder {
+  color: oklch(55.6% 0 0deg);
+}
+
+.Input:focus {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: -1px;
+}
+
+.Input[aria-invalid='true'] {
+  border-color: oklch(50.5% 0.213 27.518deg);
+}
+
+.Error {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(50.5% 0.213 27.518deg);
+}
+
+.SubmitButton {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  height: 2rem;
+  padding: 0 0.75rem;
+  margin: 0;
+  outline: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  border-radius: 0;
+  background-color: white;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1;
+  white-space: nowrap;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.SubmitButton:hover:not([data-disabled]) {
+  background-color: oklch(97% 0 0deg);
+}
+
+.SubmitButton:active:not([data-disabled]) {
+  background-color: oklch(92.2% 0 0deg);
+}
+
+.SubmitButton[data-disabled] {
+  color: oklch(55.6% 0 0deg);
+  border-color: oklch(55.6% 0 0deg);
+}
+
+.SubmitButton:focus-visible {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: -1px;
+}

--- a/.design-sync/previews/Form.tsx
+++ b/.design-sync/previews/Form.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { Field, Form, Button } from '@base-ui/react';
+import './Form.css';
+
+export const Basic = () => (
+  <Form className="Form">
+    <Field.Root name="url" className="Field">
+      <Field.Label className="Label">Homepage</Field.Label>
+      <Field.Control
+        type="url"
+        required
+        defaultValue="https://example.com"
+        placeholder="https://example.com"
+        pattern="https?://.*"
+        className="Input"
+      />
+      <Field.Error className="Error" />
+    </Field.Root>
+    <Button type="submit" className="SubmitButton">
+      Submit
+    </Button>
+  </Form>
+);
+
+export const ValidationError = () => (
+  <Form className="Form" errors={{ url: 'The example domain is not allowed' }}>
+    <Field.Root name="url" className="Field">
+      <Field.Label className="Label">Homepage</Field.Label>
+      <Field.Control
+        type="url"
+        required
+        defaultValue="https://example.com"
+        aria-invalid
+        className="Input"
+      />
+      <Field.Error className="Error">The example domain is not allowed</Field.Error>
+    </Field.Root>
+    <Button type="submit" className="SubmitButton">
+      Submit
+    </Button>
+  </Form>
+);

--- a/.design-sync/previews/Input.css
+++ b/.design-sync/previews/Input.css
@@ -1,0 +1,40 @@
+.Label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Input {
+  box-sizing: border-box;
+  padding: 0 0.5rem;
+  margin: 0;
+  border-radius: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  width: 10rem;
+  height: 2rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Input::placeholder {
+  color: oklch(55.6% 0 0deg);
+}
+
+.Input:focus {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: -1px;
+}
+
+.Input:disabled {
+  opacity: 0.5;
+  background-color: oklch(97% 0 0deg);
+}

--- a/.design-sync/previews/Input.tsx
+++ b/.design-sync/previews/Input.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { Input } from '@base-ui/react';
+import './Input.css';
+
+export const Basic = () => (
+  <label className="Label">
+    Name
+    <Input placeholder="e.g. Colm Tuite" className="Input" />
+  </label>
+);
+
+export const WithValue = () => (
+  <label className="Label">
+    Email
+    <Input type="email" defaultValue="colm@example.com" className="Input" />
+  </label>
+);
+
+export const Disabled = () => (
+  <label className="Label">
+    Company
+    <Input disabled defaultValue="Acme Inc." className="Input" />
+  </label>
+);

--- a/.design-sync/previews/Menu.css
+++ b/.design-sync/previews/Menu.css
@@ -1,0 +1,74 @@
+.Button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  height: 2rem;
+  padding: 0 0.5rem 0 0.75rem;
+  margin: 0;
+  outline: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1;
+  white-space: nowrap;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Positioner {
+  outline: 0;
+}
+
+.Popup {
+  box-sizing: border-box;
+  position: relative;
+  outline: 0;
+  padding-block: 0.25rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+}
+
+.Item {
+  outline: 0;
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+  padding-block: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 2rem;
+  display: flex;
+  font-size: 0.875rem;
+  line-height: 1rem;
+}
+
+.Item[data-highlighted] {
+  z-index: 0;
+  position: relative;
+  color: white;
+}
+
+.Item[data-highlighted]::before {
+  content: '';
+  z-index: -1;
+  position: absolute;
+  inset-block: 0;
+  inset-inline: 0.25rem;
+  background-color: oklch(14.5% 0 0deg);
+}
+
+.Item[data-disabled] {
+  color: oklch(55.6% 0 0deg);
+}
+
+.Separator {
+  margin: 0.25rem;
+  height: 1px;
+  background-color: oklch(14.5% 0 0deg);
+}

--- a/.design-sync/previews/Menu.tsx
+++ b/.design-sync/previews/Menu.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { Menu } from '@base-ui/react';
+import './Menu.css';
+
+function CaretDownIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M12 6H4l4 4.5z" />
+    </svg>
+  );
+}
+
+export const Basic = () => (
+  <Menu.Root defaultOpen modal={false}>
+    <Menu.Trigger className="Button">
+      Song <CaretDownIcon />
+    </Menu.Trigger>
+    <Menu.Portal>
+      <Menu.Positioner className="Positioner" sideOffset={8} align="start">
+        <Menu.Popup className="Popup">
+          <Menu.Item className="Item">Add to Library</Menu.Item>
+          <Menu.Item className="Item">Add to Playlist</Menu.Item>
+          <Menu.Separator className="Separator" />
+          <Menu.Item className="Item">Play Next</Menu.Item>
+          <Menu.Item className="Item">Play Last</Menu.Item>
+          <Menu.Separator className="Separator" />
+          <Menu.Item className="Item">Favorite</Menu.Item>
+          <Menu.Item className="Item">Share</Menu.Item>
+        </Menu.Popup>
+      </Menu.Positioner>
+    </Menu.Portal>
+  </Menu.Root>
+);
+
+export const WithDisabledItem = () => (
+  <Menu.Root defaultOpen modal={false}>
+    <Menu.Trigger className="Button">
+      Song <CaretDownIcon />
+    </Menu.Trigger>
+    <Menu.Portal>
+      <Menu.Positioner className="Positioner" sideOffset={8} align="start">
+        <Menu.Popup className="Popup">
+          <Menu.Item className="Item">Add to Library</Menu.Item>
+          <Menu.Item className="Item" disabled>
+            Add to Playlist
+          </Menu.Item>
+          <Menu.Separator className="Separator" />
+          <Menu.Item className="Item">Play Next</Menu.Item>
+          <Menu.Item className="Item">Play Last</Menu.Item>
+        </Menu.Popup>
+      </Menu.Positioner>
+    </Menu.Portal>
+  </Menu.Root>
+);

--- a/.design-sync/previews/Menubar.css
+++ b/.design-sync/previews/Menubar.css
@@ -1,0 +1,105 @@
+.Menubar {
+  display: flex;
+  align-items: center;
+}
+
+.MenuTrigger {
+  box-sizing: border-box;
+  height: 2rem;
+  padding: 0 0.75rem;
+  margin: 0;
+  border: 0;
+  background-color: transparent;
+  color: oklch(14.5% 0 0deg);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.MenuTrigger[data-pressed] {
+  background-color: oklch(97% 0 0deg);
+}
+
+.MenuTrigger[data-disabled] {
+  color: oklch(55.6% 0 0deg);
+}
+
+.MenuPositioner {
+  outline: 0;
+}
+
+.MenuPopup {
+  box-sizing: border-box;
+  outline: 0;
+  padding-block: 0.25rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+}
+
+.MenuItem,
+.SubmenuTrigger {
+  outline: 0;
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+  padding-block: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  display: flex;
+  font-size: 0.875rem;
+  line-height: 1rem;
+  font-weight: 400;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.MenuItem[data-highlighted],
+.SubmenuTrigger[data-highlighted] {
+  z-index: 0;
+  position: relative;
+  color: white;
+}
+
+.MenuItem[data-highlighted]::before,
+.SubmenuTrigger[data-highlighted]::before {
+  content: '';
+  z-index: -1;
+  position: absolute;
+  inset-block: 0;
+  inset-inline: 0.25rem;
+  background-color: oklch(14.5% 0 0deg);
+}
+
+.SubmenuTrigger {
+  padding-right: 0.5rem;
+}
+
+.SubmenuTrigger[data-popup-open] {
+  z-index: 0;
+  position: relative;
+}
+
+.SubmenuTrigger[data-popup-open]::before {
+  content: '';
+  z-index: -1;
+  position: absolute;
+  inset-block: 0;
+  inset-inline: 0.25rem;
+  background-color: oklch(97% 0 0deg);
+}
+
+.SubmenuTrigger[data-highlighted][data-popup-open]::before {
+  background-color: oklch(14.5% 0 0deg);
+}
+
+.MenuSeparator {
+  margin: 0.25rem;
+  height: 1px;
+  background-color: oklch(14.5% 0 0deg);
+}

--- a/.design-sync/previews/Menubar.tsx
+++ b/.design-sync/previews/Menubar.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import { Menubar, Menu } from '@base-ui/react';
+import './Menubar.css';
+
+function CaretRightIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M6 12V4l4.5 4z" />
+    </svg>
+  );
+}
+
+export const Basic = () => (
+  <Menubar className="Menubar" modal={false}>
+    <Menu.Root defaultOpen modal={false}>
+      <Menu.Trigger className="MenuTrigger">File</Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner className="MenuPositioner" sideOffset={4}>
+          <Menu.Popup className="MenuPopup">
+            <Menu.Item className="MenuItem">New</Menu.Item>
+            <Menu.Item className="MenuItem">Open</Menu.Item>
+            <Menu.Item className="MenuItem">Save</Menu.Item>
+
+            <Menu.SubmenuRoot>
+              <Menu.SubmenuTrigger className="SubmenuTrigger">
+                Export
+                <CaretRightIcon />
+              </Menu.SubmenuTrigger>
+              <Menu.Portal>
+                <Menu.Positioner className="MenuPositioner" sideOffset={-4} alignOffset={-4}>
+                  <Menu.Popup className="MenuPopup">
+                    <Menu.Item className="MenuItem">PDF</Menu.Item>
+                    <Menu.Item className="MenuItem">PNG</Menu.Item>
+                    <Menu.Item className="MenuItem">SVG</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.SubmenuRoot>
+
+            <Menu.Separator className="MenuSeparator" />
+            <Menu.Item className="MenuItem">Print</Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+
+    <Menu.Root modal={false}>
+      <Menu.Trigger className="MenuTrigger">Edit</Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner className="MenuPositioner" sideOffset={4}>
+          <Menu.Popup className="MenuPopup">
+            <Menu.Item className="MenuItem">Cut</Menu.Item>
+            <Menu.Item className="MenuItem">Copy</Menu.Item>
+            <Menu.Item className="MenuItem">Paste</Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+
+    <Menu.Root modal={false}>
+      <Menu.Trigger className="MenuTrigger">View</Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner className="MenuPositioner" sideOffset={4}>
+          <Menu.Popup className="MenuPopup">
+            <Menu.Item className="MenuItem">Zoom In</Menu.Item>
+            <Menu.Item className="MenuItem">Zoom Out</Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+
+    <Menu.Root disabled modal={false}>
+      <Menu.Trigger className="MenuTrigger">Help</Menu.Trigger>
+    </Menu.Root>
+  </Menubar>
+);
+
+export const SubmenuOpen = () => (
+  <Menubar className="Menubar" modal={false}>
+    <Menu.Root defaultOpen modal={false}>
+      <Menu.Trigger className="MenuTrigger">File</Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner className="MenuPositioner" sideOffset={4}>
+          <Menu.Popup className="MenuPopup">
+            <Menu.Item className="MenuItem">New</Menu.Item>
+            <Menu.Item className="MenuItem">Open</Menu.Item>
+            <Menu.Item className="MenuItem">Save</Menu.Item>
+
+            <Menu.SubmenuRoot defaultOpen>
+              <Menu.SubmenuTrigger className="SubmenuTrigger">
+                Export
+                <CaretRightIcon />
+              </Menu.SubmenuTrigger>
+              <Menu.Portal>
+                <Menu.Positioner className="MenuPositioner" sideOffset={-4} alignOffset={-4}>
+                  <Menu.Popup className="MenuPopup">
+                    <Menu.Item className="MenuItem">PDF</Menu.Item>
+                    <Menu.Item className="MenuItem">PNG</Menu.Item>
+                    <Menu.Item className="MenuItem">SVG</Menu.Item>
+                  </Menu.Popup>
+                </Menu.Positioner>
+              </Menu.Portal>
+            </Menu.SubmenuRoot>
+
+            <Menu.Separator className="MenuSeparator" />
+            <Menu.Item className="MenuItem">Print</Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+
+    <Menu.Root modal={false}>
+      <Menu.Trigger className="MenuTrigger">Edit</Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner className="MenuPositioner" sideOffset={4}>
+          <Menu.Popup className="MenuPopup">
+            <Menu.Item className="MenuItem">Cut</Menu.Item>
+            <Menu.Item className="MenuItem">Copy</Menu.Item>
+            <Menu.Item className="MenuItem">Paste</Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  </Menubar>
+);

--- a/.design-sync/previews/Meter.css
+++ b/.design-sync/previews/Meter.css
@@ -1,0 +1,33 @@
+.Meter {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  row-gap: 0.5rem;
+  width: 15rem;
+  max-width: 100%;
+}
+
+.Label {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Value {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(14.5% 0 0deg);
+  text-align: right;
+}
+
+.Track {
+  grid-column: 1 / 3;
+  overflow: hidden;
+  height: 0.75rem;
+  background-color: oklch(92.2% 0 0deg);
+}
+
+.Indicator {
+  background-color: oklch(14.5% 0 0deg);
+  transition: width 500ms;
+}

--- a/.design-sync/previews/Meter.tsx
+++ b/.design-sync/previews/Meter.tsx
@@ -1,0 +1,32 @@
+import { Meter } from '@base-ui/react';
+import './Meter.css';
+
+export const Basic = () => (
+  <Meter.Root className="Meter" value={24}>
+    <Meter.Label className="Label">Storage Used</Meter.Label>
+    <Meter.Value className="Value" />
+    <Meter.Track className="Track">
+      <Meter.Indicator className="Indicator" />
+    </Meter.Track>
+  </Meter.Root>
+);
+
+export const Mid = () => (
+  <Meter.Root className="Meter" value={58}>
+    <Meter.Label className="Label">Storage Used</Meter.Label>
+    <Meter.Value className="Value" />
+    <Meter.Track className="Track">
+      <Meter.Indicator className="Indicator" />
+    </Meter.Track>
+  </Meter.Root>
+);
+
+export const High = () => (
+  <Meter.Root className="Meter" value={92}>
+    <Meter.Label className="Label">Storage Used</Meter.Label>
+    <Meter.Value className="Value" />
+    <Meter.Track className="Track">
+      <Meter.Indicator className="Indicator" />
+    </Meter.Track>
+  </Meter.Root>
+);

--- a/.design-sync/previews/NavigationMenu.css
+++ b/.design-sync/previews/NavigationMenu.css
@@ -1,0 +1,173 @@
+.Root {
+  box-sizing: border-box;
+  color: oklch(14.5% 0 0deg);
+  min-width: max-content;
+}
+
+.List {
+  display: flex;
+  position: relative;
+  gap: 1px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.Trigger {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  height: 2rem;
+  padding: 0 0.75rem;
+  margin: 0;
+  outline: 0;
+  border: 0;
+  background-color: transparent;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+  text-decoration: none;
+}
+
+.Icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease;
+
+  &[data-popup-open] {
+    transform: rotate(180deg);
+  }
+}
+
+.Positioner {
+  box-sizing: border-box;
+  width: var(--positioner-width);
+  height: var(--positioner-height);
+  max-width: var(--available-width);
+}
+
+.Popup {
+  position: relative;
+  overflow: visible;
+  box-sizing: border-box;
+  outline: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+  transform-origin: var(--transform-origin);
+  width: var(--popup-width);
+  height: var(--popup-height);
+}
+
+.Content {
+  box-sizing: border-box;
+  padding: 0.5rem;
+  width: calc(100vw - 40px);
+  height: 100%;
+  max-width: 400px;
+}
+
+.Viewport {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+}
+
+.GridLinkList {
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.FlexLinkList {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  max-width: 400px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.LinkCard {
+  box-sizing: border-box;
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+  text-align: left;
+  border: 0;
+  background-color: transparent;
+}
+
+.LinkTitle {
+  margin: 0 0 4px;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1rem;
+}
+
+.LinkDescription {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(55.6% 0 0deg);
+}
+
+.Arrow {
+  display: block;
+  position: relative;
+  width: 12px;
+  height: 6px;
+  overflow: clip;
+
+  &[data-side='top'] {
+    bottom: -6px;
+    rotate: 180deg;
+  }
+
+  &[data-side='bottom'] {
+    top: -6px;
+    rotate: 0deg;
+  }
+
+  &[data-side='left'] {
+    right: -9px;
+    rotate: 90deg;
+  }
+
+  &[data-side='right'] {
+    left: -9px;
+    rotate: -90deg;
+  }
+
+  &::before {
+    content: '';
+    display: block;
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    box-sizing: border-box;
+    width: calc(6px * sqrt(2));
+    height: calc(6px * sqrt(2));
+    border: 1px solid oklch(14.5% 0 0deg);
+    background-color: white;
+    transform: translate(-50%, 50%) rotate(45deg);
+  }
+}

--- a/.design-sync/previews/NavigationMenu.tsx
+++ b/.design-sync/previews/NavigationMenu.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import { NavigationMenu } from '@base-ui/react';
+import './NavigationMenu.css';
+
+function CaretDownIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M12 6H4l4 4.5z" />
+    </svg>
+  );
+}
+
+const overviewLinks = [
+  {
+    href: '/react/overview/quick-start',
+    title: 'Quick Start',
+    description: 'Install and assemble your first component.',
+  },
+  {
+    href: '/react/overview/accessibility',
+    title: 'Accessibility',
+    description: 'Learn how we build accessible components.',
+  },
+  {
+    href: '/react/overview/releases',
+    title: 'Releases',
+    description: 'See what’s new in the latest Base UI versions.',
+  },
+  {
+    href: '/react/overview/about',
+    title: 'About',
+    description: 'Learn more about Base UI and our mission.',
+  },
+] as const;
+
+const handbookLinks = [
+  {
+    href: '/react/handbook/styling',
+    title: 'Styling',
+    description:
+      'Base UI components can be styled with plain CSS, Tailwind CSS, CSS-in-JS, or CSS Modules.',
+  },
+  {
+    href: '/react/handbook/animation',
+    title: 'Animation',
+    description:
+      'Base UI components can be animated with CSS transitions, CSS animations, or JavaScript libraries.',
+  },
+  {
+    href: '/react/handbook/composition',
+    title: 'Composition',
+    description:
+      'Base UI components can be replaced and composed with your own existing components.',
+  },
+] as const;
+
+export const Basic = () => (
+  <NavigationMenu.Root className="Root" defaultValue="overview">
+    <NavigationMenu.List className="List">
+      <NavigationMenu.Item value="overview">
+        <NavigationMenu.Trigger className="Trigger">
+          Overview
+          <NavigationMenu.Icon className="Icon">
+            <CaretDownIcon />
+          </NavigationMenu.Icon>
+        </NavigationMenu.Trigger>
+        <NavigationMenu.Content className="Content">
+          <ul className="GridLinkList">
+            {overviewLinks.map((item) => (
+              <li key={item.href}>
+                <NavigationMenu.Link className="LinkCard" href={item.href}>
+                  <h3 className="LinkTitle">{item.title}</h3>
+                  <p className="LinkDescription">{item.description}</p>
+                </NavigationMenu.Link>
+              </li>
+            ))}
+          </ul>
+        </NavigationMenu.Content>
+      </NavigationMenu.Item>
+
+      <NavigationMenu.Item value="handbook">
+        <NavigationMenu.Trigger className="Trigger">
+          Handbook
+          <NavigationMenu.Icon className="Icon">
+            <CaretDownIcon />
+          </NavigationMenu.Icon>
+        </NavigationMenu.Trigger>
+        <NavigationMenu.Content className="Content">
+          <ul className="FlexLinkList">
+            {handbookLinks.map((item) => (
+              <li key={item.href}>
+                <NavigationMenu.Link className="LinkCard" href={item.href}>
+                  <h3 className="LinkTitle">{item.title}</h3>
+                  <p className="LinkDescription">{item.description}</p>
+                </NavigationMenu.Link>
+              </li>
+            ))}
+          </ul>
+        </NavigationMenu.Content>
+      </NavigationMenu.Item>
+
+      <NavigationMenu.Item>
+        <NavigationMenu.Link className="Trigger" href="https://github.com/mui/base-ui">
+          GitHub
+        </NavigationMenu.Link>
+      </NavigationMenu.Item>
+    </NavigationMenu.List>
+
+    <NavigationMenu.Portal>
+      <NavigationMenu.Positioner
+        className="Positioner"
+        sideOffset={10}
+        collisionPadding={{ top: 5, bottom: 5, left: 20, right: 20 }}
+        collisionAvoidance={{ side: 'none' }}
+      >
+        <NavigationMenu.Popup className="Popup">
+          <NavigationMenu.Arrow className="Arrow" />
+          <NavigationMenu.Viewport className="Viewport" />
+        </NavigationMenu.Popup>
+      </NavigationMenu.Positioner>
+    </NavigationMenu.Portal>
+  </NavigationMenu.Root>
+);

--- a/.design-sync/previews/NumberField.css
+++ b/.design-sync/previews/NumberField.css
@@ -1,0 +1,98 @@
+.Field {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: 0.25rem;
+}
+
+.Field[data-disabled] {
+  opacity: 0.5;
+}
+
+.ScrubArea {
+  cursor: ew-resize;
+  font-weight: 700;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Label {
+  cursor: ew-resize;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Group {
+  display: flex;
+  height: 2rem;
+}
+
+.Input {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0 0.5rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  border-radius: 0;
+  width: 7ch;
+  height: 100%;
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  text-align: left;
+  font-variant-numeric: tabular-nums;
+}
+
+.Input:focus {
+  z-index: 1;
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: -1px;
+}
+
+.Decrement,
+.Increment {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 100%;
+  margin: 0;
+  outline: 0;
+  padding: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  border-radius: 0;
+  background-color: white;
+  background-clip: padding-box;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Decrement:hover:not([data-disabled]),
+.Increment:hover:not([data-disabled]) {
+  background-color: oklch(97% 0 0deg);
+}
+
+.Decrement:active:not([data-disabled]),
+.Increment:active:not([data-disabled]) {
+  background-color: oklch(92.2% 0 0deg);
+}
+
+.Decrement[data-disabled],
+.Increment[data-disabled] {
+  color: oklch(55.6% 0 0deg);
+  border-color: oklch(55.6% 0 0deg);
+}
+
+.Decrement {
+  border-right: 0;
+}
+
+.Increment {
+  border-left: 0;
+}

--- a/.design-sync/previews/NumberField.tsx
+++ b/.design-sync/previews/NumberField.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { NumberField } from '@base-ui/react';
+import './NumberField.css';
+
+function PlusIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="square"
+      strokeLinejoin="round"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M1.5 8h13M8 14.5v-13" />
+    </svg>
+  );
+}
+
+function MinusIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="square"
+      strokeLinejoin="round"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M1.5 8h13" />
+    </svg>
+  );
+}
+
+export const Basic = () => {
+  const id = React.useId();
+  return (
+    <NumberField.Root id={id} defaultValue={100} className="Field">
+      <NumberField.ScrubArea className="ScrubArea">
+        <label htmlFor={id} className="Label">
+          Amount
+        </label>
+      </NumberField.ScrubArea>
+
+      <NumberField.Group className="Group">
+        <NumberField.Decrement className="Decrement">
+          <MinusIcon />
+        </NumberField.Decrement>
+        <NumberField.Input className="Input" />
+        <NumberField.Increment className="Increment">
+          <PlusIcon />
+        </NumberField.Increment>
+      </NumberField.Group>
+    </NumberField.Root>
+  );
+};
+
+export const Disabled = () => {
+  const id = React.useId();
+  return (
+    <NumberField.Root id={id} defaultValue={100} disabled className="Field">
+      <label htmlFor={id} className="Label">
+        Amount
+      </label>
+
+      <NumberField.Group className="Group">
+        <NumberField.Decrement className="Decrement">
+          <MinusIcon />
+        </NumberField.Decrement>
+        <NumberField.Input className="Input" />
+        <NumberField.Increment className="Increment">
+          <PlusIcon />
+        </NumberField.Increment>
+      </NumberField.Group>
+    </NumberField.Root>
+  );
+};
+
+export const MinMax = () => {
+  const id = React.useId();
+  return (
+    <NumberField.Root id={id} defaultValue={0} min={0} max={10} className="Field">
+      <label htmlFor={id} className="Label">
+        Quantity
+      </label>
+
+      <NumberField.Group className="Group">
+        <NumberField.Decrement className="Decrement">
+          <MinusIcon />
+        </NumberField.Decrement>
+        <NumberField.Input className="Input" />
+        <NumberField.Increment className="Increment">
+          <PlusIcon />
+        </NumberField.Increment>
+      </NumberField.Group>
+    </NumberField.Root>
+  );
+};

--- a/.design-sync/previews/OTPField.css
+++ b/.design-sync/previews/OTPField.css
@@ -1,0 +1,54 @@
+.Field {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: 0.25rem;
+  width: 100%;
+  max-width: 20rem;
+}
+
+.Label {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Root {
+  display: flex;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.Root[data-disabled] {
+  opacity: 0.5;
+}
+
+.Input {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0;
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 400;
+  text-align: center;
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Input:focus {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: -1px;
+}
+
+.Description {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(43.9% 0 0deg);
+}

--- a/.design-sync/previews/OTPField.tsx
+++ b/.design-sync/previews/OTPField.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import { OTPField } from '@base-ui/react';
+import './OTPField.css';
+
+const OTP_LENGTH = 6;
+
+export const Basic = () => {
+  const id = React.useId();
+  const descriptionId = `${id}-description`;
+
+  return (
+    <div className="Field">
+      <label htmlFor={id} className="Label">
+        Verification code
+      </label>
+      <OTPField.Root id={id} length={OTP_LENGTH} aria-describedby={descriptionId} className="Root">
+        {Array.from({ length: OTP_LENGTH }, (_, index) => (
+          <OTPField.Input
+            key={index}
+            className="Input"
+            aria-label={index === 0 ? undefined : `Character ${index + 1} of ${OTP_LENGTH}`}
+          />
+        ))}
+      </OTPField.Root>
+      <p id={descriptionId} className="Description">
+        Enter the 6-character code we sent to your device.
+      </p>
+    </div>
+  );
+};
+
+export const Filled = () => {
+  const id = React.useId();
+  const descriptionId = `${id}-description`;
+
+  return (
+    <div className="Field">
+      <label htmlFor={id} className="Label">
+        Verification code
+      </label>
+      <OTPField.Root
+        id={id}
+        length={OTP_LENGTH}
+        defaultValue="482913"
+        aria-describedby={descriptionId}
+        className="Root"
+      >
+        {Array.from({ length: OTP_LENGTH }, (_, index) => (
+          <OTPField.Input
+            key={index}
+            className="Input"
+            aria-label={index === 0 ? undefined : `Character ${index + 1} of ${OTP_LENGTH}`}
+          />
+        ))}
+      </OTPField.Root>
+      <p id={descriptionId} className="Description">
+        Enter the 6-character code we sent to your device.
+      </p>
+    </div>
+  );
+};
+
+export const Disabled = () => {
+  const id = React.useId();
+  const descriptionId = `${id}-description`;
+
+  return (
+    <div className="Field">
+      <label htmlFor={id} className="Label">
+        Verification code
+      </label>
+      <OTPField.Root
+        id={id}
+        length={OTP_LENGTH}
+        disabled
+        aria-describedby={descriptionId}
+        className="Root"
+      >
+        {Array.from({ length: OTP_LENGTH }, (_, index) => (
+          <OTPField.Input
+            key={index}
+            className="Input"
+            aria-label={index === 0 ? undefined : `Character ${index + 1} of ${OTP_LENGTH}`}
+          />
+        ))}
+      </OTPField.Root>
+      <p id={descriptionId} className="Description">
+        Enter the 6-character code we sent to your device.
+      </p>
+    </div>
+  );
+};

--- a/.design-sync/previews/Popover.css
+++ b/.design-sync/previews/Popover.css
@@ -1,0 +1,104 @@
+.Popup {
+  box-sizing: border-box;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  outline: none;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+  max-width: 500px;
+  width: max-content;
+}
+
+.Arrow {
+  display: block;
+  position: relative;
+  width: 12px;
+  height: 6px;
+  overflow: clip;
+}
+
+.Arrow[data-side='top'] {
+  bottom: -6px;
+  rotate: 180deg;
+}
+
+.Arrow[data-side='bottom'] {
+  top: -6px;
+  rotate: 0deg;
+}
+
+.Arrow[data-side='left'] {
+  right: -9px;
+  rotate: 90deg;
+}
+
+.Arrow[data-side='right'] {
+  left: -9px;
+  rotate: -90deg;
+}
+
+.Arrow::before {
+  content: '';
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  box-sizing: border-box;
+  width: calc(6px * sqrt(2));
+  height: calc(6px * sqrt(2));
+  background-color: white;
+  border: 1px solid oklch(14.5% 0 0deg);
+  transform: translate(-50%, 50%) rotate(45deg);
+}
+
+.Title {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+}
+
+.Description {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(43.9% 0 0deg);
+}
+
+.Actions {
+  display: flex;
+  justify-content: end;
+  margin-top: 0.5rem;
+}
+
+.Button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  height: 2rem;
+  padding: 0 0.75rem;
+  margin: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1;
+  white-space: nowrap;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Button[data-disabled],
+.Button:disabled {
+  color: oklch(55.6% 0 0deg);
+  border-color: oklch(55.6% 0 0deg);
+}

--- a/.design-sync/previews/Popover.tsx
+++ b/.design-sync/previews/Popover.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Popover } from '@base-ui/react';
+import './Popover.css';
+
+export const Basic = () => (
+  <Popover.Root defaultOpen modal={false}>
+    <Popover.Trigger className="Button">Notifications</Popover.Trigger>
+    <Popover.Portal>
+      <Popover.Positioner sideOffset={8}>
+        <Popover.Popup className="Popup">
+          <Popover.Arrow className="Arrow" />
+          <Popover.Title className="Title">Notifications</Popover.Title>
+          <Popover.Description className="Description">
+            You are all caught up. Good job!
+          </Popover.Description>
+        </Popover.Popup>
+      </Popover.Positioner>
+    </Popover.Portal>
+  </Popover.Root>
+);
+
+export const InfoPanel = () => (
+  <Popover.Root defaultOpen modal={false}>
+    <Popover.Trigger className="Button">Account limits</Popover.Trigger>
+    <Popover.Portal>
+      <Popover.Positioner sideOffset={8}>
+        <Popover.Popup className="Popup">
+          <Popover.Arrow className="Arrow" />
+          <Popover.Title className="Title">Storage usage</Popover.Title>
+          <Popover.Description className="Description">
+            You have used 8.2 GB of your 10 GB plan. Upgrade to get more space.
+          </Popover.Description>
+          <div className="Actions">
+            <Popover.Close className="Button">Dismiss</Popover.Close>
+          </div>
+        </Popover.Popup>
+      </Popover.Positioner>
+    </Popover.Portal>
+  </Popover.Root>
+);
+
+export const Disabled = () => (
+  <Popover.Root modal={false}>
+    <Popover.Trigger className="Button" disabled>
+      Notifications
+    </Popover.Trigger>
+  </Popover.Root>
+);

--- a/.design-sync/previews/PreviewCard.css
+++ b/.design-sync/previews/PreviewCard.css
@@ -1,0 +1,94 @@
+.Popup {
+  box-sizing: border-box;
+  position: relative;
+  width: var(--popup-width, auto);
+  height: var(--popup-height, auto);
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+}
+
+.Arrow {
+  display: block;
+  position: relative;
+  width: 12px;
+  height: 6px;
+  overflow: clip;
+}
+
+.Arrow[data-side='top'] {
+  bottom: -6px;
+  rotate: 180deg;
+}
+
+.Arrow[data-side='bottom'] {
+  top: -6px;
+  rotate: 0deg;
+}
+
+.Arrow[data-side='left'] {
+  right: -9px;
+  rotate: 90deg;
+}
+
+.Arrow[data-side='right'] {
+  left: -9px;
+  rotate: -90deg;
+}
+
+.Arrow::before {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  box-sizing: border-box;
+  width: calc(6px * 1.41421356);
+  height: calc(6px * 1.41421356);
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  transform: translate(-50%, 50%) rotate(45deg);
+}
+
+.PopupContent {
+  width: min-content;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  box-sizing: border-box;
+}
+
+.ImagePlaceholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 224px;
+  height: 150px;
+  background-color: oklch(92.2% 0 0deg);
+  color: oklch(43.9% 0 0deg);
+  font-size: 0.875rem;
+}
+
+.Summary {
+  margin: 0;
+  width: 224px;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.Paragraph {
+  margin: 0;
+  max-width: 20rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Link {
+  outline: 0;
+  color: oklch(14.5% 0 0deg);
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}

--- a/.design-sync/previews/PreviewCard.tsx
+++ b/.design-sync/previews/PreviewCard.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { PreviewCard } from '@base-ui/react';
+import './PreviewCard.css';
+
+export const Basic = () => (
+  <PreviewCard.Root defaultOpen>
+    <p className="Paragraph">
+      The principles of good{' '}
+      <PreviewCard.Trigger className="Link" href="https://en.wikipedia.org/wiki/Typography">
+        typography
+      </PreviewCard.Trigger>{' '}
+      remain in the digital age.
+    </p>
+
+    <PreviewCard.Portal>
+      <PreviewCard.Positioner sideOffset={8}>
+        <PreviewCard.Popup className="Popup">
+          <PreviewCard.Arrow className="Arrow" />
+          <div className="PopupContent">
+            <div className="ImagePlaceholder">Typography</div>
+            <p className="Summary">
+              <strong>Typography</strong> is the art and science of arranging type to make written
+              language clear, visually appealing, and effective in communication.
+            </p>
+          </div>
+        </PreviewCard.Popup>
+      </PreviewCard.Positioner>
+    </PreviewCard.Portal>
+  </PreviewCard.Root>
+);

--- a/.design-sync/previews/Progress.css
+++ b/.design-sync/previews/Progress.css
@@ -1,0 +1,42 @@
+.Progress {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  row-gap: 0.5rem;
+  width: 15rem;
+  max-width: 100%;
+}
+
+.Label {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Value {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(14.5% 0 0deg);
+  text-align: right;
+}
+
+.Track {
+  grid-column: 1 / 3;
+  overflow: hidden;
+  height: 0.25rem;
+  background-color: oklch(92.2% 0 0deg);
+}
+
+.Indicator {
+  height: 100%;
+  background-color: oklch(14.5% 0 0deg);
+  transition: width 500ms;
+}
+
+/* The indicator has no inline width/height when indeterminate
+   (percentageValue is null) since the real component drives an animation
+   via JS/CSS the demo doesn't define; give it a fixed partial width here so
+   the static screenshot reads as "in progress" rather than empty. */
+.Indicator[data-indeterminate] {
+  width: 40%;
+}

--- a/.design-sync/previews/Progress.tsx
+++ b/.design-sync/previews/Progress.tsx
@@ -1,0 +1,42 @@
+import { Progress } from '@base-ui/react';
+import './Progress.css';
+
+export const Basic = () => (
+  <Progress.Root className="Progress" value={20}>
+    <Progress.Label className="Label">Export data</Progress.Label>
+    <Progress.Value className="Value" />
+    <Progress.Track className="Track">
+      <Progress.Indicator className="Indicator" />
+    </Progress.Track>
+  </Progress.Root>
+);
+
+export const Mid = () => (
+  <Progress.Root className="Progress" value={65}>
+    <Progress.Label className="Label">Export data</Progress.Label>
+    <Progress.Value className="Value" />
+    <Progress.Track className="Track">
+      <Progress.Indicator className="Indicator" />
+    </Progress.Track>
+  </Progress.Root>
+);
+
+export const Complete = () => (
+  <Progress.Root className="Progress" value={100}>
+    <Progress.Label className="Label">Export data</Progress.Label>
+    <Progress.Value className="Value" />
+    <Progress.Track className="Track">
+      <Progress.Indicator className="Indicator" />
+    </Progress.Track>
+  </Progress.Root>
+);
+
+export const Indeterminate = () => (
+  <Progress.Root className="Progress" value={null}>
+    <Progress.Label className="Label">Export data</Progress.Label>
+    <Progress.Value className="Value" />
+    <Progress.Track className="Track">
+      <Progress.Indicator className="Indicator" />
+    </Progress.Track>
+  </Progress.Root>
+);

--- a/.design-sync/previews/Radio.css
+++ b/.design-sync/previews/Radio.css
@@ -1,0 +1,70 @@
+.RadioGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: 0.25rem;
+  color: oklch(14.5% 0 0deg);
+}
+
+.RadioGroup[data-disabled] {
+  opacity: 0.4;
+}
+
+.Caption {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+}
+
+.Item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+}
+
+.Radio {
+  box-sizing: border-box;
+  display: flex;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid oklch(14.5% 0 0deg);
+  border-radius: 100%;
+  background-color: white;
+  color: white;
+  padding: 0;
+  margin: 0;
+}
+
+.Radio[data-checked] {
+  background-color: oklch(14.5% 0 0deg);
+  color: white;
+}
+
+.Radio:focus-visible {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: 2px;
+}
+
+.Indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.Indicator[data-unchecked] {
+  display: none;
+}
+
+.Indicator::before {
+  content: '';
+  border-radius: 100%;
+  width: 0.5rem;
+  height: 0.5rem;
+  background-color: currentcolor;
+}

--- a/.design-sync/previews/Radio.tsx
+++ b/.design-sync/previews/Radio.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { Radio } from '@base-ui/react';
+import { RadioGroup } from '@base-ui/react';
+import './Radio.css';
+
+export const Basic = () => (
+  <RadioGroup aria-label="Best apple" defaultValue="fuji-apple" className="RadioGroup">
+    <div className="Caption">Best apple</div>
+    <label className="Item">
+      <Radio.Root value="fuji-apple" className="Radio">
+        <Radio.Indicator className="Indicator" />
+      </Radio.Root>
+      Fuji
+    </label>
+    <label className="Item">
+      <Radio.Root value="gala-apple" className="Radio">
+        <Radio.Indicator className="Indicator" />
+      </Radio.Root>
+      Gala
+    </label>
+    <label className="Item">
+      <Radio.Root value="granny-smith-apple" className="Radio">
+        <Radio.Indicator className="Indicator" />
+      </Radio.Root>
+      Granny Smith
+    </label>
+  </RadioGroup>
+);
+
+export const Disabled = () => (
+  <RadioGroup aria-label="Best apple" disabled defaultValue="fuji-apple" className="RadioGroup">
+    <div className="Caption">Best apple</div>
+    <label className="Item">
+      <Radio.Root value="fuji-apple" className="Radio">
+        <Radio.Indicator className="Indicator" />
+      </Radio.Root>
+      Fuji
+    </label>
+    <label className="Item">
+      <Radio.Root value="gala-apple" className="Radio">
+        <Radio.Indicator className="Indicator" />
+      </Radio.Root>
+      Gala
+    </label>
+  </RadioGroup>
+);

--- a/.design-sync/previews/RadioGroup.css
+++ b/.design-sync/previews/RadioGroup.css
@@ -1,0 +1,70 @@
+.RadioGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: 0.25rem;
+  color: oklch(14.5% 0 0deg);
+}
+
+.RadioGroup[data-disabled] {
+  opacity: 0.4;
+}
+
+.Caption {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+}
+
+.Item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+}
+
+.Radio {
+  box-sizing: border-box;
+  display: flex;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid oklch(14.5% 0 0deg);
+  border-radius: 100%;
+  background-color: white;
+  color: white;
+  padding: 0;
+  margin: 0;
+}
+
+.Radio[data-checked] {
+  background-color: oklch(14.5% 0 0deg);
+  color: white;
+}
+
+.Radio:focus-visible {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: 2px;
+}
+
+.Indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.Indicator[data-unchecked] {
+  display: none;
+}
+
+.Indicator::before {
+  content: '';
+  border-radius: 100%;
+  width: 0.5rem;
+  height: 0.5rem;
+  background-color: currentcolor;
+}

--- a/.design-sync/previews/RadioGroup.tsx
+++ b/.design-sync/previews/RadioGroup.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { Radio } from '@base-ui/react';
+import { RadioGroup } from '@base-ui/react';
+import './RadioGroup.css';
+
+export const Basic = () => (
+  <RadioGroup aria-label="Best apple" defaultValue="fuji-apple" className="RadioGroup">
+    <div className="Caption">Best apple</div>
+    <label className="Item">
+      <Radio.Root value="fuji-apple" className="Radio">
+        <Radio.Indicator className="Indicator" />
+      </Radio.Root>
+      Fuji
+    </label>
+    <label className="Item">
+      <Radio.Root value="gala-apple" className="Radio">
+        <Radio.Indicator className="Indicator" />
+      </Radio.Root>
+      Gala
+    </label>
+    <label className="Item">
+      <Radio.Root value="granny-smith-apple" className="Radio">
+        <Radio.Indicator className="Indicator" />
+      </Radio.Root>
+      Granny Smith
+    </label>
+  </RadioGroup>
+);
+
+export const Disabled = () => (
+  <RadioGroup aria-label="Best apple" disabled defaultValue="fuji-apple" className="RadioGroup">
+    <div className="Caption">Best apple</div>
+    <label className="Item">
+      <Radio.Root value="fuji-apple" className="Radio">
+        <Radio.Indicator className="Indicator" />
+      </Radio.Root>
+      Fuji
+    </label>
+    <label className="Item">
+      <Radio.Root value="gala-apple" className="Radio">
+        <Radio.Indicator className="Indicator" />
+      </Radio.Root>
+      Gala
+    </label>
+  </RadioGroup>
+);

--- a/.design-sync/previews/ScrollArea.css
+++ b/.design-sync/previews/ScrollArea.css
@@ -1,0 +1,46 @@
+.ScrollArea {
+  box-sizing: border-box;
+  width: 24rem;
+  height: 8.5rem;
+  max-width: 100%;
+  background-color: white;
+}
+
+.Viewport {
+  box-sizing: border-box;
+  height: 100%;
+  border: 1px solid oklch(14.5% 0 0deg);
+}
+
+.Content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-block: 0.5rem;
+  padding-left: 0.75rem;
+  padding-right: 1.25rem;
+}
+
+.Paragraph {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.375rem;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Scrollbar {
+  display: flex;
+  justify-content: center;
+  background-color: rgb(0 0 0 / 12%);
+  width: 1rem;
+  margin: 1px;
+  /* The real demo fades the scrollbar in only on hover/scroll (opacity 0 by
+     default). Hover state can't be simulated in a static screenshot, so the
+     scrollbar is forced visible here to show the thumb. */
+  opacity: 1;
+}
+
+.Thumb {
+  width: 100%;
+  background-color: oklch(14.5% 0 0deg);
+}

--- a/.design-sync/previews/ScrollArea.tsx
+++ b/.design-sync/previews/ScrollArea.tsx
@@ -1,0 +1,39 @@
+import { ScrollArea } from '@base-ui/react';
+import './ScrollArea.css';
+
+export const Basic = () => (
+  <ScrollArea.Root className="ScrollArea">
+    <ScrollArea.Viewport className="Viewport">
+      <ScrollArea.Content className="Content">
+        <p className="Paragraph">
+          Vernacular architecture is building done outside any academic tradition, and without
+          professional guidance. It is not a particular architectural movement or style, but
+          rather a broad category, encompassing a wide range and variety of building types, with
+          differing methods of construction, from around the world, both historical and extant
+          and classical and modern. Vernacular architecture constitutes 95% of the world's built
+          environment, as estimated in 1995 by Amos Rapoport, as measured against the small
+          percentage of new buildings every year designed by architects and built by engineers.
+        </p>
+        <p className="Paragraph">
+          This type of architecture usually serves immediate, local needs, is constrained by the
+          materials available in its particular region and reflects local traditions and cultural
+          practices. The study of vernacular architecture does not examine formally schooled
+          architects, but instead that of the design skills and tradition of local builders, who
+          were rarely given any attribution for the work. More recently, vernacular architecture
+          has been examined by designers and the building industry in an effort to be more energy
+          conscious with contemporary design and construction—part of a broader interest in
+          sustainable design.
+        </p>
+        <p className="Paragraph">
+          Vernacular architecture can be found across the inhabited world, and, whatever culture,
+          takes a similar path in developing appropriate methods and forms. Buildings are made
+          using locally available resources and traditions to address needs, whether accommodation,
+          storage, or gathering places.
+        </p>
+      </ScrollArea.Content>
+    </ScrollArea.Viewport>
+    <ScrollArea.Scrollbar className="Scrollbar">
+      <ScrollArea.Thumb className="Thumb" />
+    </ScrollArea.Scrollbar>
+  </ScrollArea.Root>
+);

--- a/.design-sync/previews/Select.css
+++ b/.design-sync/previews/Select.css
@@ -1,0 +1,110 @@
+.Field {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: 0.25rem;
+}
+
+.Label {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 700;
+  color: oklch(14.5% 0 0deg);
+  cursor: default;
+}
+
+.Value[data-placeholder] {
+  color: oklch(55.6% 0 0deg);
+}
+
+.Select {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  height: 2rem;
+  padding-left: 0.5rem;
+  padding-right: 0.25rem;
+  margin: 0;
+  outline: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1;
+  white-space: nowrap;
+  font-weight: 400;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+  min-width: 10rem;
+
+  &[data-disabled] {
+    color: oklch(55.6% 0 0deg);
+    border-color: oklch(55.6% 0 0deg);
+  }
+}
+
+.Positioner {
+  outline: none;
+  z-index: 10;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Popup {
+  box-sizing: border-box;
+  outline: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  background-clip: padding-box;
+  color: oklch(14.5% 0 0deg);
+  min-width: var(--anchor-width);
+  transform-origin: var(--transform-origin);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+
+  &[data-side='none'] {
+    transform: translateY(1px);
+    min-width: calc(var(--anchor-width) + 1.75rem);
+  }
+}
+
+.List {
+  box-sizing: border-box;
+  position: relative;
+  padding-block: 0.25rem;
+  overflow-y: auto;
+  max-height: var(--available-height);
+  scroll-padding-block: 1.5rem;
+}
+
+.Item {
+  box-sizing: border-box;
+  outline: 0;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  padding-block: 0.375rem;
+  padding-left: 0.625rem;
+  padding-right: 1rem;
+  display: grid;
+  gap: 0.5rem;
+  align-items: center;
+  grid-template-columns: 1rem 1fr;
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+
+  &[data-highlighted] {
+    background-color: oklch(14.5% 0 0deg);
+    color: white;
+  }
+}
+
+.ItemIndicator {
+  grid-column-start: 1;
+}
+
+.ItemText {
+  grid-column-start: 2;
+}

--- a/.design-sync/previews/Select.tsx
+++ b/.design-sync/previews/Select.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { Select } from '@base-ui/react';
+import './Select.css';
+
+const apples = [
+  { label: 'Gala', value: 'gala' },
+  { label: 'Fuji', value: 'fuji' },
+  { label: 'Honeycrisp', value: 'honeycrisp' },
+  { label: 'Granny Smith', value: 'granny-smith' },
+  { label: 'Pink Lady', value: 'pink-lady' },
+];
+
+function CaretUpDownIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M11 10H5l3 3.5zm0-4H5l3-3.5z" />
+    </svg>
+  );
+}
+
+function CheckIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="m2.5 8.5 4 4 7-9" />
+    </svg>
+  );
+}
+
+export const Basic = () => (
+  <div className="Field">
+    <Select.Root items={apples} defaultOpen modal={false}>
+      <Select.Label className="Label">Apple</Select.Label>
+      <Select.Trigger className="Select">
+        <Select.Value className="Value" placeholder="Select apple" />
+        <Select.Icon>
+          <CaretUpDownIcon />
+        </Select.Icon>
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Positioner className="Positioner" sideOffset={4}>
+          <Select.Popup className="Popup">
+            <Select.List className="List">
+              {apples.map(({ label, value }) => (
+                <Select.Item key={label} value={value} className="Item">
+                  <Select.ItemIndicator className="ItemIndicator">
+                    <CheckIcon />
+                  </Select.ItemIndicator>
+                  <Select.ItemText className="ItemText">{label}</Select.ItemText>
+                </Select.Item>
+              ))}
+            </Select.List>
+          </Select.Popup>
+        </Select.Positioner>
+      </Select.Portal>
+    </Select.Root>
+  </div>
+);
+
+export const Disabled = () => (
+  <div className="Field">
+    <Select.Root items={apples} disabled modal={false}>
+      <Select.Label className="Label">Apple</Select.Label>
+      <Select.Trigger className="Select">
+        <Select.Value className="Value" placeholder="Select apple" />
+        <Select.Icon>
+          <CaretUpDownIcon />
+        </Select.Icon>
+      </Select.Trigger>
+    </Select.Root>
+  </div>
+);

--- a/.design-sync/previews/Separator.css
+++ b/.design-sync/previews/Separator.css
@@ -1,0 +1,35 @@
+.Container {
+  display: flex;
+  gap: 1rem;
+  text-wrap: nowrap;
+  align-items: center;
+}
+
+.VerticalContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 12rem;
+}
+
+.Separator {
+  width: 1px;
+  align-self: stretch;
+  background-color: oklch(87% 0 0deg);
+}
+
+.SeparatorHorizontal {
+  height: 1px;
+  width: 100%;
+  background-color: oklch(87% 0 0deg);
+}
+
+.Link {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: oklch(14.5% 0 0deg);
+  text-decoration-color: oklch(87% 0 0deg);
+  text-decoration-thickness: 1px;
+  text-decoration-line: none;
+  text-underline-offset: 2px;
+}

--- a/.design-sync/previews/Separator.tsx
+++ b/.design-sync/previews/Separator.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { Separator } from '@base-ui/react';
+import './Separator.css';
+
+export const Horizontal = () => (
+  <div className="VerticalContainer">
+    <span className="Link">Section one</span>
+    <Separator orientation="horizontal" className="SeparatorHorizontal" />
+    <span className="Link">Section two</span>
+  </div>
+);
+
+export const Vertical = () => (
+  <div className="Container">
+    <a href="#" className="Link">
+      Home
+    </a>
+    <a href="#" className="Link">
+      Pricing
+    </a>
+    <a href="#" className="Link">
+      Blog
+    </a>
+    <a href="#" className="Link">
+      Support
+    </a>
+
+    <Separator orientation="vertical" className="Separator" />
+
+    <a href="#" className="Link">
+      Log in
+    </a>
+    <a href="#" className="Link">
+      Sign up
+    </a>
+  </div>
+);

--- a/.design-sync/previews/Slider.css
+++ b/.design-sync/previews/Slider.css
@@ -1,0 +1,46 @@
+.Control {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  width: 14rem;
+  padding-block: 0.75rem;
+  touch-action: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Track {
+  width: 100%;
+  height: 0.25rem;
+  background-color: oklch(92.2% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Indicator {
+  background-color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Thumb {
+  box-sizing: border-box;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Control[data-disabled] .Track {
+  background-color: oklch(96% 0 0deg);
+}
+
+.Control[data-disabled] .Indicator {
+  background-color: oklch(70.8% 0 0deg);
+}
+
+.Control[data-disabled] .Thumb {
+  border-color: oklch(70.8% 0 0deg);
+}

--- a/.design-sync/previews/Slider.tsx
+++ b/.design-sync/previews/Slider.tsx
@@ -1,0 +1,36 @@
+import { Slider } from '@base-ui/react';
+import './Slider.css';
+
+export const Basic = () => (
+  <Slider.Root defaultValue={25}>
+    <Slider.Control className="Control">
+      <Slider.Track className="Track">
+        <Slider.Indicator className="Indicator" />
+        <Slider.Thumb aria-label="Volume" className="Thumb" />
+      </Slider.Track>
+    </Slider.Control>
+  </Slider.Root>
+);
+
+export const Range = () => (
+  <Slider.Root defaultValue={[25, 45]}>
+    <Slider.Control className="Control">
+      <Slider.Track className="Track">
+        <Slider.Indicator className="Indicator" />
+        <Slider.Thumb index={0} aria-label="Minimum value" className="Thumb" />
+        <Slider.Thumb index={1} aria-label="Maximum value" className="Thumb" />
+      </Slider.Track>
+    </Slider.Control>
+  </Slider.Root>
+);
+
+export const Disabled = () => (
+  <Slider.Root defaultValue={40} disabled>
+    <Slider.Control className="Control">
+      <Slider.Track className="Track">
+        <Slider.Indicator className="Indicator" />
+        <Slider.Thumb aria-label="Volume" className="Thumb" />
+      </Slider.Track>
+    </Slider.Control>
+  </Slider.Root>
+);

--- a/.design-sync/previews/Switch.css
+++ b/.design-sync/previews/Switch.css
@@ -1,0 +1,48 @@
+.Label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  color: oklch(14.5% 0 0deg);
+}
+
+.Switch {
+  box-sizing: border-box;
+  display: flex;
+  flex-shrink: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  padding: 0.125rem;
+  width: 2.25rem;
+  height: 1.25rem;
+  background-color: white;
+  transition: background-color 150ms ease;
+}
+
+.Switch[data-checked] {
+  background-color: oklch(14.5% 0 0deg);
+}
+
+.Switch[data-disabled] {
+  opacity: 0.4;
+}
+
+.Switch:focus-visible {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: 2px;
+}
+
+.Thumb {
+  width: 0.875rem;
+  height: 0.875rem;
+  background-color: oklch(14.5% 0 0deg);
+  transition:
+    translate 150ms ease,
+    background-color 150ms ease;
+}
+
+.Thumb[data-checked] {
+  translate: 1rem 0;
+  background-color: white;
+}

--- a/.design-sync/previews/Switch.tsx
+++ b/.design-sync/previews/Switch.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { Switch } from '@base-ui/react';
+import './Switch.css';
+
+export const Basic = () => (
+  <label className="Label">
+    <Switch.Root defaultChecked className="Switch">
+      <Switch.Thumb className="Thumb" />
+    </Switch.Root>
+    Notifications
+  </label>
+);
+
+export const Unchecked = () => (
+  <label className="Label">
+    <Switch.Root className="Switch">
+      <Switch.Thumb className="Thumb" />
+    </Switch.Root>
+    Airplane mode
+  </label>
+);
+
+export const Disabled = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+    <label className="Label">
+      <Switch.Root disabled className="Switch">
+        <Switch.Thumb className="Thumb" />
+      </Switch.Root>
+      Disabled, off
+    </label>
+    <label className="Label">
+      <Switch.Root disabled defaultChecked className="Switch">
+        <Switch.Thumb className="Thumb" />
+      </Switch.Root>
+      Disabled, on
+    </label>
+  </div>
+);

--- a/.design-sync/previews/Tabs.css
+++ b/.design-sync/previews/Tabs.css
@@ -1,0 +1,91 @@
+.Root {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 20rem;
+}
+
+.List {
+  display: flex;
+  position: relative;
+  z-index: 1;
+  gap: 0.25rem;
+  margin-bottom: -1px;
+}
+
+.Tab {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  margin: 0;
+  outline: 0;
+  background: none;
+  color: oklch(43.9% 0 0deg);
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 400;
+  -webkit-user-select: none;
+  user-select: none;
+  white-space: nowrap;
+  word-break: keep-all;
+  padding-inline: 0.5rem;
+  padding-block: 0;
+  height: calc(2rem + 1px);
+}
+
+.Tab[data-active] {
+  color: oklch(14.5% 0 0deg);
+}
+
+.Indicator {
+  box-sizing: border-box;
+  position: absolute;
+  z-index: -1;
+  left: 0;
+  top: 0;
+  translate: var(--active-tab-left);
+  width: var(--active-tab-width);
+  height: 100%;
+  transition-property: translate, width;
+  transition-duration: 150ms;
+  transition-timing-function: ease-in-out;
+  border-top: 1px solid oklch(14.5% 0 0deg);
+  border-inline: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+}
+
+.PanelViewport {
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  width: 100%;
+  min-height: 8rem;
+  border-inline: 1px solid oklch(14.5% 0 0deg);
+  border-block: 1px solid oklch(14.5% 0 0deg);
+}
+
+.Panel {
+  box-sizing: border-box;
+  grid-area: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 1rem;
+  outline: 0;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  text-align: center;
+  color: oklch(14.5% 0 0deg);
+  background-color: white;
+}
+
+.Panel[hidden] {
+  display: none;
+}
+
+.Paragraph {
+  margin: 0;
+}

--- a/.design-sync/previews/Tabs.tsx
+++ b/.design-sync/previews/Tabs.tsx
@@ -1,0 +1,58 @@
+import { Tabs } from '@base-ui/react';
+import './Tabs.css';
+
+export const Basic = () => (
+  <Tabs.Root className="Root" defaultValue="overview">
+    <Tabs.List className="List">
+      <Tabs.Tab className="Tab" value="overview">
+        Overview
+      </Tabs.Tab>
+      <Tabs.Tab className="Tab" value="projects">
+        Projects
+      </Tabs.Tab>
+      <Tabs.Tab className="Tab" value="account">
+        Account
+      </Tabs.Tab>
+      <Tabs.Indicator className="Indicator" />
+    </Tabs.List>
+    <div className="PanelViewport">
+      <Tabs.Panel className="Panel" value="overview">
+        <p className="Paragraph">Workspace stats and activity.</p>
+      </Tabs.Panel>
+      <Tabs.Panel className="Panel" value="projects">
+        <p className="Paragraph">Milestones and deadlines.</p>
+      </Tabs.Panel>
+      <Tabs.Panel className="Panel" value="account">
+        <p className="Paragraph">Profile and preferences.</p>
+      </Tabs.Panel>
+    </div>
+  </Tabs.Root>
+);
+
+export const ActiveProjects = () => (
+  <Tabs.Root className="Root" defaultValue="projects">
+    <Tabs.List className="List">
+      <Tabs.Tab className="Tab" value="overview">
+        Overview
+      </Tabs.Tab>
+      <Tabs.Tab className="Tab" value="projects">
+        Projects
+      </Tabs.Tab>
+      <Tabs.Tab className="Tab" value="account">
+        Account
+      </Tabs.Tab>
+      <Tabs.Indicator className="Indicator" />
+    </Tabs.List>
+    <div className="PanelViewport">
+      <Tabs.Panel className="Panel" value="overview">
+        <p className="Paragraph">Workspace stats and activity.</p>
+      </Tabs.Panel>
+      <Tabs.Panel className="Panel" value="projects">
+        <p className="Paragraph">Milestones and deadlines.</p>
+      </Tabs.Panel>
+      <Tabs.Panel className="Panel" value="account">
+        <p className="Paragraph">Profile and preferences.</p>
+      </Tabs.Panel>
+    </div>
+  </Tabs.Root>
+);

--- a/.design-sync/previews/Toast.css
+++ b/.design-sync/previews/Toast.css
@@ -1,0 +1,74 @@
+.PreviewRoot {
+  box-sizing: border-box;
+  width: 24rem;
+  height: 10rem;
+  max-width: 100%;
+}
+
+.Viewport {
+  position: fixed;
+  z-index: 1;
+  width: 20rem;
+  max-width: calc(100vw - 2rem);
+  bottom: 1rem;
+  right: 1rem;
+}
+
+.Toast {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+  cursor: default;
+}
+
+.Content {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem;
+  overflow: hidden;
+}
+
+.Text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.Title {
+  font-weight: 700;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  margin: 0;
+}
+
+.Description {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  margin: 0;
+}
+
+.Close {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  height: 2rem;
+  padding: 0 0.75rem;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1;
+  white-space: nowrap;
+}

--- a/.design-sync/previews/Toast.tsx
+++ b/.design-sync/previews/Toast.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { Toast } from '@base-ui/react';
+import './Toast.css';
+
+// Toast is purely imperative (`useToastManager().add()`), so there is no
+// static "open" prop to set like other overlay components. To render a
+// toast for a static screenshot, seed one via the manager on mount instead
+// of behind a button click.
+function useSeedToast(options: { title: string; description: string }) {
+  const toastManager = Toast.useToastManager();
+  const added = React.useRef(false);
+
+  React.useEffect(() => {
+    if (added.current) {
+      return;
+    }
+    added.current = true;
+    toastManager.add(options);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+function SeedToast(props: { title: string; description: string }) {
+  useSeedToast(props);
+  return null;
+}
+
+function ToastList() {
+  const { toasts } = Toast.useToastManager();
+  return toasts.map((toast) => (
+    <Toast.Root key={toast.id} toast={toast} className="Toast">
+      <Toast.Content className="Content">
+        <div className="Text">
+          <Toast.Title className="Title" />
+          <Toast.Description className="Description" />
+        </div>
+        <Toast.Close className="Close">Dismiss</Toast.Close>
+      </Toast.Content>
+    </Toast.Root>
+  ));
+}
+
+export const Basic = () => (
+  <div className="PreviewRoot">
+    <Toast.Provider>
+      <SeedToast title="Toast created" description="This is a toast notification." />
+      <Toast.Portal>
+        <Toast.Viewport className="Viewport">
+          <ToastList />
+        </Toast.Viewport>
+      </Toast.Portal>
+    </Toast.Provider>
+  </div>
+);

--- a/.design-sync/previews/Toggle.css
+++ b/.design-sync/previews/Toggle.css
@@ -1,0 +1,35 @@
+.Panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.Button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Button[data-pressed] {
+  color: oklch(14.5% 0 0deg);
+}
+
+.Button[data-disabled] {
+  opacity: 0.4;
+}
+
+.Button:focus-visible {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: -1px;
+}

--- a/.design-sync/previews/Toggle.tsx
+++ b/.design-sync/previews/Toggle.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { Toggle } from '@base-ui/react';
+import './Toggle.css';
+
+function HeartFilledIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M7.99961 13.8667C7.88761 13.8667 7.77561 13.8315 7.68121 13.7611C7.43321 13.5766 1.59961 9.1963 1.59961 5.8667C1.59961 3.80856 3.27481 2.13336 5.33294 2.13336C6.59054 2.13336 7.49934 2.81176 7.99961 3.3131C8.49988 2.81176 9.40868 2.13336 10.6663 2.13336C12.7244 2.13336 14.3996 3.80803 14.3996 5.8667C14.3996 9.1963 8.56601 13.5766 8.31801 13.7616C8.22361 13.8315 8.11161 13.8667 7.99961 13.8667Z" />
+    </svg>
+  );
+}
+
+function HeartOutlineIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="m7.99961 4.8232-.75505-.75666c-.40333-.40419-1.0559-.86651-1.91162-.86651-1.46903 0-2.66666 1.19764-2.66666 2.66667 0 .5412.24648 1.2356.75339 2.04713.49581.79376 1.17682 1.59861 1.89311 2.33647 1.06989 1.1022 2.1604 1.9962 2.68705 2.4102.52751-.4149 1.61735-1.3085 2.68657-2.4101.7163-.73792 1.3973-1.54278 1.8932-2.33656.5069-.81154.7533-1.50594.7533-2.04714 0-1.46947-1.1975-2.66667-2.6666-2.66667-.85574 0-1.50831.46232-1.91164.86651zm-.01387-1.52394c-.5031-.49988-1.40673-1.1659-2.6528-1.1659-2.05813 0-3.73333 1.6752-3.73333 3.73334 0 3.3296 5.8336 7.7099 6.0816 7.8944a.532.532 0 0 0 .3184.1056c.112 0 .224-.0352.3184-.1051.248-.185 6.08159-4.5653 6.08159-7.8949 0-2.05867-1.6752-3.73334-3.7333-3.73334-1.24617 0-2.14985.66611-2.65293 1.166q-.0069.00686-.0137.01367c.00002-.00003-.00002.00002 0 0-.00459-.0046-.00927-.00914-.01393-.01377"
+      />
+    </svg>
+  );
+}
+
+export const Basic = () => (
+  <div className="Panel">
+    <Toggle
+      aria-label="Favorite"
+      className="Button"
+      render={(props, state) => {
+        if (state.pressed) {
+          return (
+            <button type="button" {...props}>
+              <HeartFilledIcon />
+            </button>
+          );
+        }
+
+        return (
+          <button type="button" {...props}>
+            <HeartOutlineIcon />
+          </button>
+        );
+      }}
+    />
+  </div>
+);
+
+export const Pressed = () => (
+  <div className="Panel">
+    <Toggle
+      aria-label="Favorite"
+      defaultPressed
+      className="Button"
+      render={(props, state) => {
+        if (state.pressed) {
+          return (
+            <button type="button" {...props}>
+              <HeartFilledIcon />
+            </button>
+          );
+        }
+
+        return (
+          <button type="button" {...props}>
+            <HeartOutlineIcon />
+          </button>
+        );
+      }}
+    />
+  </div>
+);
+
+export const Disabled = () => (
+  <div className="Panel" style={{ display: 'flex', gap: '0.5rem' }}>
+    <Toggle aria-label="Favorite, disabled off" disabled className="Button">
+      <HeartOutlineIcon />
+    </Toggle>
+    <Toggle aria-label="Favorite, disabled on" disabled defaultPressed className="Button">
+      <HeartFilledIcon />
+    </Toggle>
+  </div>
+);

--- a/.design-sync/previews/ToggleGroup.css
+++ b/.design-sync/previews/ToggleGroup.css
@@ -1,0 +1,39 @@
+.Panel {
+  display: flex;
+  gap: 1px;
+  padding: 1px;
+  border: 1px solid oklch(14.5% 0 0deg);
+}
+
+.Panel[data-disabled] {
+  opacity: 0.4;
+}
+
+.Button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Button[data-pressed] {
+  background-color: oklch(14.5% 0 0deg);
+  color: white;
+}
+
+.Button:focus-visible {
+  outline: 2px solid oklch(14.5% 0 0deg);
+  outline-offset: 1px;
+  position: relative;
+  z-index: 1;
+}

--- a/.design-sync/previews/ToggleGroup.tsx
+++ b/.design-sync/previews/ToggleGroup.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { Toggle } from '@base-ui/react';
+import { ToggleGroup } from '@base-ui/react';
+import './ToggleGroup.css';
+
+function AlignLeftIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      fill="none"
+      viewBox="0 0 16 16"
+      stroke="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path strokeLinecap="square" strokeLinejoin="round" d="M2.5 4.5h11m-11 7h9M2.5 8h5" />
+    </svg>
+  );
+}
+
+function AlignCenterIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      stroke="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path strokeLinecap="square" strokeLinejoin="round" d="M2.5 4.5h11m-10 7h9M5.5 8h5" />
+    </svg>
+  );
+}
+
+function AlignRightIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      stroke="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path strokeLinecap="square" strokeLinejoin="round" d="M2.5 4.5h11m-9 7h9M8.5 8h5" />
+    </svg>
+  );
+}
+
+export const Basic = () => (
+  <ToggleGroup aria-label="Text alignment" defaultValue={['left']} className="Panel">
+    <Toggle aria-label="Align left" value="left" className="Button">
+      <AlignLeftIcon />
+    </Toggle>
+    <Toggle aria-label="Align center" value="center" className="Button">
+      <AlignCenterIcon />
+    </Toggle>
+    <Toggle aria-label="Align right" value="right" className="Button">
+      <AlignRightIcon />
+    </Toggle>
+  </ToggleGroup>
+);
+
+export const Disabled = () => (
+  <ToggleGroup aria-label="Text alignment" disabled defaultValue={['left']} className="Panel">
+    <Toggle aria-label="Align left" value="left" className="Button">
+      <AlignLeftIcon />
+    </Toggle>
+    <Toggle aria-label="Align center" value="center" className="Button">
+      <AlignCenterIcon />
+    </Toggle>
+    <Toggle aria-label="Align right" value="right" className="Button">
+      <AlignRightIcon />
+    </Toggle>
+  </ToggleGroup>
+);

--- a/.design-sync/previews/Toolbar.css
+++ b/.design-sync/previews/Toolbar.css
@@ -1,0 +1,121 @@
+.Toolbar {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  padding: 1px;
+  width: 37.5rem;
+  max-width: 100%;
+}
+
+.Group {
+  display: flex;
+  gap: 1px;
+}
+
+.Button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-width: 2rem;
+  height: 2rem;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background-color: transparent;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.Button[aria-pressed] {
+  padding: 0 0.75rem;
+}
+
+.Button[data-pressed] {
+  background-color: oklch(14.5% 0 0deg);
+  color: white;
+}
+
+.Button[role='combobox'] {
+  min-width: 8rem;
+  justify-content: space-between;
+  padding: 0 0.5rem;
+}
+
+.Separator {
+  width: 1px;
+  height: 16px;
+  margin: 0.25rem;
+  background-color: oklch(14.5% 0 0deg);
+}
+
+.Link {
+  color: oklch(55.6% 0 0deg);
+  font-family: inherit;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  text-decoration: none;
+  align-self: center;
+  flex: 0 0 auto;
+  margin-inline: auto 0.875rem;
+}
+
+.Positioner {
+  outline: none;
+  -webkit-user-select: none;
+  user-select: none;
+  z-index: 10;
+}
+
+.Popup {
+  box-sizing: border-box;
+  outline: 0;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  background-clip: padding-box;
+  color: oklch(14.5% 0 0deg);
+  min-width: var(--anchor-width);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+  overflow-y: auto;
+  max-height: var(--available-height);
+}
+
+.Item {
+  box-sizing: border-box;
+  outline: 0;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  padding-block: 0.375rem;
+  padding-left: 0.625rem;
+  padding-right: 1rem;
+  display: grid;
+  gap: 0.5rem;
+  align-items: center;
+  grid-template-columns: 1rem 1fr;
+  cursor: default;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.Item[data-highlighted] {
+  background-color: oklch(14.5% 0 0deg);
+  color: white;
+}
+
+.ItemIndicator {
+  grid-column-start: 1;
+}
+
+.ItemText {
+  grid-column-start: 2;
+}

--- a/.design-sync/previews/Toolbar.tsx
+++ b/.design-sync/previews/Toolbar.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { Toolbar, ToggleGroup, Toggle, Select } from '@base-ui/react';
+import './Toolbar.css';
+
+function CaretUpDownIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M11 10H5l3 3.5zm0-4H5l3-3.5z" />
+    </svg>
+  );
+}
+
+function CheckIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="m2.5 8.5 4 4 7-9" />
+    </svg>
+  );
+}
+
+export const Basic = () => (
+  <Toolbar.Root className="Toolbar">
+    <ToggleGroup className="Group" aria-label="Alignment" defaultValue={['align-left']}>
+      <Toolbar.Button
+        render={<Toggle />}
+        aria-label="Align left"
+        value="align-left"
+        className="Button"
+      >
+        Align Left
+      </Toolbar.Button>
+      <Toolbar.Button
+        render={<Toggle />}
+        aria-label="Align right"
+        value="align-right"
+        className="Button"
+      >
+        Align Right
+      </Toolbar.Button>
+    </ToggleGroup>
+    <Toolbar.Separator className="Separator" />
+    <Toolbar.Group className="Group" aria-label="Numerical format">
+      <Toolbar.Button className="Button" aria-label="Format as currency">
+        $
+      </Toolbar.Button>
+      <Toolbar.Button className="Button" aria-label="Format as percent">
+        %
+      </Toolbar.Button>
+    </Toolbar.Group>
+    <Toolbar.Separator className="Separator" />
+    <Select.Root defaultValue="Helvetica">
+      <Toolbar.Button render={<Select.Trigger />} className="Button">
+        <Select.Value />
+        <Select.Icon>
+          <CaretUpDownIcon />
+        </Select.Icon>
+      </Toolbar.Button>
+      <Select.Portal>
+        <Select.Positioner className="Positioner" sideOffset={4} alignItemWithTrigger={false}>
+          <Select.Popup className="Popup">
+            <Select.Item className="Item" value="Helvetica">
+              <Select.ItemIndicator className="ItemIndicator">
+                <CheckIcon />
+              </Select.ItemIndicator>
+              <Select.ItemText className="ItemText">Helvetica</Select.ItemText>
+            </Select.Item>
+            <Select.Item className="Item" value="Arial">
+              <Select.ItemIndicator className="ItemIndicator">
+                <CheckIcon />
+              </Select.ItemIndicator>
+              <Select.ItemText className="ItemText">Arial</Select.ItemText>
+            </Select.Item>
+          </Select.Popup>
+        </Select.Positioner>
+      </Select.Portal>
+    </Select.Root>
+    <Toolbar.Separator className="Separator" />
+    <Toolbar.Link className="Link" href="#">
+      Edited 51m ago
+    </Toolbar.Link>
+  </Toolbar.Root>
+);

--- a/.design-sync/previews/Tooltip.css
+++ b/.design-sync/previews/Tooltip.css
@@ -1,0 +1,82 @@
+.Panel {
+  display: inline-flex;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+}
+
+.Button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background-color: transparent;
+  color: oklch(14.5% 0 0deg);
+  -webkit-user-select: none;
+  user-select: none;
+
+  &[data-popup-open] {
+    background-color: oklch(97% 0 0deg);
+  }
+}
+
+.Popup {
+  box-sizing: border-box;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  padding: 0.25rem 0.5rem;
+  position: relative;
+  border: 1px solid oklch(14.5% 0 0deg);
+  background-color: white;
+  color: oklch(14.5% 0 0deg);
+  box-shadow: 0.25rem 0.25rem 0 rgb(0 0 0 / 12%);
+  transform-origin: var(--transform-origin);
+}
+
+.Arrow {
+  display: block;
+  position: relative;
+  width: 12px;
+  height: 6px;
+  overflow: clip;
+
+  &[data-side='top'] {
+    bottom: -6px;
+    rotate: 180deg;
+  }
+
+  &[data-side='bottom'] {
+    top: -6px;
+    rotate: 0deg;
+  }
+
+  &[data-side='left'] {
+    right: -9px;
+    rotate: 90deg;
+  }
+
+  &[data-side='right'] {
+    left: -9px;
+    rotate: -90deg;
+  }
+
+  &::before {
+    content: '';
+    display: block;
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    box-sizing: border-box;
+    width: calc(6px * sqrt(2));
+    height: calc(6px * sqrt(2));
+    background-color: white;
+    border: 1px solid oklch(14.5% 0 0deg);
+    transform: translate(-50%, 50%) rotate(45deg);
+  }
+}

--- a/.design-sync/previews/Tooltip.tsx
+++ b/.design-sync/previews/Tooltip.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { Tooltip } from '@base-ui/react';
+import './Tooltip.css';
+
+function InfoIcon(props: React.ComponentProps<'svg'>) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      {...props}
+      style={{ display: 'block', ...props.style }}
+    >
+      <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm.75 10.5h-1.5v-4h1.5v4Zm0-5.5h-1.5V4.5h1.5V6Z" />
+    </svg>
+  );
+}
+
+export const Basic = () => (
+  <Tooltip.Provider>
+    <div className="Panel">
+      <Tooltip.Root defaultOpen>
+        <Tooltip.Trigger className="Button" aria-label="Help">
+          <InfoIcon aria-hidden="true" />
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Positioner sideOffset={11}>
+            <Tooltip.Popup className="Popup">
+              <Tooltip.Arrow className="Arrow" />
+              Saves your changes automatically
+            </Tooltip.Popup>
+          </Tooltip.Positioner>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </div>
+  </Tooltip.Provider>
+);

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ test-results/
 
 # Benchmark results
 test/performance/benchmarks/results.json
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules


### PR DESCRIPTION
Syncs @base-ui/react's 40 components into a Claude Design project as fully functional, styled preview cards - a docs-hero-demo-derived .tsx + .css preview per component, ported from the repo's own CSS Modules demos since Base UI ships no CSS by design.

- .design-sync/config.json: package-shape sync config (docsDir mapped to docs/react/components, componentSrcMap/docsMap exceptions, cardMode overrides for overlay/portal components, plain-CSS loader override for previews)
- .design-sync/overrides/docs.mjs: forked doc-discovery heuristic to match Base UI's page.mdx-per-slug-directory docs layout
- .design-sync/previews/*.{tsx,css}: 40 authored preview compositions
- .design-sync/conventions.md: the design agent's usage guide (no shipped CSS, state via data-* attributes, compound namespace imports) - prepended to the generated README
- .design-sync/NOTES.md: repo-specific gotchas and known limitations for future re-syncs (notably: compound .d.ts props extract as unusable stubs - a converter-level limitation, not fixed here)

Project: https://claude.ai/design/p/e9789c9e-6c98-4c73-a2e5-23fc4b370d03


Claude-Session: https://claude.ai/code/session_01HKwPYwPNzRMdJ6uQ39pCSZ

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
