### PR TITLE
[test] Snapshot commit counts for benchmarked scenarios

### DIFF
--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -1,6 +1,6 @@
 import { expect, vi, describe, it } from 'vitest';
 import * as React from 'react';
-import { act, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import { act, fireEvent, screen, waitFor, reactMajor } from '@mui/internal-test-utils';
 import { Checkbox } from '@base-ui/react/checkbox';
 import { CheckboxGroup } from '@base-ui/react/checkbox-group';
 import { Field } from '@base-ui/react/field';
@@ -1790,7 +1790,10 @@ describe('<Checkbox.Root />', () => {
     await user.click(checkbox);
     expect(checkbox).toHaveAttribute('aria-checked', 'false');
   });
-  describe.skipIf(isJSDOM)('render counts', () => {
+
+  // React 19 only: the recorded sequences are specific to its scheduling, and the legacy React
+  // workflow re-runs this whole suite against React 18.
+  describe.skipIf(isJSDOM || reactMajor < 19)('render counts', () => {
     const rows = Array.from({ length: 10 }, (_, index) => index);
 
     it('mounting 10 instances', async () => {

--- a/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
+++ b/packages/react/src/checkbox/root/CheckboxRoot.test.tsx
@@ -5,7 +5,7 @@ import { Checkbox } from '@base-ui/react/checkbox';
 import { CheckboxGroup } from '@base-ui/react/checkbox-group';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
-import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { createRenderer, createCommitPhases, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<Checkbox.Root />', () => {
   const { render, renderToString } = createRenderer();
@@ -1789,5 +1789,32 @@ describe('<Checkbox.Root />', () => {
 
     await user.click(checkbox);
     expect(checkbox).toHaveAttribute('aria-checked', 'false');
+  });
+  describe.skipIf(isJSDOM)('render counts', () => {
+    const rows = Array.from({ length: 10 }, (_, index) => index);
+
+    it('mounting 10 instances', async () => {
+      const phases = createCommitPhases();
+
+      await renderNonStrict(
+        phases.wrap(
+          <div>
+            {rows.map((row) => (
+              <Checkbox.Root key={row} aria-label={`Checkbox ${row + 1}`}>
+                <Checkbox.Indicator />
+              </Checkbox.Root>
+            ))}
+          </div>,
+        ),
+      );
+
+      await phases.waitForQuiescence();
+
+      expect(phases.get()).toMatchInlineSnapshot(`
+        [
+          "mount",
+        ]
+      `);
+    });
   });
 });

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -13207,7 +13207,10 @@ describe('<Combobox.Root />', () => {
       expect(input).toHaveFocus();
     });
   });
-  describe.skipIf(isJSDOM)('render counts', () => {
+
+  // React 19 only: the recorded sequences are specific to its scheduling, and the legacy React
+  // workflow re-runs this whole suite against React 18.
+  describe.skipIf(isJSDOM || reactMajor < 19)('render counts', () => {
     const { render: renderNonStrict } = createRenderer({ strict: false });
     // Referentially stable across renders, so `React.memo` on the items can legitimately bail:
     // what makes them re-render per keystroke is whether they subscribe to a context that changes.

--- a/packages/react/src/combobox/root/ComboboxRoot.test.tsx
+++ b/packages/react/src/combobox/root/ComboboxRoot.test.tsx
@@ -10,7 +10,7 @@ import {
   ignoreActWarnings,
   reactMajor,
 } from '@mui/internal-test-utils';
-import { createRenderer, isJSDOM, popupConformanceTests } from '#test-utils';
+import { createRenderer, createCommitPhases, isJSDOM, popupConformanceTests } from '#test-utils';
 import { Combobox } from '@base-ui/react/combobox';
 import { Autocomplete } from '@base-ui/react/autocomplete';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
@@ -13205,6 +13205,95 @@ describe('<Combobox.Root />', () => {
 
       await user.keyboard('{ArrowRight}');
       expect(input).toHaveFocus();
+    });
+  });
+  describe.skipIf(isJSDOM)('render counts', () => {
+    const { render: renderNonStrict } = createRenderer({ strict: false });
+    // Referentially stable across renders, so `React.memo` on the items can legitimately bail:
+    // what makes them re-render per keystroke is whether they subscribe to a context that changes.
+    const items = Array.from({ length: 20 }, (_, index) => `Row ${index + 1}`);
+
+    function OpenCombobox() {
+      return (
+        <Combobox.Root items={items} defaultOpen>
+          <Combobox.Input data-testid="combobox-input" />
+          <Combobox.List>
+            {(item: string) => (
+              <Combobox.Item key={item} value={item}>
+                {item}
+              </Combobox.Item>
+            )}
+          </Combobox.List>
+        </Combobox.Root>
+      );
+    }
+
+    it('mounting an open list of 20 items', async () => {
+      const phases = createCommitPhases();
+
+      await renderNonStrict(phases.wrap(<OpenCombobox />));
+      await phases.waitForQuiescence();
+
+      expect(phases.get()).toMatchInlineSnapshot(`
+        [
+          "mount",
+          "update",
+          "nested-update",
+          "nested-update",
+        ]
+      `);
+    });
+
+    it('typing a prefix that keeps every item mounted', async () => {
+      const phases = createCommitPhases();
+
+      const { user } = await renderNonStrict(phases.wrap(<OpenCombobox />));
+      await phases.waitForQuiescence();
+      phases.reset();
+
+      // Every item matches "Row ", so none unmount: this isolates the per-keystroke re-render
+      // cost of items that are already on screen.
+      await user.type(screen.getByTestId('combobox-input'), 'Row ');
+      await phases.waitForQuiescence();
+
+      expect(phases.get()).toMatchInlineSnapshot(`
+        [
+          "update",
+          "nested-update",
+          "update",
+          "nested-update",
+          "update",
+          "nested-update",
+          "update",
+        ]
+      `);
+    });
+
+    it('typing a query that narrows the list', async () => {
+      const phases = createCommitPhases();
+
+      const { user } = await renderNonStrict(phases.wrap(<OpenCombobox />));
+      await phases.waitForQuiescence();
+      phases.reset();
+
+      // Narrows 20 items down to "Row 2" and "Row 20", mixing unmount cost with re-renders of
+      // the items that survive.
+      await user.type(screen.getByTestId('combobox-input'), 'Row 2');
+      await phases.waitForQuiescence();
+
+      expect(phases.get()).toMatchInlineSnapshot(`
+        [
+          "update",
+          "nested-update",
+          "update",
+          "nested-update",
+          "update",
+          "nested-update",
+          "update",
+          "update",
+          "nested-update",
+        ]
+      `);
     });
   });
 });

--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -4,7 +4,13 @@ import * as React from 'react';
 import { act, fireEvent, screen, waitFor, flushMicrotasks } from '@mui/internal-test-utils';
 import { AlertDialog } from '@base-ui/react/alert-dialog';
 import { Dialog } from '@base-ui/react/dialog';
-import { createRenderer, isJSDOM, popupConformanceTests, wait } from '#test-utils';
+import {
+  createRenderer,
+  createCommitPhases,
+  isJSDOM,
+  popupConformanceTests,
+  wait,
+} from '#test-utils';
 import { Menu } from '@base-ui/react/menu';
 import { Select } from '@base-ui/react/select';
 import { NumberField } from '@base-ui/react/number-field';
@@ -2241,6 +2247,44 @@ describe('<Dialog.Root />', () => {
       expect(field).not.toHaveFocus();
     },
   );
+  describe.skipIf(isJSDOM)('render counts', () => {
+    const { render: renderNonStrict } = createRenderer({ strict: false });
+    const rows = Array.from({ length: 10 }, (_, index) => index);
+
+    it('mounting 10 instances', async () => {
+      const phases = createCommitPhases();
+
+      await renderNonStrict(
+        phases.wrap(
+          <div>
+            {rows.map((row) => (
+              <Dialog.Root key={row}>
+                <Dialog.Trigger aria-label={`Open Dialog ${row + 1}`}>
+                  Dialog {row + 1}
+                </Dialog.Trigger>
+                <Dialog.Portal>
+                  <Dialog.Backdrop />
+                  <Dialog.Popup>
+                    <Dialog.Title>Dialog {row + 1}</Dialog.Title>
+                    <Dialog.Description>Dialog content</Dialog.Description>
+                    <Dialog.Close>Close</Dialog.Close>
+                  </Dialog.Popup>
+                </Dialog.Portal>
+              </Dialog.Root>
+            ))}
+          </div>,
+        ),
+      );
+
+      await phases.waitForQuiescence();
+
+      expect(phases.get()).toMatchInlineSnapshot(`
+        [
+          "mount",
+        ]
+      `);
+    });
+  });
 });
 
 // The viewport takes its overflow from <html>, falling back to <body> when <html> doesn't

--- a/packages/react/src/dialog/root/DialogRoot.test.tsx
+++ b/packages/react/src/dialog/root/DialogRoot.test.tsx
@@ -1,7 +1,14 @@
 import { expect, vi, describe, beforeEach, it, afterEach } from 'vitest';
 import type { CDPSession } from '@vitest/browser-playwright';
 import * as React from 'react';
-import { act, fireEvent, screen, waitFor, flushMicrotasks } from '@mui/internal-test-utils';
+import {
+  act,
+  fireEvent,
+  screen,
+  waitFor,
+  flushMicrotasks,
+  reactMajor,
+} from '@mui/internal-test-utils';
 import { AlertDialog } from '@base-ui/react/alert-dialog';
 import { Dialog } from '@base-ui/react/dialog';
 import {
@@ -2247,7 +2254,10 @@ describe('<Dialog.Root />', () => {
       expect(field).not.toHaveFocus();
     },
   );
-  describe.skipIf(isJSDOM)('render counts', () => {
+
+  // React 19 only: the recorded sequences are specific to its scheduling, and the legacy React
+  // workflow re-runs this whole suite against React 18.
+  describe.skipIf(isJSDOM || reactMajor < 19)('render counts', () => {
     const { render: renderNonStrict } = createRenderer({ strict: false });
     const rows = Array.from({ length: 10 }, (_, index) => index);
 

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -8,6 +8,7 @@ import {
   ignoreActWarnings,
   screen,
   waitFor,
+  reactMajor,
 } from '@mui/internal-test-utils';
 import { DirectionProvider } from '@base-ui/react/direction-provider';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
@@ -3186,7 +3187,10 @@ describe('<Menu.Root />', () => {
       expect(screen.queryByRole('menuitem', { name: 'Add to Library' })).toHaveFocus();
     });
   });
-  describe.skipIf(isJSDOM)('render counts', () => {
+
+  // React 19 only: the recorded sequences are specific to its scheduling, and the legacy React
+  // workflow re-runs this whole suite against React 18.
+  describe.skipIf(isJSDOM || reactMajor < 19)('render counts', () => {
     const { render: renderNonStrict } = createRenderer({ strict: false });
     const rows = Array.from({ length: 10 }, (_, index) => index);
     const items = Array.from({ length: 5 }, (_, index) => index);

--- a/packages/react/src/menu/root/MenuRoot.test.tsx
+++ b/packages/react/src/menu/root/MenuRoot.test.tsx
@@ -18,6 +18,7 @@ import { platform } from '@base-ui/utils/platform';
 import userEvent from '@testing-library/user-event';
 import {
   createRenderer,
+  createCommitPhases,
   enterWithMouse,
   isJSDOM,
   moveMouse,
@@ -3183,6 +3184,89 @@ describe('<Menu.Root />', () => {
       await user.keyboard('{ArrowDown}'); // loops back to Add to Library
 
       expect(screen.queryByRole('menuitem', { name: 'Add to Library' })).toHaveFocus();
+    });
+  });
+  describe.skipIf(isJSDOM)('render counts', () => {
+    const { render: renderNonStrict } = createRenderer({ strict: false });
+    const rows = Array.from({ length: 10 }, (_, index) => index);
+    const items = Array.from({ length: 5 }, (_, index) => index);
+
+    it('mounting 10 instances', async () => {
+      const phases = createCommitPhases();
+
+      await renderNonStrict(
+        phases.wrap(
+          <div>
+            {rows.map((row) => (
+              <Menu.Root key={row}>
+                <Menu.Trigger aria-label={`Open Menu ${row + 1}`}>Menu {row + 1}</Menu.Trigger>
+                <Menu.Portal>
+                  <Menu.Positioner sideOffset={8}>
+                    <Menu.Popup>
+                      {items.map((item) => (
+                        <Menu.Item key={item}>Menu item {item + 1}</Menu.Item>
+                      ))}
+                    </Menu.Popup>
+                  </Menu.Positioner>
+                </Menu.Portal>
+              </Menu.Root>
+            ))}
+          </div>,
+        ),
+      );
+
+      await phases.waitForQuiescence();
+
+      expect(phases.get()).toMatchInlineSnapshot(`
+        [
+          "mount",
+        ]
+      `);
+    });
+
+    it('opening a menu of 20 items', async () => {
+      const phases = createCommitPhases();
+      const menuItems = Array.from({ length: 20 }, (_, index) => index);
+
+      const { user } = await renderNonStrict(
+        phases.wrap(
+          <Menu.Root>
+            <Menu.Trigger data-testid="open-menu">Open menu</Menu.Trigger>
+            <Menu.Portal>
+              <Menu.Positioner sideOffset={8} positionMethod="fixed">
+                <Menu.Popup>
+                  {menuItems.map((item) => (
+                    <Menu.Item key={item}>Menu item {item + 1}</Menu.Item>
+                  ))}
+                </Menu.Popup>
+              </Menu.Positioner>
+            </Menu.Portal>
+          </Menu.Root>,
+        ),
+      );
+
+      await phases.waitForQuiescence();
+      phases.reset();
+
+      await user.click(screen.getByTestId('open-menu'));
+      await screen.findByRole('menu');
+      await phases.waitForQuiescence();
+
+      expect(phases.get()).toMatchInlineSnapshot(`
+        [
+          "update",
+          "update",
+          "update",
+          "nested-update",
+          "nested-update",
+          "nested-update",
+          "nested-update",
+          "nested-update",
+          "update",
+          "update",
+          "nested-update",
+        ]
+      `);
     });
   });
 });

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -4,7 +4,14 @@ import { Popover } from '@base-ui/react/popover';
 import { Combobox } from '@base-ui/react/combobox';
 import { Menu } from '@base-ui/react/menu';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
-import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
+import {
+  act,
+  fireEvent,
+  flushMicrotasks,
+  screen,
+  waitFor,
+  reactMajor,
+} from '@mui/internal-test-utils';
 import {
   createRenderer,
   createCommitPhases,
@@ -2216,7 +2223,10 @@ describe('<Popover.Root />', () => {
       });
     });
   });
-  describe.skipIf(isJSDOM)('render counts', () => {
+
+  // React 19 only: the recorded sequences are specific to its scheduling, and the legacy React
+  // workflow re-runs this whole suite against React 18.
+  describe.skipIf(isJSDOM || reactMajor < 19)('render counts', () => {
     const { render: renderNonStrict } = createRenderer({ strict: false });
     const rows = Array.from({ length: 10 }, (_, index) => index);
 

--- a/packages/react/src/popover/root/PopoverRoot.test.tsx
+++ b/packages/react/src/popover/root/PopoverRoot.test.tsx
@@ -5,7 +5,13 @@ import { Combobox } from '@base-ui/react/combobox';
 import { Menu } from '@base-ui/react/menu';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer, isJSDOM, popupConformanceTests, wait } from '#test-utils';
+import {
+  createRenderer,
+  createCommitPhases,
+  isJSDOM,
+  popupConformanceTests,
+  wait,
+} from '#test-utils';
 import { OPEN_DELAY } from '../utils/constants';
 import { PATIENT_CLICK_THRESHOLD } from '../../internals/constants';
 import { REASONS } from '../../internals/reasons';
@@ -2208,6 +2214,44 @@ describe('<Popover.Root />', () => {
       await waitFor(() => {
         expect(screen.queryByTestId('popup')).toBe(null);
       });
+    });
+  });
+  describe.skipIf(isJSDOM)('render counts', () => {
+    const { render: renderNonStrict } = createRenderer({ strict: false });
+    const rows = Array.from({ length: 10 }, (_, index) => index);
+
+    it('mounting 10 instances', async () => {
+      const phases = createCommitPhases();
+
+      await renderNonStrict(
+        phases.wrap(
+          <div>
+            {rows.map((row) => (
+              <Popover.Root key={row}>
+                <Popover.Trigger aria-label={`Open Popover ${row + 1}`}>
+                  Popover {row + 1}
+                </Popover.Trigger>
+                <Popover.Portal>
+                  <Popover.Positioner sideOffset={8}>
+                    <Popover.Popup>
+                      <Popover.Title>Popover {row + 1}</Popover.Title>
+                      <Popover.Description>Popover content</Popover.Description>
+                    </Popover.Popup>
+                  </Popover.Positioner>
+                </Popover.Portal>
+              </Popover.Root>
+            ))}
+          </div>,
+        ),
+      );
+
+      await phases.waitForQuiescence();
+
+      expect(phases.get()).toMatchInlineSnapshot(`
+        [
+          "mount",
+        ]
+      `);
     });
   });
 });

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -6631,7 +6631,10 @@ describe('<Select.Root />', () => {
       });
     });
   });
