### PR TITLE
[internal] mark EMPTY_ARRAY as readonly never[]

### DIFF
--- a/docs/src/app/(docs)/react/components/accordion/types.md
+++ b/docs/src/app/(docs)/react/components/accordion/types.md
@@ -41,10 +41,7 @@ Re-export of [Root](#root) props.
 
 ```typescript
 type AccordionRootState<TValue = any> = {
-  /**
-   * The current value.
-   * Treat it as read-only: it may be a shared frozen array when no value is set.
-   */
+  /** The current value. */
   value: TValue[];
   /** Whether the component should ignore user interaction. */
   disabled: boolean;
@@ -128,10 +125,7 @@ type AccordionTriggerState = {
   index: number;
   /** Whether the component is open. */
   open: boolean;
-  /**
-   * The current value.
-   * Treat it as read-only: it may be a shared frozen array when no value is set.
-   */
+  /** The current value. */
   value: any[];
   /** Whether the component should ignore user interaction. */
   disabled: boolean;
@@ -195,10 +189,7 @@ type AccordionItemState = {
   index: number;
   /** Whether the component is open. */
   open: boolean;
-  /**
-   * The current value.
-   * Treat it as read-only: it may be a shared frozen array when no value is set.
-   */
+  /** The current value. */
   value: any[];
   /** Whether the component should ignore user interaction. */
   disabled: boolean;
@@ -276,10 +267,7 @@ type AccordionHeaderState = {
   index: number;
   /** Whether the component is open. */
   open: boolean;
-  /**
-   * The current value.
-   * Treat it as read-only: it may be a shared frozen array when no value is set.
-   */
+  /** The current value. */
   value: any[];
   /** Whether the component should ignore user interaction. */
   disabled: boolean;
@@ -345,10 +333,7 @@ type AccordionPanelState = {
   index: number;
   /** Whether the component is open. */
   open: boolean;
-  /**
-   * The current value.
-   * Treat it as read-only: it may be a shared frozen array when no value is set.
-   */
+  /** The current value. */
   value: any[];
   /** Whether the component should ignore user interaction. */
   disabled: boolean;
@@ -367,10 +352,16 @@ type AccordionPanelState = {
 
 ## Additional Types
 
-### AccordionValue
+### AccordionInputValue
 
 ```typescript
-type AccordionValue<Value = any> = Value[];
+type AccordionInputValue<Value = any> = Value[];
+```
+
+### AccordionOutputValue
+
+```typescript
+type AccordionOutputValue<Value = any> = Value[];
 ```
 
 ## External Types
@@ -388,7 +379,7 @@ type Orientation = 'horizontal' | 'vertical';
 - `Accordion.Header`: `Accordion.Header`, `Accordion.Header.State`, `Accordion.Header.Props`
 - `Accordion.Trigger`: `Accordion.Trigger`, `Accordion.Trigger.State`, `Accordion.Trigger.Props`
 - `Accordion.Panel`: `Accordion.Panel`, `Accordion.Panel.State`, `Accordion.Panel.Props`
-- `Default`: `AccordionValue`, `AccordionRootState`, `AccordionRootProps`, `AccordionRootChangeEventReason`, `AccordionRootChangeEventDetails`, `AccordionItemState`, `AccordionItemProps`, `AccordionItemChangeEventReason`, `AccordionItemChangeEventDetails`, `AccordionHeaderState`, `AccordionHeaderProps`, `AccordionTriggerState`, `AccordionTriggerProps`, `AccordionPanelState`, `AccordionPanelProps`
+- `Default`: `AccordionInputValue`, `AccordionOutputValue`, `AccordionRootState`, `AccordionRootProps`, `AccordionRootChangeEventReason`, `AccordionRootChangeEventDetails`, `AccordionItemState`, `AccordionItemProps`, `AccordionItemChangeEventReason`, `AccordionItemChangeEventDetails`, `AccordionHeaderState`, `AccordionHeaderProps`, `AccordionTriggerState`, `AccordionTriggerProps`, `AccordionPanelState`, `AccordionPanelProps`
 
 ## Canonical Types
 

--- a/packages/react/src/accordion/root/AccordionRoot.tsx
+++ b/packages/react/src/accordion/root/AccordionRoot.tsx
@@ -133,14 +133,14 @@ export const AccordionRoot = React.forwardRef(function AccordionRoot<Value = any
   <Value = any>(props: AccordionRoot.Props<Value>): React.JSX.Element;
 };
 
-export type AccordionValue<Value = any> = Value[];
+export type AccordionInputValue<Value = any> = readonly Value[];
+export type AccordionOutputValue<Value = any> = Value[];
 
 export interface AccordionRootState<Value = any> {
   /**
    * The current value.
-   * Treat it as read-only: it may be a shared frozen array when no value is set.
    */
-  value: AccordionValue<Value>;
+  value: AccordionInputValue<Value>;
   /**
    * Whether the component should ignore user interaction.
    */
@@ -166,13 +166,13 @@ export interface AccordionRootProps<Value = any> extends BaseUIComponentProps<
    *
    * To render an uncontrolled accordion, use the `defaultValue` prop instead.
    */
-  value?: AccordionValue<Value> | undefined;
+  value?: AccordionInputValue<Value> | undefined;
   /**
    * The uncontrolled value of the item(s) that should be initially expanded.
    *
    * To render a controlled accordion, use the `value` prop instead.
    */
-  defaultValue?: AccordionValue<Value> | undefined;
+  defaultValue?: AccordionInputValue<Value> | undefined;
   /**
    * Whether the component should ignore user interaction.
    * @default false
@@ -205,7 +205,7 @@ export interface AccordionRootProps<Value = any> extends BaseUIComponentProps<
    * Provides the new value as an argument.
    */
   onValueChange?:
-    | ((value: AccordionValue<Value>, eventDetails: AccordionRootChangeEventDetails) => void)
+    | ((value: AccordionOutputValue<Value>, eventDetails: AccordionRootChangeEventDetails) => void)
     | undefined;
   /**
    * Whether multiple items can be open at the same time.
@@ -229,7 +229,7 @@ export type AccordionRootChangeEventDetails =
   BaseUIChangeEventDetails<AccordionRoot.ChangeEventReason>;
 
 export namespace AccordionRoot {
-  export type Value<TValue = any> = AccordionValue<TValue>;
+  export type Value<TValue = any> = AccordionInputValue<TValue>;
   export type State<TValue = any> = AccordionRootState<TValue>;
   export type Props<TValue = any> = AccordionRootProps<TValue>;
   export type ChangeEventReason = AccordionRootChangeEventReason;

--- a/packages/react/src/checkbox-group/CheckboxGroupContext.ts
+++ b/packages/react/src/checkbox-group/CheckboxGroupContext.ts
@@ -7,7 +7,7 @@ import type { BaseUIEventReasons } from '../internals/reasons';
 import type { LabelableContext } from '../internals/labelable-provider/LabelableContext';
 
 export interface CheckboxGroupContext {
-  value: string[];
+  value: readonly string[];
   setValue: (
     value: string[],
     eventDetails: BaseUIChangeEventDetails<BaseUIEventReasons['none']>,

--- a/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
+++ b/packages/react/src/checkbox-group/useCheckboxGroupParent.ts
@@ -96,7 +96,7 @@ export function useCheckboxGroupParent(
           nextValue = none;
         }
 
-        onValueChange(nextValue, eventDetails);
+        onValueChange(nextValue.slice(), eventDetails);
 
         if (!eventDetails.isCanceled) {
           setStatus(nextStatus);
@@ -141,7 +141,7 @@ export function useCheckboxGroupParent(
 
 export interface UseCheckboxGroupParentParameters {
   allValues?: string[] | undefined;
-  value: string[];
+  value: readonly string[];
   onValueChange?:
     | ((
         value: string[],

--- a/packages/react/src/combobox/root/AriaCombobox.tsx
+++ b/packages/react/src/combobox/root/AriaCombobox.tsx
@@ -359,7 +359,7 @@ export function AriaCombobox<Value = any, Mode extends SelectionMode = 'none', I
     [items],
   );
 
-  const filteredItems: Item[] | Group<Item>[] = React.useMemo(() => {
+  const filteredItems: readonly Item[] | Group<Item>[] = React.useMemo(() => {
     if (filteredItemsProp && !shouldIgnoreExternalFiltering) {
       return filteredItemsProp as Item[] | Group<Item>[];
     }

--- a/packages/react/src/combobox/root/ComboboxRootContext.tsx
+++ b/packages/react/src/combobox/root/ComboboxRootContext.tsx
@@ -6,12 +6,12 @@ import type { FloatingRootContext } from '../../floating-ui-react';
 export interface ComboboxDerivedItemsContext {
   query: string;
   hasItems: boolean;
-  filteredItems: any[];
+  filteredItems: readonly any[];
   /**
    * `filteredItems` flattened across groups and projected to selection values. Identical to the
    * items themselves unless `items` is a `createItems()` collection.
    */
-  flatFilteredValues: any[];
+  flatFilteredValues: readonly any[];
 }
 
 export const ComboboxRootContext = React.createContext<ComboboxStore | undefined>(undefined);

--- a/packages/react/src/internals/composite/root/CompositeRoot.tsx
+++ b/packages/react/src/internals/composite/root/CompositeRoot.tsx
@@ -19,7 +19,7 @@ export function CompositeRoot<Metadata extends {}, State extends Record<string, 
     className,
     style,
     refs = EMPTY_ARRAY,
-    props = EMPTY_ARRAY as any[],
+    props = EMPTY_ARRAY as readonly any[],
     state = EMPTY_OBJECT as State,
     stateAttributesMapping,
     highlightedIndex: highlightedIndexProp,
@@ -124,7 +124,7 @@ export interface CompositeRootProps<Metadata, State extends Record<string, any>>
   onKeyDown?: ((event: BaseUIEvent<React.KeyboardEvent>) => void) | undefined;
   stopEventPropagation?: boolean | undefined;
   rootRef?: React.RefObject<HTMLElement | null> | undefined;
-  disabledIndices?: number[] | undefined;
+  disabledIndices?: readonly number[] | undefined;
   modifierKeys?: ModifierKey[] | undefined;
   highlightItemOnHover?: boolean | undefined;
 }

--- a/packages/react/src/internals/composite/root/gridNavigation.ts
+++ b/packages/react/src/internals/composite/root/gridNavigation.ts
@@ -35,7 +35,7 @@ export interface CompositeGridNavigationState {
   orientation: 'horizontal' | 'vertical' | 'both';
   loopFocus: boolean;
   onLoop?: CompositeGridOnLoop | undefined;
-  disabledIndices?: number[] | undefined;
+  disabledIndices?: readonly number[] | undefined;
   rtl: boolean;
 }
 

--- a/packages/react/src/internals/composite/root/useCompositeRoot.ts
+++ b/packages/react/src/internals/composite/root/useCompositeRoot.ts
@@ -62,7 +62,7 @@ export interface UseCompositeRootParameters {
    * Array of item indices to be considered disabled.
    * Used for composite items that are focusable when disabled.
    */
-  disabledIndices?: number[] | undefined;
+  disabledIndices?: readonly number[] | undefined;
   /**
    * Array of [modifier key values](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values#modifier_keys) that should allow normal keyboard actions
    * when pressed. By default, all modifier keys prevent normal actions.
@@ -342,7 +342,10 @@ export function useCompositeRoot(params: UseCompositeRootParameters) {
 // Resolves the item that should hold the tab stop: the active item when it can take focus,
 // otherwise the first item that can. Falls back to index 0 so an all-disabled composite keeps the
 // index in range and regains a tab stop as soon as one of its items becomes focusable.
-function getFallbackIndex(elements: Array<HTMLElement | null>, disabledIndices?: number[]) {
+function getFallbackIndex(
+  elements: Array<HTMLElement | null>,
+  disabledIndices?: readonly number[],
+) {
   let fallbackIndex = -1;
 
   for (let index = 0; index < elements.length; index += 1) {
@@ -364,7 +367,7 @@ function getFallbackIndex(elements: Array<HTMLElement | null>, disabledIndices?:
   return Math.max(fallbackIndex, 0);
 }
 
-function isModifierKeySet(event: React.KeyboardEvent, ignoredModifierKeys: ModifierKey[]) {
+function isModifierKeySet(event: React.KeyboardEvent, ignoredModifierKeys: readonly ModifierKey[]) {
   for (const key of MODIFIER_KEYS) {
     if (ignoredModifierKeys.includes(key)) {
       continue;

--- a/packages/react/src/internals/useRenderElement.tsx
+++ b/packages/react/src/internals/useRenderElement.tsx
@@ -99,7 +99,9 @@ function useRenderElementProps<
     } else if (Array.isArray(ref)) {
       outProps.ref = useMergedRefsN([outProps.ref, getReactElementRef(renderProp), ...ref]);
     } else {
-      outProps.ref = useMergedRefs(outProps.ref, getReactElementRef(renderProp), ref);
+      // Array.isArray doesn't get rid of readonly arrays https://github.com/microsoft/TypeScript/issues/17002
+      const actualRef = ref as React.Ref<RenderedElementType> | undefined;
+      outProps.ref = useMergedRefs(outProps.ref, getReactElementRef(renderProp), actualRef);
     }
   }
 
@@ -262,7 +264,10 @@ export type UseRenderElementParameters<
   /**
    * The ref to apply to the rendered element.
    */
-  ref?: React.Ref<RenderedElementType> | (React.Ref<RenderedElementType> | undefined)[] | undefined;
+  ref?:
+    | React.Ref<RenderedElementType>
+    | readonly (React.Ref<RenderedElementType> | undefined)[]
+    | undefined;
   /**
    * The state of the component.
    */

--- a/packages/utils/src/empty.ts
+++ b/packages/utils/src/empty.ts
@@ -1,8 +1,6 @@
 export function NOOP() {}
 
-// Typed as mutable `never[]` so it is assignable to any `T[]` fallback (for example
-// `defaultValue ?? EMPTY_ARRAY` in `useControlled` callers) without widening `T`.
 // Frozen so a write through a widened alias throws instead of mutating the shared singleton.
-export const EMPTY_ARRAY: never[] = Object.freeze([]) as never[];
+export const EMPTY_ARRAY: readonly never[] = Object.freeze([]);
 
 export const EMPTY_OBJECT = Object.freeze({});

--- a/packages/utils/src/empty.ts
+++ b/packages/utils/src/empty.ts
@@ -1,6 +1,6 @@
-export function NOOP() {}
+export function NOOP(): void {}
 
 // Frozen so a write through a widened alias throws instead of mutating the shared singleton.
 export const EMPTY_ARRAY: readonly never[] = Object.freeze([]);
 
-export const EMPTY_OBJECT = Object.freeze({});
+export const EMPTY_OBJECT: Readonly<{}> = Object.freeze({});


### PR DESCRIPTION
This is done as requested in https://github.com/mui/base-ui/issues/5707#issuecomment-5633396983

This PR is related: https://github.com/mui/base-ui/pull/5710, as this is sort of continuation of the same work, and has to necessarily split some other inputs/outputs like the 5710.