### PR TITLE
[toast] Keep high-priority toasts out of the tab order while aria-hidden

### DIFF
--- a/packages/react/src/toast/action/ToastAction.tsx
+++ b/packages/react/src/toast/action/ToastAction.tsx
@@ -25,13 +25,14 @@ export const ToastAction = React.forwardRef(function ToastAction(
     ...elementProps
   } = componentProps;
 
-  const { toast } = useToastRootContext();
+  const { toast, hideFromAT } = useToastRootContext();
 
   const computedChildren = toast.actionProps?.children ?? elementProps.children;
 
   const { getButtonProps, buttonRef } = useButton({
     disabled,
     native: nativeButton,
+    tabIndex: hideFromAT ? -1 : 0,
   });
 
   const state: ToastActionState = {

--- a/packages/react/src/toast/close/ToastClose.tsx
+++ b/packages/react/src/toast/close/ToastClose.tsx
@@ -26,13 +26,14 @@ export const ToastClose = React.forwardRef(function ToastClose(
   } = componentProps;
 
   const store = useToastProviderContext();
-  const { toast, expanded } = useToastRootContext();
+  const { toast, expanded, hideFromAT } = useToastRootContext();
 
   const [hasFocus, setHasFocus] = React.useState(false);
 
   const { getButtonProps, buttonRef } = useButton({
     disabled,
     native: nativeButton,
+    tabIndex: hideFromAT ? -1 : 0,
   });
 
   const state: ToastCloseState = {

--- a/packages/react/src/toast/root/ToastRoot.test.tsx
+++ b/packages/react/src/toast/root/ToastRoot.test.tsx
@@ -109,6 +109,84 @@ describe('<Toast.Root />', () => {
     expect(screen.getByTestId('root').style.getPropertyValue('--toast-offset-y')).not.toBe('');
   });
 
+  describe('high priority', () => {
+    function HighPriorityToasts() {
+      const { add, toasts } = Toast.useToastManager();
+      return (
+        <React.Fragment>
+          <Toast.Viewport data-testid="viewport">
+            {toasts.map((toastItem) => (
+              <Toast.Root key={toastItem.id} toast={toastItem} data-testid="root">
+                <Toast.Title />
+                <Toast.Close data-testid="close" aria-label="close" />
+                <Toast.Action data-testid="action">undo</Toast.Action>
+                <button type="button" data-testid="custom">
+                  custom
+                </button>
+              </Toast.Root>
+            ))}
+          </Toast.Viewport>
+          <button type="button" onClick={() => add({ title: 'Urgent', priority: 'high' })}>
+            add
+          </button>
+        </React.Fragment>
+      );
+    }
+
+    it('is not in the tab order while aria-hidden', async () => {
+      await render(
+        <Toast.Provider>
+          <HighPriorityToasts />
+        </Toast.Provider>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'add' }));
+
+      const root = screen.getByTestId('root');
+      expect(root).toHaveAttribute('aria-hidden', 'true');
+      expect(root).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByTestId('close')).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByTestId('action')).toHaveAttribute('tabindex', '-1');
+      expect(screen.getByTestId('custom')).toHaveAttribute('tabindex', '-1');
+      expect(screen.queryByRole('alertdialog')).toBe(null);
+    });
+
+    it('returns to the tab order when the viewport is focused', async () => {
+      const { user } = await render(
+        <Toast.Provider>
+          <HighPriorityToasts />
+        </Toast.Provider>,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'add' }));
+      await user.keyboard('{F6}');
+
+      const root = screen.getByTestId('root');
+      expect(root).not.toHaveAttribute('aria-hidden');
+      expect(root).toHaveAttribute('tabindex', '0');
+      expect(screen.getByTestId('close').tabIndex).toBe(0);
+      expect(screen.getByTestId('action').tabIndex).toBe(0);
+      expect(screen.getByTestId('custom').tabIndex).toBe(0);
+      expect(screen.getByRole('alertdialog')).toBe(root);
+
+      await user.keyboard('{Tab}');
+      expect(root).toHaveFocus();
+    });
+
+    it('can still be dismissed with a pointer while aria-hidden', async () => {
+      await render(
+        <Toast.Provider>
+          <HighPriorityToasts />
+        </Toast.Provider>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'add' }));
+      fireEvent.click(screen.getByTestId('close'));
+
+      expect(screen.queryByTestId('root')).toBe(null);
+    });
+  });
+
   it('keeps dynamic title and description ids synchronized with mounted label parts', async () => {
     function App() {
       const [mode, setMode] = React.useState<'fallback' | 'explicit' | 'none' | 'restored'>(

--- a/packages/react/src/toast/root/ToastRoot.tsx
+++ b/packages/react/src/toast/root/ToastRoot.tsx
@@ -6,7 +6,14 @@ import { ownerDocument } from '@base-ui/utils/owner';
 import { inertValue } from '@base-ui/utils/inertValue';
 import { useIsoLayoutEffect } from '@base-ui/utils/useIsoLayoutEffect';
 import { useStableCallback } from '@base-ui/utils/useStableCallback';
-import { activeElement, closest, contains, getTarget } from '../../floating-ui-react/utils';
+import {
+  activeElement,
+  closest,
+  contains,
+  disableFocusInside,
+  enableFocusInside,
+  getTarget,
+} from '../../floating-ui-react/utils';
 import type { BaseUIComponentProps, HTMLProps } from '../../internals/types';
 import type { ToastObject as ToastObjectType } from '../useToastManager';
 import { ToastRootContext } from './ToastRootContext';
@@ -459,14 +466,30 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
   }
 
   const isHighPriority = toast.priority === 'high';
+  const hideFromAT = isHighPriority && !focused;
+
+  // High-priority toasts are announced by a sibling live region, so the
+  // alertdialog stays aria-hidden until F6. While hidden it must not remain a
+  // tab stop, including interactive descendants.
+  useIsoLayoutEffect(() => {
+    const element = rootRef.current;
+    if (!element || !hideFromAT) {
+      return undefined;
+    }
+
+    disableFocusInside(element);
+    return () => {
+      enableFocusInside(element);
+    };
+  }, [hideFromAT]);
 
   const defaultProps: HTMLProps = {
     role: isHighPriority ? 'alertdialog' : 'dialog',
-    tabIndex: 0,
+    tabIndex: hideFromAT ? -1 : 0,
     'aria-modal': false,
     'aria-labelledby': titleId,
     'aria-describedby': descriptionId,
-    'aria-hidden': isHighPriority && !focused ? true : undefined,
+    'aria-hidden': hideFromAT ? true : undefined,
     onPointerDown: swipeEnabled ? handlePointerDown : undefined,
     onPointerMove: swipeEnabled ? handlePointerMove : undefined,
     onPointerUp: swipeEnabled ? handleSwipeEnd : undefined,
@@ -490,8 +513,9 @@ export const ToastRoot = React.forwardRef(function ToastRoot(
       recalculateHeight,
       visibleIndex,
       expanded,
+      hideFromAT,
     }),
-    [toast, setTitleId, setDescriptionId, recalculateHeight, visibleIndex, expanded],
+    [toast, setTitleId, setDescriptionId, recalculateHeight, visibleIndex, expanded, hideFromAT],
   );
 
   const state: ToastRootState = {

--- a/packages/react/src/toast/root/ToastRootContext.ts
+++ b/packages/react/src/toast/root/ToastRootContext.ts
@@ -8,6 +8,7 @@ export interface ToastRootContext {
   setDescriptionId: React.Dispatch<React.SetStateAction<string | undefined>>;
   visibleIndex: number;
   expanded: boolean;
+  hideFromAT: boolean;
   recalculateHeight: (flushSync?: boolean) => void;
 }
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/base-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

High-priority `Toast.Root` is out of the tab order (including Close, Action, and other tabbable descendants) while `aria-hidden`. The sibling live region still announces it. Pointer dismissal still works. After F6, the toast is exposed and tabbable again.

Fixes #5659

It had `tabIndex={0}` while hidden, so keyboard users could land on an alertdialog that assistive technology does not expose (axe `aria-hidden-focus`).

`Toast.Close` and `Toast.Action` go through `useButton({ tabIndex: 0 })`, so a root-only `tabIndex: -1` would still leave those buttons as tab stops. Their tabIndex is React-controlled, so a DOM-only patch would be overwritten on the next render. `disableFocusInside` / `enableFocusInside` cover custom descendants without using `inert`.

### Decision

Keep `aria-hidden` on unfocused high-priority toasts; set `tabIndex={-1}` and disable focus inside until the viewport is focused. The alternative is to remove `aria-hidden` and leave `tabIndex={0}`. Existing tests and docs already treat the live region as the announcement path; removing `aria-hidden` would risk double announcement.

Can switch to dropping `aria-hidden`, or to `inert` (that would also block clicks). Can add a docs line that `getByRole('alertdialog')` does not match until the viewport is focused.

### Test plan

- [x] High-priority toast is `aria-hidden` and not in the tab order (root, Close, Action, custom button).
- [x] After F6, `aria-hidden` is gone, `getByRole('alertdialog')` works, Tab focuses the toast.
- [x] Clicking Close still dismisses while the toast is `aria-hidden`.
- [x] Existing toast tests (`pnpm test:jsdom Toast --no-watch`).