-  describe.skipIf(isJSDOM)('render counts', () => {
+
+  // React 19 only: the recorded sequences are specific to its scheduling, and the legacy React
+  // workflow re-runs this whole suite against React 18.
+  describe.skipIf(isJSDOM || reactMajor < 19)('render counts', () => {
     const { render: renderNonStrict } = createRenderer({ strict: false });
     const rows = Array.from({ length: 10 }, (_, index) => index);
     const items = Array.from({ length: 5 }, (_, index) => ({

--- a/packages/react/src/select/root/SelectRoot.test.tsx
+++ b/packages/react/src/select/root/SelectRoot.test.tsx
@@ -12,7 +12,13 @@ import {
   ignoreActWarnings,
   reactMajor,
 } from '@mui/internal-test-utils';
-import { createRenderer, isJSDOM, popupConformanceTests, wait } from '#test-utils';
+import {
+  createRenderer,
+  createCommitPhases,
+  isJSDOM,
+  popupConformanceTests,
+  wait,
+} from '#test-utils';
 import { Field } from '@base-ui/react/field';
 import { Form } from '@base-ui/react/form';
 
@@ -6623,6 +6629,117 @@ describe('<Select.Root />', () => {
       await waitFor(() => {
         expect(optionA).toHaveAttribute('data-highlighted');
       });
+    });
+  });
+  describe.skipIf(isJSDOM)('render counts', () => {
+    const { render: renderNonStrict } = createRenderer({ strict: false });
+    const rows = Array.from({ length: 10 }, (_, index) => index);
+    const items = Array.from({ length: 5 }, (_, index) => ({
+      value: `option-${index + 1}`,
+      label: `Option ${index + 1}`,
+    }));
+
+    it('mounting 10 instances', async () => {
+      const phases = createCommitPhases();
+
+      await renderNonStrict(
+        phases.wrap(
+          <div>
+            {rows.map((row) => (
+              <Select.Root key={row} items={items}>
+                <Select.Trigger aria-label={`Open Select ${row + 1}`}>
+                  <Select.Value placeholder={`Select ${row + 1}`} />
+                  <Select.Icon>v</Select.Icon>
+                </Select.Trigger>
+                <Select.Portal>
+                  <Select.Positioner sideOffset={8}>
+                    <Select.Popup>
+                      <Select.List>
+                        {items.map((item) => (
+                          <Select.Item key={item.value} value={item.value}>
+                            <Select.ItemIndicator />
+                            <Select.ItemText>{item.label}</Select.ItemText>
+                          </Select.Item>
+                        ))}
+                      </Select.List>
+                    </Select.Popup>
+                  </Select.Positioner>
+                </Select.Portal>
+              </Select.Root>
+            ))}
+          </div>,
+        ),
+      );
+
+      await phases.waitForQuiescence();
+
+      expect(phases.get()).toMatchInlineSnapshot(`
+        [
+          "mount",
+          "update",
+          "nested-update",
+        ]
+      `);
+    });
+
+    it('opening a select of 20 options', async () => {
+      const phases = createCommitPhases();
+      const options = Array.from({ length: 20 }, (_, index) => ({
+        value: `option-${index + 1}`,
+        label: `Option ${index + 1}`,
+      }));
+
+      const { user } = await renderNonStrict(
+        phases.wrap(
+          <Select.Root items={options}>
+            <Select.Trigger data-testid="open-select">
+              <Select.Value placeholder="Choose option" />
+              <Select.Icon>v</Select.Icon>
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner sideOffset={8}>
+                <Select.Popup>
+                  <Select.List>
+                    {options.map((item) => (
+                      <Select.Item key={item.value} value={item.value}>
+                        <Select.ItemIndicator />
+                        <Select.ItemText>{item.label}</Select.ItemText>
+                      </Select.Item>
+                    ))}
+                  </Select.List>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>,
+        ),
+      );
+
+      await phases.waitForQuiescence();
+      phases.reset();
+
+      await user.click(screen.getByTestId('open-select'));
+      await screen.findByRole('listbox');
+      await phases.waitForQuiescence();
+
+      expect(phases.get()).toMatchInlineSnapshot(`
+        [
+          "update",
+          "update",
+          "update",
+          "nested-update",
+          "nested-update",
+          "nested-update",
+          "nested-update",
+          "update",
+          "update",
+          "nested-update",
+          "nested-update",
+          "update",
+          "nested-update",
+          "update",
+          "nested-update",
+        ]
+      `);
     });
   });
 });

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -5,7 +5,7 @@ import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-
 import { Field } from '@base-ui/react/field';
 import { Slider } from '@base-ui/react/slider';
 import { Form } from '@base-ui/react/form';
-import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { createRenderer, createCommitPhases, describeConformance, isJSDOM } from '#test-utils';
 import { platform } from '@base-ui/utils/platform';
 import { REASONS } from '../../internals/reasons';
 import {
@@ -3560,6 +3560,41 @@ describe('<Slider.Root />', () => {
         'aria-describedby',
         `external-description ${screen.getByTestId('description').id}`,
       );
+    });
+  });
+  describe.skipIf(isJSDOM)('render counts', () => {
+    const { render: renderNonStrict } = createRenderer({ strict: false });
+    const rows = Array.from({ length: 10 }, (_, index) => index);
+
+    it('mounting 10 instances', async () => {
+      const phases = createCommitPhases();
+
+      await renderNonStrict(
+        phases.wrap(
+          <div>
+            {rows.map((row) => (
+              <Slider.Root key={row} defaultValue={50}>
+                <Slider.Value />
+                <Slider.Control aria-label={`Slider ${row + 1}`}>
+                  <Slider.Track>
+                    <Slider.Indicator />
+                    <Slider.Thumb />
+                  </Slider.Track>
+                </Slider.Control>
+              </Slider.Root>
+            ))}
+          </div>,
+        ),
+      );
+
+      await phases.waitForQuiescence();
+
+      expect(phases.get()).toMatchInlineSnapshot(`
+        [
+          "mount",
+          "nested-update",
+        ]
+      `);
     });
   });
 });

--- a/packages/react/src/slider/root/SliderRoot.test.tsx
+++ b/packages/react/src/slider/root/SliderRoot.test.tsx
@@ -1,6 +1,13 @@
 import { expect, vi, describe, beforeAll, it } from 'vitest';
 import * as React from 'react';
-import { act, flushMicrotasks, fireEvent, screen, waitFor } from '@mui/internal-test-utils';
+import {
+  act,
+  flushMicrotasks,
+  fireEvent,
+  screen,
+  waitFor,
+  reactMajor,
+} from '@mui/internal-test-utils';
 import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
 import { Field } from '@base-ui/react/field';
 import { Slider } from '@base-ui/react/slider';
@@ -3562,7 +3569,10 @@ describe('<Slider.Root />', () => {
       );
     });
   });
-  describe.skipIf(isJSDOM)('render counts', () => {
+
+  // React 19 only: the recorded sequences are specific to its scheduling, and the legacy React
+  // workflow re-runs this whole suite against React 18.
+  describe.skipIf(isJSDOM || reactMajor < 19)('render counts', () => {
     const { render: renderNonStrict } = createRenderer({ strict: false });
     const rows = Array.from({ length: 10 }, (_, index) => index);
 

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -5,7 +5,7 @@ import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-
 import { Popover } from '@base-ui/react/popover';
 import { Dialog } from '@base-ui/react/dialog';
 import { Tabs } from '@base-ui/react/tabs';
-import { createRenderer, describeConformance, isJSDOM } from '#test-utils';
+import { createRenderer, createCommitPhases, describeConformance, isJSDOM } from '#test-utils';
 
 describe('<Tabs.Root />', () => {
   const { render } = createRenderer();
@@ -2597,6 +2597,53 @@ describe('<Tabs.Root />', () => {
       // Selection remains the externally-set tab since activateOnFocus=false
       expect(thirdTab).toHaveAttribute('aria-selected', 'true');
       expect(secondTab).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+  describe.skipIf(isJSDOM)('render counts', () => {
+    const { render: renderNonStrict } = createRenderer({ strict: false });
+    const rows = Array.from({ length: 10 }, (_, index) => index);
+    const tabValues = ['overview', 'details', 'activity'] as const;
+
+    it('mounting 10 instances', async () => {
+      const phases = createCommitPhases();
+
+      await renderNonStrict(
+        phases.wrap(
+          <div>
+            {rows.map((row) => (
+              <Tabs.Root key={row} defaultValue={tabValues[0]}>
+                <Tabs.List aria-label={`Tabs ${row + 1}`}>
+                  {tabValues.map((value) => (
+                    <Tabs.Tab key={value} value={value}>
+                      {value}
+                    </Tabs.Tab>
+                  ))}
+                  {/* `Tabs.Indicator` is deliberately left out, unlike the benchmark fixture it
+                      is ported from. It re-renders itself from a `ResizeObserver` callback that
+                      fires once or twice depending on how the layout settles, so including it
+                      makes the recorded sequence vary run to run (measured: 8 of 10) no matter how
+                      long the tree is left to quiesce. */}
+                </Tabs.List>
+                {tabValues.map((value) => (
+                  <Tabs.Panel key={value} value={value}>
+                    Tabs {row + 1} {value}
+                  </Tabs.Panel>
+                ))}
+              </Tabs.Root>
+            ))}
+          </div>,
+        ),
+      );
+
+      await phases.waitForQuiescence();
+
+      expect(phases.get()).toMatchInlineSnapshot(`
+        [
+          "mount",
+          "nested-update",
+          "update",
+        ]
+      `);
     });
   });
 });

--- a/packages/react/src/tabs/root/TabsRoot.test.tsx
+++ b/packages/react/src/tabs/root/TabsRoot.test.tsx
@@ -1,6 +1,14 @@
 import { expect, vi, describe, beforeEach, it } from 'vitest';
 import * as React from 'react';
-import { act, flushMicrotasks, fireEvent, screen, waitFor, within } from '@mui/internal-test-utils';
+import {
+  act,
+  flushMicrotasks,
+  fireEvent,
+  screen,
+  waitFor,
+  within,
+  reactMajor,
+} from '@mui/internal-test-utils';
 import { DirectionProvider, type TextDirection } from '@base-ui/react/direction-provider';
 import { Popover } from '@base-ui/react/popover';
 import { Dialog } from '@base-ui/react/dialog';
@@ -2599,7 +2607,10 @@ describe('<Tabs.Root />', () => {
       expect(secondTab).toHaveAttribute('aria-selected', 'false');
     });
   });
-  describe.skipIf(isJSDOM)('render counts', () => {
+
+  // React 19 only: the recorded sequences are specific to its scheduling, and the legacy React
+  // workflow re-runs this whole suite against React 18.
+  describe.skipIf(isJSDOM || reactMajor < 19)('render counts', () => {
     const { render: renderNonStrict } = createRenderer({ strict: false });
     const rows = Array.from({ length: 10 }, (_, index) => index);
     const tabValues = ['overview', 'details', 'activity'] as const;

--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -1,7 +1,14 @@
 import { expect, vi, describe, beforeEach, afterEach, it } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
-import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
+import {
+  act,
+  fireEvent,
+  flushMicrotasks,
+  screen,
+  waitFor,
+  reactMajor,
+} from '@mui/internal-test-utils';
 import {
   createRenderer,
   createCommitPhases,
@@ -1559,7 +1566,10 @@ describe('<Tooltip.Root />', () => {
       expect(screen.getByTestId('popup')).toBeVisible();
     });
   });
-  describe.skipIf(isJSDOM)('render counts', () => {
+
+  // React 19 only: the recorded sequences are specific to its scheduling, and the legacy React
+  // workflow re-runs this whole suite against React 18.
+  describe.skipIf(isJSDOM || reactMajor < 19)('render counts', () => {
     const { render: renderNonStrict } = createRenderer({ strict: false });
     const rows = Array.from({ length: 10 }, (_, index) => index);
     // The real cursor persists across the run and can come to rest over one of these triggers,

--- a/packages/react/src/tooltip/root/TooltipRoot.test.tsx
+++ b/packages/react/src/tooltip/root/TooltipRoot.test.tsx
@@ -2,7 +2,13 @@ import { expect, vi, describe, beforeEach, afterEach, it } from 'vitest';
 import * as React from 'react';
 import { Tooltip } from '@base-ui/react/tooltip';
 import { act, fireEvent, flushMicrotasks, screen, waitFor } from '@mui/internal-test-utils';
-import { createRenderer, isJSDOM, popupConformanceTests, resetBrowserPointer } from '#test-utils';
+import {
+  createRenderer,
+  createCommitPhases,
+  isJSDOM,
+  popupConformanceTests,
+  resetBrowserPointer,
+} from '#test-utils';
 import { useRefWithInit } from '@base-ui/utils/useRefWithInit';
 import { OPEN_DELAY } from '../utils/constants';
 import { REASONS } from '../../internals/reasons';
@@ -1551,6 +1557,45 @@ describe('<Tooltip.Root />', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('popup')).toBeVisible();
+    });
+  });
+  describe.skipIf(isJSDOM)('render counts', () => {
+    const { render: renderNonStrict } = createRenderer({ strict: false });
+    const rows = Array.from({ length: 10 }, (_, index) => index);
+    // The real cursor persists across the run and can come to rest over one of these triggers,
+    // opening a tooltip on its own and adding commits that land inside the recording only some of
+    // the time. Mount is what this measures, so the triggers never need to be hoverable.
+    const INERT_TO_POINTER: React.CSSProperties = { pointerEvents: 'none' };
+
+    it('mounting 10 instances', async () => {
+      const phases = createCommitPhases();
+
+      await renderNonStrict(
+        phases.wrap(
+          <div style={INERT_TO_POINTER}>
+            {rows.map((row) => (
+              <Tooltip.Root key={row}>
+                <Tooltip.Trigger aria-label={`Show Tooltip ${row + 1}`}>
+                  Tooltip {row + 1}
+                </Tooltip.Trigger>
+                <Tooltip.Portal>
+                  <Tooltip.Positioner sideOffset={8}>
+                    <Tooltip.Popup>Tooltip for {row + 1}</Tooltip.Popup>
+                  </Tooltip.Positioner>
+                </Tooltip.Portal>
+              </Tooltip.Root>
+            ))}
+          </div>,
+        ),
+      );
+
+      await phases.waitForQuiescence();
+
+      expect(phases.get()).toMatchInlineSnapshot(`
+        [
+          "mount",
+        ]
+      `);
     });
   });
 });

--- a/packages/react/test/commitPhases.test.tsx
+++ b/packages/react/test/commitPhases.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import * as React from 'react';
+import { createRenderer, createCommitPhases } from '#test-utils';
+
+describe('createCommitPhases', () => {
+  const { render } = createRenderer({ strict: false });
+
+  it('records a single commit for a static tree', async () => {
+    const phases = createCommitPhases();
+
+    await render(phases.wrap(<div />));
+
+    expect(phases.get()).toEqual(['mount']);
+  });
+
+  it('records an update when an effect commits a state change', async () => {
+    function Test() {
+      const [value, setValue] = React.useState(0);
+
+      React.useEffect(() => {
+        setValue(1);
+      }, []);
+
+      return <div>{value}</div>;
+    }
+
+    const phases = createCommitPhases();
+
+    await render(phases.wrap(<Test />));
+
+    expect(phases.get()).toEqual(['mount', 'update']);
+  });
+
+  it('waits for a commit scheduled a frame after mount', async () => {
+    function Test() {
+      const [value, setValue] = React.useState(0);
+
+      React.useEffect(() => {
+        const frame = requestAnimationFrame(() => setValue(1));
+        return () => cancelAnimationFrame(frame);
+      }, []);
+
+      return <div>{value}</div>;
+    }
+
+    const phases = createCommitPhases();
+
+    await render(phases.wrap(<Test />));
+    // Without the wait this commit lands after the assertion on most runs.
+    await phases.waitForQuiescence();
+
+    expect(phases.get()).toEqual(['mount', 'update']);
+  });
+
+  it('drops previously recorded phases on reset', async () => {
+    const phases = createCommitPhases();
+
+    await render(phases.wrap(<div />));
+    phases.reset();
+
+    expect(phases.get()).toEqual([]);
+  });
+});

--- a/packages/react/test/commitPhases.tsx
+++ b/packages/react/test/commitPhases.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { act, flushMicrotasks } from '@mui/internal-test-utils';
+import { waitSingleFrame } from './wait';
+
+export type CommitPhase = 'mount' | 'update' | 'nested-update';
+
+/**
+ * Records the React commit phases of a subtree.
+ *
+ * `React.Profiler` fires once per commit of the wrapped tree, so this counts commits rather than
+ * individual component renders: it catches effect-driven re-render cascades and extra commits per
+ * interaction, but not how many components re-rendered within a single commit.
+ *
+ * Wrap the scenario with `wrap()`, then snapshot `get()`:
+ *
+ * ```tsx
+ * const phases = createCommitPhases();
+ * await render(phases.wrap(<Scenario />));
+ * expect(phases.get()).toMatchInlineSnapshot();
+ * ```
+ *
+ * Not every tree can be snapshotted this way. A part that re-renders itself from a
+ * `ResizeObserver` callback commits a number of times that depends on how the layout settles and
+ * on machine load, so no amount of waiting makes it reproducible. `Tabs.Indicator` and
+ * `ScrollArea`'s scrollbars both behave that way. Measure a scenario over repeated runs before
+ * committing its snapshot, and leave such parts out rather than weakening the assertion.
+ */
+export function createCommitPhases() {
+  const phases: CommitPhase[] = [];
+
+  return {
+    wrap(children: React.ReactNode) {
+      return (
+        <React.Profiler
+          id="commit-phases"
+          onRender={(_id, phase) => {
+            phases.push(phase);
+          }}
+        >
+          {children}
+        </React.Profiler>
+      );
+    },
+    /**
+     * The phases recorded so far, oldest first.
+     */
+    get() {
+      return phases.slice();
+    },
+    /**
+     * Drops everything recorded so far, to isolate an interaction from the initial mount.
+     */
+    reset() {
+      phases.length = 0;
+    },
+    /**
+     * Waits until the tree stops committing.
+     *
+     * Mounting can schedule follow-up work that lands one or more frames later, such as a
+     * `ResizeObserver` callback forcing a rerender. Whether that commit arrives before the
+     * assertion runs is a matter of timing, so without this the snapshot records however much of
+     * the work happened to land in time and varies between runs. Waiting for quiescence makes a
+     * snapshot mean "the commits this scenario settles into", which is both stable and the number
+     * worth guarding.
+     */
+    async waitForQuiescence(idleFrames = 12) {
+      let idle = 0;
+
+      while (idle < idleFrames) {
+        const before = phases.length;
+        // eslint-disable-next-line no-await-in-loop
+        await act(async () => {
+          await waitSingleFrame();
+          await flushMicrotasks();
+        });
+        idle = phases.length === before ? idle + 1 : 0;
+      }
+    },
+  };
+}

--- a/packages/react/test/commitPhases.tsx
+++ b/packages/react/test/commitPhases.tsx
@@ -24,6 +24,10 @@ export type CommitPhase = 'mount' | 'update' | 'nested-update';
  * on machine load, so no amount of waiting makes it reproducible. `Tabs.Indicator` and
  * `ScrollArea`'s scrollbars both behave that way. Measure a scenario over repeated runs before
  * committing its snapshot, and leave such parts out rather than weakening the assertion.
+ *
+ * Recorded sequences are also specific to one React version, and the legacy React workflow re-runs
+ * this whole suite against React 18, so gate a scenario with
+ * `describe.skipIf(isJSDOM || reactMajor < 19)`.
  */
 export function createCommitPhases() {
   const phases: CommitPhase[] = [];

--- a/packages/react/test/index.ts
+++ b/packages/react/test/index.ts
@@ -5,6 +5,8 @@ export { describeConformance } from './describeConformance';
 export { enterWithMouse, firePointer, moveMouse } from './pointer';
 export { mergeRefs } from './mergeRefs';
 export { popupConformanceTests } from './popupConformanceTests';
+export { createCommitPhases } from './commitPhases';
+export type { CommitPhase } from './commitPhases';
 export { resetBrowserPointer } from './resetBrowserPointer';
 export { useTestInteractions } from './useTestInteractions';
 export * from './wait';


### PR DESCRIPTION
Ports the scenarios from `test/performance` into the main test suite as inline snapshot tests. A render count change then shows up as a changed line in the PR diff, reviewed like any other code change, with no CI machinery behind it.

Context: #5403 builds a per-PR render count check out of three workflows, a merge base collector run, a cross workflow artifact trust model and a comment upsert. This is the same signal without any of that. It covers only the render count half; timing is a separate question.

## The helper

`createCommitPhases()` in `packages/react/test/commitPhases.tsx`, exported from `#test-utils`:

```tsx
const phases = createCommitPhases();
await render(phases.wrap(<Scenario />));
await phases.waitForQuiescence();
expect(phases.get()).toMatchInlineSnapshot();
```

It replaces three hand rolled Profiler counters already in the suite (`DrawerProvider`, `CheckboxIndicator`, `useAnimationsFinished` each roll their own counter, array push or `vi.fn()`).

`waitForQuiescence()` matters: mounting schedules follow up work that lands a frame or more later, so without it a snapshot records however much happened to arrive before the assertion and varies run to run.

## What this measures

`Profiler.onRender` fires once per commit, so these are commit counts, not per component render counts. React exposes no public API for the latter. That catches effect driven re-render cascades, double commits and extra commits per keystroke. It does not catch "every item re-rendered inside one commit", the regression class behind #4964. Neither does #5403, worth saying plainly so the check is not oversold.

Sample of what gets recorded:

| Scenario | Commits |
| --- | --- |
| Checkbox, Dialog, Popover, Tooltip, Menu mount | `["mount"]` |
| Slider mount | `["mount", "nested-update"]` |
| Select mount | `["mount", "update", "nested-update"]` |
| Menu open, 20 items | 11 commits |
| Select open, 20 options | 15 commits |
| Combobox, type a prefix keeping all 20 items | 7 commits |
| Combobox, type a query narrowing the list | 9 commits |

## Choices

- **Chromium and React 19 only**, via `describe.skipIf(isJSDOM || reactMajor < 19)`. jsdom misses the layout driven commits that most of these components do. The recorded sequences are specific to React 19 scheduling, and the `react-18` workflow re-runs this whole suite with react and react-dom swapped through pnpm overrides, so it has to skip them. `commitPhases.test.tsx` stays ungated: it asserts helper behaviour, not Base UI commit counts.
- **Co-located** in each component's existing root test file.
- **10 instances** rather than the benchmark's 200 to 500. Commit counts do not scale with instance count.

## Not ported

- `Mixed surface mount (app-like density)` measures total mount cost across 330 components, which is a timing question.
- The scroll area scenario. Its scrollbars measure from a `ResizeObserver`, so the commit count depends on machine load: stable 15/15 in isolation but failing 2 of 10 combined runs, at any settle length tried. `Tabs.Indicator` is left out of the tabs scenario for the same reason (8/10).

Both are called out in comments where they would otherwise look like oversights.

## Verification

- Every snapshot recorded over 10 consecutive full file runs with no variance.
- Mutation checked: adding one extra commit to a scenario fails its snapshot.
- Full chromium suite green, 8967 tests.
- jsdom lane skips the new blocks rather than failing.

`test/performance` is untouched.

